### PR TITLE
feat: support container with web based UI (close #65)

### DIFF
--- a/controllers/container_template.go
+++ b/controllers/container_template.go
@@ -1,0 +1,136 @@
+package controllers
+
+import (
+	"encoding/json"
+	"math/rand"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/casosorg/casos/object"
+)
+
+type containerTemplateSummary struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	Icon        string `json:"icon"`
+	Image       string `json:"image"`
+	DefaultPort int32  `json:"defaultPort"`
+}
+
+func toContainerTemplateSummatry(t object.ContainerTemplate) containerTemplateSummary {
+	return containerTemplateSummary{
+		Name:        t.Name,
+		DisplayName: t.DisplayName,
+		Description: t.Discription,
+		Icon:        t.Icon,
+		Image:       t.Image,
+		DefaultPort: t.DefaultPort,
+	}
+}
+func (c *ApiController) GetContainerTemplates() {
+	templates := object.GetContainerTemplates()
+	result := make([]containerTemplateSummary, 0, len(templates))
+	for _, t := range templates {
+		result = append(result, toContainerTemplateSummatry(t))
+	}
+	c.ResponseOk(result)
+}
+
+type deployContainerTemplateRequest struct {
+	TemplateName string `json:"templateName"`
+	Namespace    string `json:"namespace"`
+}
+
+func (c *ApiController) DeployContainerTemplate() {
+	cfg := getAdminRestConfig()
+	if cfg == nil {
+		c.ResponseError("apiserver not ready")
+		return
+	}
+	var req deployContainerTemplateRequest
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &req); err != nil {
+		c.ResponseError("invalid request body:" + err.Error())
+		return
+	}
+	if req.Namespace == "" {
+		req.Namespace = "default"
+	}
+	templates := object.GetContainerTemplates()
+	var tpl *object.ContainerTemplate
+	for i := range templates {
+		if templates[i].Name == req.TemplateName {
+			tpl = &templates[i]
+			break
+		}
+	}
+	if tpl == nil {
+		c.ResponseError("template not found" + req.TemplateName)
+		return
+	}
+	appName := tpl.Name + "-" + randSeq(5)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      appName,
+			Namespace: req.Namespace,
+			Labels: map[string]string{
+				"app": appName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app",
+					Image: tpl.Image,
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: tpl.DefaultPort,
+						},
+					},
+				},
+			},
+		},
+	}
+	if _, err := object.AddPod(cfg, pod); err != nil {
+		c.ResponseError("create pod:" + err.Error())
+		return
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      appName,
+			Namespace: req.Namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				"app": appName,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "app",
+					Port:       tpl.DefaultPort,
+					TargetPort: intstr.FromInt32(tpl.DefaultPort),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+	if _, err := object.AddService(cfg, svc); err != nil {
+		c.ResponseError("create service:" + err.Error())
+		return
+	}
+	c.ResponseOk(map[string]string{
+		"name":      appName,
+		"namespace": req.Namespace,
+	})
+
+}
+func randSeq(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/object/container_template.go
+++ b/object/container_template.go
@@ -1,0 +1,23 @@
+package object
+
+type ContainerTemplate struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Discription string `json:"description"`
+	Icon        string `json:"icon"`
+	Image       string `json:"image"`
+	DefaultPort int32  `json:"defaultPort"`
+}
+
+func GetContainerTemplates() []ContainerTemplate {
+	return []ContainerTemplate{
+		{
+			Name:        "firefox",
+			DisplayName: "Firefox",
+			Discription: "Firefox browser with noVNC web UI (jlesage/firefox).",
+			Icon:        "🦊",
+			Image:       "docker.io/jlesage/firefox:latest",
+			DefaultPort: 5800,
+		},
+	}
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -66,4 +66,6 @@ func InitAPI() {
 	beego.Router("/api/add-configmap", &controllers.ApiController{}, "POST:AddConfigMap")
 	beego.Router("/api/update-configmap", &controllers.ApiController{}, "POST:UpdateConfigMap")
 	beego.Router("/api/delete-configmap", &controllers.ApiController{}, "POST:DeleteConfigMap")
+	beego.Router("/api/get-container-templates", &controllers.ApiController{}, "GET:GetContainerTemplates")
+	beego.Router("/api/deploy-container-template", &controllers.ApiController{}, "POST:DeployContainerTemplate")
 }

--- a/test/container_template_test.go
+++ b/test/container_template_test.go
@@ -1,0 +1,52 @@
+// Package test contains the project's test files.
+//
+// CasOS did not ship with tests historically; this package is the
+// starting point for the project's testing effort (issue #65).
+//
+// Files here follow Go's "external test package" pattern: the package
+// name is `test` (not `object` or any other internal package), so
+// tests exercise the public API only.
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/casosorg/casos/object"
+)
+
+// TestGetContainerTemplates covers the only piece of the App Store
+// feature that is pure (no K8s, no DB) and therefore cheap to test:
+// the built-in template list. The contract is small:
+//
+//  1. At least one template ships.
+//  2. The "firefox" template exists and is well-formed.
+//  3. Its image carries a registry prefix so K8s does not silently
+//     default to docker.io/library/<name>:latest.
+func TestGetContainerTemplates(t *testing.T) {
+	templates := object.GetContainerTemplates()
+	if len(templates) == 0 {
+		t.Fatal("expected at least one built-in template")
+	}
+
+	var firefox *object.ContainerTemplate
+	for i := range templates {
+		if templates[i].Name == "firefox" {
+			firefox = &templates[i]
+			break
+		}
+	}
+	if firefox == nil {
+		t.Fatal("firefox template not found")
+	}
+
+	if firefox.DisplayName == "" {
+		t.Error("DisplayName must not be empty")
+	}
+	if !strings.Contains(firefox.Image, "/") {
+		t.Errorf("Image %q must include a registry prefix (e.g. docker.io/...)", firefox.Image)
+	}
+	if firefox.DefaultPort <= 0 || firefox.DefaultPort > 65535 {
+		t.Errorf("DefaultPort %d is out of valid TCP range", firefox.DefaultPort)
+	}
+}

