### PR TITLE
fix: require sign in for protected API endpoints

### DIFF
--- a/routers/api_filter.go
+++ b/routers/api_filter.go
@@ -8,7 +8,29 @@ import (
 func ApiFilter(ctx *context.Context) {
 	if beego.AppConfig.DefaultBool("isDemoMode", false) && !isAllowedInDemoMode(ctx.Request.Method, ctx.Request.URL.Path) {
 		denyRequest(ctx)
+		return
 	}
+
+	if !isPublicAPI(ctx.Request.Method, ctx.Request.URL.Path) && !isSignedIn(ctx) {
+		responseError(ctx, "please sign in first")
+	}
+}
+
+func isPublicAPI(method, urlPath string) bool {
+	if method == "POST" {
+		return urlPath == "/api/signin" || urlPath == "/api/signout"
+	}
+	if method == "GET" {
+		return urlPath == "/api/get-built-in-site"
+	}
+	return false
+}
+
+func isSignedIn(ctx *context.Context) bool {
+	if ctx.Input.CruSession == nil {
+		return false
+	}
+	return ctx.Input.CruSession.Get("user") != nil
 }
 
 func isAllowedInDemoMode(method, urlPath string) bool {

--- a/routers/api_filter_test.go
+++ b/routers/api_filter_test.go
@@ -1,0 +1,97 @@
+// Copyright 2022 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/beego/beego"
+)
+
+type apiResponse struct {
+	Status string `json:"status"`
+	Msg    string `json:"msg"`
+}
+
+var initTestAppOnce sync.Once
+
+func initTestApp() {
+	initTestAppOnce.Do(func() {
+		_, currentFile, _, _ := runtime.Caller(0)
+		projectRoot := filepath.Dir(filepath.Dir(currentFile))
+
+		beego.TestBeegoInit(projectRoot)
+		beego.BeeApp = beego.NewApp()
+
+		InitAPI()
+		beego.InsertFilter("/api/*", beego.BeforeRouter, ApiFilter)
+	})
+}
+
+func performRequest(method, target string, body string) apiResponse {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	recorder := httptest.NewRecorder()
+
+	beego.BeeApp.Handlers.ServeHTTP(recorder, req)
+
+	var resp apiResponse
+	_ = json.Unmarshal(recorder.Body.Bytes(), &resp)
+	return resp
+}
+
+func TestUnauthenticatedSensitiveAPIsRequireSignin(t *testing.T) {
+	initTestApp()
+
+	testCases := []struct {
+		name   string
+		method string
+		target string
+		body   string
+	}{
+		{name: "get-nodes", method: http.MethodGet, target: "/api/get-nodes"},
+		{name: "get-pods", method: http.MethodGet, target: "/api/get-pods?namespace=default"},
+		{name: "get-dashboard", method: http.MethodGet, target: "/api/get-dashboard"},
+		{name: "get-worker-kubeconfig", method: http.MethodGet, target: "/api/get-worker-kubeconfig?nodeName=test-worker"},
+		{name: "delete-node", method: http.MethodPost, target: "/api/delete-node", body: `{"name":"node-1"}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := performRequest(tc.method, tc.target, tc.body)
+			if resp.Status != "error" || resp.Msg != "please sign in first" {
+				t.Fatalf("expected unauthenticated request to be rejected, got status=%q msg=%q", resp.Status, resp.Msg)
+			}
+		})
+	}
+}
+
+func TestSignoutRemainsPublic(t *testing.T) {
+	initTestApp()
+
+	resp := performRequest(http.MethodPost, "/api/signout", "")
+	if resp.Status != "ok" {
+		t.Fatalf("expected signout to remain public, got status=%q msg=%q", resp.Status, resp.Msg)
+	}
+}


### PR DESCRIPTION
This PR fixes an auth bug where several protected API endpoints could still be accessed without signing in.

## Problem

Before this change, some sensitive API endpoints were not protected consistently.

An unauthenticated user could still access endpoints such as:

- `/api/get-nodes`
- `/api/get-pods`
- `/api/get-dashboard`
- `/api/get-worker-kubeconfig`

This could expose cluster information and operational data without a valid session.

## Root cause

The existing API filter only checked demo mode restrictions, but did not enforce sign-in for protected `/api/*` endpoints.

As a result, endpoints without explicit controller-level auth checks could be accessed anonymously.

## Solution

This PR adds a default sign-in check in the API filter for protected `/api/*` endpoints.

At the same time, it keeps the required public endpoints accessible:

- `/api/signin`
- `/api/signout`
- `/api/get-built-in-site`

## Tests

Added regression tests to verify that:

- unauthenticated requests to sensitive endpoints are rejected with `please sign in first`
- public endpoints like `/api/signout` still work as expected

Verified with:

- `go test ./routers -run "TestUnauthenticatedSensitiveAPIsRequireSignin|TestSignoutRemainsPublic" -count=1`
- `go build -o "$env:TEMP\\casos-build-check.exe" .`