--- a/web/src/ContainerTemplateListPage.js
+++ b/web/src/ContainerTemplateListPage.js
@@ -1,0 +1,207 @@
+import React from "react";
+import {withRouter} from "react-router-dom";
+import {Alert, Button, Card, Form, Modal, Select, Space, Tag} from "antd";
+import {AppstoreOutlined, ReloadOutlined, RocketOutlined} from "@ant-design/icons";
+import * as ContainerTemplateBackend from "./backend/ContainerTemplateBackend";
+import * as NamespaceBackend from "./backend/NamespaceBackend";
+import * as Setting from "./Setting";
+
+class ContainerTemplateListPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      templates: [],
+      namespaces: [],
+      loading: false,
+      error: null,
+      deployModalVisible: false,
+      deployingTemplate: null,
+      submitting: false,
+    };
+    this.formRef = React.createRef();
+  }
+
+  componentDidMount() {
+    this.fetchTemplates();
+    this.fetchNamespaces();
+  }
+
+  fetchTemplates() {
+    this.setState({loading: true, error: null});
+    ContainerTemplateBackend.getContainerTemplates().then(res => {
+      if (res.status === "ok") {
+        this.setState({templates: res.data ?? []});
+      } else {
+        Setting.showMessage("error", res.msg);
+        this.setState({error: res.msg});
+      }
+    }).catch(e => {
+      Setting.showMessage("error", e.message);
+      this.setState({error: e.message});
+    }).finally(() => {
+      this.setState({loading: false});
+    });
+  }
+
+  fetchNamespaces() {
+    NamespaceBackend.getNamespaces().then(res => {
+      if (res.status === "ok") {
+        this.setState({namespaces: res.data ?? []});
+      }
+    }).catch(() => {});
+  }
+
+  openDeployModal(template) {
+    const nsList = this.state.namespaces.map(n => n.name);
+    const defaultNs = nsList.includes("default") ? "default" : (nsList[0] ?? "default");
+    this.setState({
+      deployModalVisible: true,
+      deployingTemplate: template,
+    }, () => {
+      // Set initial form values after the modal is rendered.
+      setTimeout(() => {
+        this.formRef.current?.setFieldsValue({namespace: defaultNs});
+      }, 0);
+    });
+  }
+
+  closeDeployModal() {
+    this.setState({deployModalVisible: false, deployingTemplate: null});
+  }
+
+  handleDeploy() {
+    this.formRef.current?.validateFields().then(values => {
+      const {deployingTemplate} = this.state;
+      this.setState({submitting: true});
+      ContainerTemplateBackend.deployContainerTemplate(
+        deployingTemplate.name,
+        values.namespace
+      ).then(res => {
+        if (res.status === "ok") {
+          Setting.showMessage("success", `Deployed ${deployingTemplate.displayName}`);
+          this.closeDeployModal();
+          // Navigate to Pod list after a short delay.
+          setTimeout(() => this.props.history.push("/pods"), 1500);
+        } else {
+          Setting.showMessage("error", res.msg);
+        }
+      }).catch(e => Setting.showMessage("error", e.message))
+        .finally(() => this.setState({submitting: false}));
+    });
+  }
+
+  renderTemplateCard(template) {
+    return (
+      <Card
+        key={template.name}
+        hoverable
+        style={{width: 280}}
+        styles={{body: {padding: 16}}}
+      >
+        <Space direction="vertical" size={8} style={{width: "100%"}}>
+          <div style={{display: "flex", alignItems: "center", gap: 8}}>
+            <span style={{fontSize: 28}}>{template.icon}</span>
+            <span style={{fontWeight: 600, fontSize: 16}}>{template.displayName}</span>
+          </div>
+          <div style={{fontSize: 12, color: "#8c8c8c", minHeight: 36}}>
+            {template.description}
+          </div>
+          <div style={{fontSize: 11, color: "#bfbfbf"}}>
+            <code style={{background: "#f5f5f5", padding: "2px 6px", borderRadius: 3}}>
+              {template.image}
+            </code>
+          </div>
+          <Tag color="blue">Port: {template.defaultPort}</Tag>
+          <Button
+            type="primary"
+            icon={<RocketOutlined />}
+            onClick={() => this.openDeployModal(template)}
+            block
+          >
+            Deploy
+          </Button>
+        </Space>
+      </Card>
+    );
+  }
+
+  render() {
+    const {templates, loading, error, deployModalVisible, deployingTemplate, submitting} = this.state;
+    const nsOptions = this.state.namespaces.map(ns => ({label: ns.name, value: ns.name}));
+
+    return (
+      <div style={{padding: 24}}>
+        {error && (
+          <Alert type="error" message={error} style={{marginBottom: 16}} showIcon />
+        )}
+        <div style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 16,
+        }}>
+          <Space>
+            <AppstoreOutlined style={{fontSize: 18, color: "#1677ff"}} />
+            <span style={{fontWeight: 600, fontSize: 16}}>App Store</span>
+          </Space>
+          <Button
+            icon={<ReloadOutlined />}
+            onClick={() => this.fetchTemplates()}
+            loading={loading}
+            size="small"
+          >
+            Refresh
+          </Button>
+        </div>
+        <div style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 16,
+        }}>
+          {templates.map(t => this.renderTemplateCard(t))}
+        </div>
+        {templates.length === 0 && !loading && (
+          <div style={{textAlign: "center", color: "#bfbfbf", padding: 48}}>
+            No templates available.
+          </div>
+        )}
+
+        <Modal
+          title={deployingTemplate ? `Deploy ${deployingTemplate.displayName}` : "Deploy"}
+          open={deployModalVisible}
+          onOk={() => this.handleDeploy()}
+          onCancel={() => this.closeDeployModal()}
+          confirmLoading={submitting}
+          okText="Deploy"
+          destroyOnHidden
+        >
+          {deployingTemplate && (
+            <Form ref={this.formRef} layout="vertical">
+              <div style={{marginBottom: 16, padding: 12, background: "#f5f5f5", borderRadius: 6}}>
+                <div><b>{deployingTemplate.icon} {deployingTemplate.displayName}</b></div>
+                <div style={{fontSize: 12, color: "#8c8c8c", marginTop: 4}}>
+                  {deployingTemplate.description}
+                </div>
+              </div>
+              <Form.Item
+                label="Namespace"
+                name="namespace"
+                rules={[{required: true, message: "Namespace is required"}]}
+              >
+                <Select options={nsOptions} placeholder="Select a namespace" showSearch />
+              </Form.Item>
+              <Form.Item label="Image">
+                <code>{deployingTemplate.image}</code>
+              </Form.Item>
+              <Form.Item label="Service Port">
+                <Tag color="blue">{deployingTemplate.defaultPort} (ClusterIP)</Tag>
+              </Form.Item>
+            </Form>
+          )}
+        </Modal>
+      </div>
+    );
+  }
+}
+
+export default withRouter(ContainerTemplateListPage);

--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -32,6 +32,7 @@ import DashboardPage from "./DashboardPage";
 import SiteListPage from "./SiteListPage";
 import SiteEditPage from "./SiteEditPage";
 import i18next from "i18next";
+import ContainerTemplateListPage from "./ContainerTemplateListPage";
 
 const {Header, Footer, Content, Sider} = Layout;
 
@@ -44,6 +45,7 @@ function getMenuParentKey(uri) {
   if (uri.includes("/services")) {return "/networking";}
   if (uri.includes("/clusterrolebindings")) {return "/accesscontrol";}
   if (uri.includes("/sites")) {return "/admin";}
+  if (uri.includes("/apps")) {return "/admin";}
   return null;
 }
 
@@ -211,6 +213,7 @@ function ManagementPage(props) {
       ]),
       Setting.getItem(<Link to="/sites/site-built-in">{i18next.t("general:Admin")}</Link>, "/admin", <LayoutOutlined />, [
         Setting.getItem(<Link to="/sites/site-built-in">{i18next.t("general:Sites")}</Link>, "/sites"),
+        Setting.getItem(<Link to="/apps">{i18next.t("general:App Store")}</Link>, "/apps"),
       ]),
     ];
     return filterMenuItems(allItems, site?.navItems);
@@ -229,6 +232,7 @@ function ManagementPage(props) {
         <Route exact path="/services" render={(props) => <ServiceListPage {...props} />} />
         <Route exact path="/clusterrolebindings" render={(props) => <ClusterRoleBindingListPage {...props} />} />
         <Route exact path="/sites" render={(props) => <SiteListPage account={account} {...props} />} />
+        <Route exact path="/apps" render={(props) => <ContainerTemplateListPage {...props} />} />
         <Route exact path="/sites/:siteName" render={(props) => <SiteEditPage account={account} onUpdateSite={onUpdateSite} {...props} />} />
         <Route path="" render={() => <Result status="404" title="404 NOT FOUND" subTitle="Sorry, the page you visited does not exist." extra={<a href="/"><Button type="primary">Back Home</Button></a>} />} />
       </Switch>

--- a/web/src/backend/ContainerTemplateBackend.js
+++ b/web/src/backend/ContainerTemplateBackend.js
@@ -1,0 +1,21 @@
+import * as Setting from "../Setting";
+
+export function getContainerTemplates() {
+  return fetch(`${Setting.ServerUrl}/api/get-container-templates`, {
+    method: "GET",
+    credentials: "include",
+    headers: {"Accept-Language": Setting.getAcceptLanguage()},
+  }).then(res => res.json());
+}
+
+export function deployContainerTemplate(templateName, namespace) {
+  return fetch(`${Setting.ServerUrl}/api/deploy-container-template`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+    body: JSON.stringify({templateName, namespace}),
+  }).then(res => res.json());
+}

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -8,6 +8,7 @@
     "Action": "Action",
     "Add": "Add",
     "Admin": "Admin",
+    "App Store": "App Store",
     "Branding": "Branding",
     "Branding desc": "Logo and favicon",
     "Cancel": "Cancel",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -8,6 +8,7 @@
     "Action": "操作",
     "Add": "添加",
     "Admin": "管理",
+    "App Store": "应用商店",
     "Branding": "品牌标识",
     "Branding desc": "Logo与网站图标",
     "Cancel": "取消",


### PR DESCRIPTION
Implements the "App Store" feature requested in #65. Users can browse built-in container templates and launch them with one click.

The MVP ships with a single template — Firefox via `jlesage/firefox` (with noVNC web UI on port 5800) — to demonstrate the mechanism. Adding more templates is just appending entries to `object.GetContainerTemplates()`; no other code needs to change.

Reference: [Sealos App Store / Firefox](https://sealos.io/products/app-store/firefox/) (linked in #65)

## Changes

### Backend
- `object/container_template.go` — built-in template list (`ContainerTemplate` type + `GetContainerTemplates`)
- `controllers/container_template.go` — `GetContainerTemplates` (list) and `DeployContainerTemplate` (Pod + ClusterIP Service) handlers
- `routers/router.go` — two new routes:
  - `GET /api/get-container-templates`
  - `POST /api/deploy-container-template`

### Frontend
- `web/src/ContainerTemplateListPage.js` — card grid + deploy modal under `/apps`
- `web/src/backend/ContainerTemplateBackend.js` — API client
- `web/src/ManagementPage.js` — menu item + route mounted under the Admin group
- `i18n` — `App Store` key added to `en` and `zh` locale files

### Tests
- `test/container_template_test.go` — first test in the project. Covers the only piece of the feature that is pure (no K8s, no DB): `object.GetContainerTemplates()`. Uses the external test package pattern (`package test`) so it exercises only the public API.

## How it works

1. User opens the "App Store" page (`/apps`).
2. Page calls `GET /api/get-container-templates` and renders one card per template.
3. User clicks **Deploy** → modal asks for the target namespace.
4. Confirm calls `POST /api/deploy-container-template` with `{ templateName, namespace }`.
5. Backend creates a Pod (label `app: <unique-name>`) and a ClusterIP Service (selector `app: <unique-name>`, port = template's `defaultPort`).
6. The user is redirected to the Pods page; the new pod appears there with a 5-char random suffix on its name.

## Manual verification performed

- `go build ./...` — clean
- `go test -v ./test/...` — `PASS`
- Backend started, `curl GET /api/get-container-templates` returns the firefox template
- `curl POST /api/deploy-container-template ...` returns ok and the K8s API server log shows `allocated clusterIPs service="default/firefox-xxxxx" clusterIPs={"IPv4":"10.43.x.x"}` — confirming the Service was actually created in the cluster

## Notes for reviewers

- The template list is hard-coded in Go (not stored in the DB) by design. This keeps the MVP small; a future PR can move it to the `site` ORM if/when user-defined templates are wanted.
- The deployed Service is `ClusterIP` (intentionally — issue #65 mentions "web based UI" but does not specify external access; switching to `NodePort` later is a one-line change in the controller).
- I added a test, but the project does not yet have any other tests. I followed Go's external-test-package pattern. If maintainers prefer tests next to the code (e.g. `object/container_template_test.go`), I'm happy to relocate.