### PR TITLE
fix: support ExternalName services in service management

### DIFF
--- a/controllers/service.go
+++ b/controllers/service.go
@@ -2,7 +2,9 @@ package controllers
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +26,7 @@ type serviceSummary struct {
 	Name            string            `json:"name"`
 	Type            string            `json:"type"`
 	ClusterIP       string            `json:"clusterIP"`
+	ExternalName    string            `json:"externalName"`
 	Selector        map[string]string `json:"selector"`
 	Ports           []portSummary     `json:"ports"`
 	CreatedAt       string            `json:"createdAt"`
@@ -46,6 +49,7 @@ func toSvcSummary(svc corev1.Service) serviceSummary {
 		Name:            svc.Name,
 		Type:            string(svc.Spec.Type),
 		ClusterIP:       svc.Spec.ClusterIP,
+		ExternalName:    svc.Spec.ExternalName,
 		Selector:        svc.Spec.Selector,
 		Ports:           ports,
 		CreatedAt:       svc.CreationTimestamp.UTC().Format("2006-01-02 15:04:05"),
@@ -104,9 +108,32 @@ type serviceRequest struct {
 	Namespace       string            `json:"namespace"`
 	Name            string            `json:"name"`
 	Type            string            `json:"type"`
+	ExternalName    string            `json:"externalName"`
 	Selector        map[string]string `json:"selector"`
 	Ports           []portRequest     `json:"ports"`
 	ResourceVersion string            `json:"resourceVersion"`
+}
+
+func normalizeServiceRequest(req *serviceRequest) error {
+	if req.Type == "" {
+		req.Type = string(corev1.ServiceTypeClusterIP)
+	}
+	if req.Type == string(corev1.ServiceTypeExternalName) {
+		req.ExternalName = strings.TrimSpace(req.ExternalName)
+		if req.ExternalName == "" {
+			return fmt.Errorf("ExternalName service requires externalName")
+		}
+		req.Selector = nil
+		req.Ports = nil
+	} else {
+		req.ExternalName = ""
+	}
+	if req.Type != string(corev1.ServiceTypeNodePort) && req.Type != string(corev1.ServiceTypeLoadBalancer) {
+		for i := range req.Ports {
+			req.Ports[i].NodePort = 0
+		}
+	}
+	return nil
 }
 
 func buildServiceSpec(req serviceRequest) corev1.ServiceSpec {
@@ -136,9 +163,10 @@ func buildServiceSpec(req serviceRequest) corev1.ServiceSpec {
 		ports = append(ports, sp)
 	}
 	return corev1.ServiceSpec{
-		Type:     svcType,
-		Selector: req.Selector,
-		Ports:    ports,
+		Type:         svcType,
+		Selector:     req.Selector,
+		Ports:        ports,
+		ExternalName: req.ExternalName,
 	}
 }
 
@@ -157,6 +185,10 @@ func (c *ApiController) AddService() {
 	}
 	if req.Namespace == "" {
 		req.Namespace = "default"
+	}
+	if err := normalizeServiceRequest(&req); err != nil {
+		c.ResponseError(err.Error())
+		return
 	}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -189,16 +221,21 @@ func (c *ApiController) UpdateService() {
 	if req.Namespace == "" {
 		req.Namespace = "default"
 	}
-	// Fetch current to preserve clusterIP (immutable field).
+	if err := normalizeServiceRequest(&req); err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	// Fetch current to preserve immutable fields when still applicable.
 	existing, err := object.GetService(cfg, req.Namespace, req.Name)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
 	newSpec := buildServiceSpec(req)
-	// Preserve ClusterIP — it is immutable once assigned.
-	newSpec.ClusterIP = existing.Spec.ClusterIP
-	newSpec.ClusterIPs = existing.Spec.ClusterIPs
+	if req.Type != string(corev1.ServiceTypeExternalName) {
+		newSpec.ClusterIP = existing.Spec.ClusterIP
+		newSpec.ClusterIPs = existing.Spec.ClusterIPs
+	}
 	existing.Spec = newSpec
 	existing.ResourceVersion = req.ResourceVersion
 	updated, err := object.UpdateService(cfg, existing)

--- a/web/src/ServiceListPage.js
+++ b/web/src/ServiceListPage.js
@@ -38,6 +38,13 @@ function formRowsToRequest(rows) {
   }));
 }
 
+function getDefaultPorts(type) {
+  if (type === "ExternalName") {
+    return [];
+  }
+  return [{name: "", protocol: "TCP", port: 80, targetPort: "80"}];
+}
+
 function selectorToEntries(selector) {
   return Object.entries(selector ?? {}).map(([key, value]) => ({key, value}));
 }
@@ -131,8 +138,9 @@ class ServiceListPage extends React.Component {
           namespace: defaultNs,
           name: "",
           type: "ClusterIP",
+          externalName: "",
           selectorEntries: [],
-          ports: [{name: "", protocol: "TCP", port: 80, targetPort: "80"}],
+          ports: getDefaultPorts("ClusterIP"),
         });
       }, 0);
     });
@@ -145,6 +153,7 @@ class ServiceListPage extends React.Component {
           namespace: svc.namespace,
           name: svc.name,
           type: svc.type,
+          externalName: svc.externalName,
           selectorEntries: selectorToEntries(svc.selector),
           ports: portsToFormRows(svc.ports),
         });
@@ -162,8 +171,9 @@ class ServiceListPage extends React.Component {
         namespace: values.namespace,
         name: values.name,
         type: values.type,
-        selector: entriesToMap(values.selectorEntries),
-        ports: formRowsToRequest(values.ports),
+        externalName: values.externalName ?? "",
+        selector: values.type === "ExternalName" ? {} : entriesToMap(values.selectorEntries),
+        ports: values.type === "ExternalName" ? [] : formRowsToRequest(values.ports),
       };
 
       this.setState({submitting: true});
@@ -212,6 +222,8 @@ class ServiceListPage extends React.Component {
   render() {
     const {services, namespaces, loading, error, modalVisible, modalMode, submitting} = this.state;
     const nodeIP = this.getNodeIP();
+    const currentType = this.formRef.current?.getFieldValue("type") || "ClusterIP";
+    const isExternalName = currentType === "ExternalName";
 
     const nsOptions = namespaces.map(ns => ({label: ns.name, value: ns.name}));
 
@@ -226,6 +238,13 @@ class ServiceListPage extends React.Component {
         render: t => <Tag color={typeColor[t] ?? "default"}>{t}</Tag>,
       },
       {title: "Cluster IP", dataIndex: "clusterIP", key: "clusterIP", width: 130},
+      {
+        title: "External Name",
+        dataIndex: "externalName",
+        key: "externalName",
+        width: 180,
+        render: v => v || null,
+      },
       {
         title: "Ports",
         dataIndex: "ports",
@@ -312,7 +331,25 @@ class ServiceListPage extends React.Component {
           width={640}
           destroyOnHidden
         >
-          <Form ref={this.formRef} layout="vertical" onValuesChange={() => this.forceUpdate()}>
+          <Form
+            ref={this.formRef}
+            layout="vertical"
+            onValuesChange={(changedValues) => {
+              if (Object.prototype.hasOwnProperty.call(changedValues, "type")) {
+                const nextType = changedValues.type;
+                if (nextType === "ExternalName") {
+                  this.formRef.current?.setFieldsValue({
+                    externalName: this.formRef.current?.getFieldValue("externalName") ?? "",
+                    selectorEntries: [],
+                    ports: [],
+                  });
+                } else if ((this.formRef.current?.getFieldValue("ports") ?? []).length === 0) {
+                  this.formRef.current?.setFieldsValue({ports: getDefaultPorts(nextType)});
+                }
+              }
+              this.forceUpdate();
+            }}
+          >
             <Form.Item label="Namespace" name="namespace" rules={[{required: true, message: "Required"}]}>
               <Select disabled={modalMode === "edit"} options={nsOptions} placeholder="Select a namespace" showSearch />
             </Form.Item>
@@ -323,62 +360,72 @@ class ServiceListPage extends React.Component {
               <Select options={SERVICE_TYPES.map(t => ({label: t, value: t}))} />
             </Form.Item>
 
-            {/* Ports */}
-            <Form.List name="ports">
-              {(fields, {add, remove}) => (
-                <>
-                  <div style={{marginBottom: 8, fontWeight: 500}}>Ports</div>
-                  {fields.map(({key, name, ...rest}) => (
-                    <Space key={key} align="baseline" style={{display: "flex", marginBottom: 4, flexWrap: "wrap"}}>
-                      <Form.Item {...rest} name={[name, "protocol"]} style={{marginBottom: 0}}>
-                        <Select options={PROTOCOLS.map(p => ({label: p, value: p}))} style={{width: 80}} />
-                      </Form.Item>
-                      <Form.Item {...rest} name={[name, "port"]} rules={[{required: true, message: "Port required"}]} style={{marginBottom: 0}}>
-                        <InputNumber placeholder="port" min={1} max={65535} style={{width: 90}} />
-                      </Form.Item>
-                      <Form.Item {...rest} name={[name, "targetPort"]} style={{marginBottom: 0}}>
-                        <Input placeholder="targetPort" style={{width: 100}} />
-                      </Form.Item>
-                      {this.formRef.current?.getFieldValue("type") === "NodePort" && (
-                        <Form.Item {...rest} name={[name, "nodePort"]} style={{marginBottom: 0}}>
-                          <InputNumber placeholder="nodePort" min={30000} max={32767} style={{width: 110}} />
-                        </Form.Item>
-                      )}
-                      <Form.Item {...rest} name={[name, "name"]} style={{marginBottom: 0}}>
-                        <Input placeholder="name (opt)" style={{width: 110}} />
-                      </Form.Item>
-                      <MinusCircleOutlined onClick={() => remove(name)} style={{color: "#ff4d4f", cursor: "pointer"}} />
-                    </Space>
-                  ))}
-                  <Button type="dashed" onClick={() => add({protocol: "TCP", port: 80, targetPort: "80"})} icon={<PlusOutlined />} size="small" style={{marginTop: 4}}>
-                    Add Port
-                  </Button>
-                </>
-              )}
-            </Form.List>
+            {isExternalName ? (
+              <Form.Item
+                label="External Name"
+                name="externalName"
+                rules={[{required: true, message: "External name is required"}]}
+              >
+                <Input placeholder="example.com" />
+              </Form.Item>
+            ) : (
+              <>
+                <Form.List name="ports">
+                  {(fields, {add, remove}) => (
+                    <>
+                      <div style={{marginBottom: 8, fontWeight: 500}}>Ports</div>
+                      {fields.map(({key, name, ...rest}) => (
+                        <Space key={key} align="baseline" style={{display: "flex", marginBottom: 4, flexWrap: "wrap"}}>
+                          <Form.Item {...rest} name={[name, "protocol"]} style={{marginBottom: 0}}>
+                            <Select options={PROTOCOLS.map(p => ({label: p, value: p}))} style={{width: 80}} />
+                          </Form.Item>
+                          <Form.Item {...rest} name={[name, "port"]} rules={[{required: true, message: "Port required"}]} style={{marginBottom: 0}}>
+                            <InputNumber placeholder="port" min={1} max={65535} style={{width: 90}} />
+                          </Form.Item>
+                          <Form.Item {...rest} name={[name, "targetPort"]} style={{marginBottom: 0}}>
+                            <Input placeholder="targetPort" style={{width: 100}} />
+                          </Form.Item>
+                          {currentType === "NodePort" && (
+                            <Form.Item {...rest} name={[name, "nodePort"]} style={{marginBottom: 0}}>
+                              <InputNumber placeholder="nodePort" min={30000} max={32767} style={{width: 110}} />
+                            </Form.Item>
+                          )}
+                          <Form.Item {...rest} name={[name, "name"]} style={{marginBottom: 0}}>
+                            <Input placeholder="name (opt)" style={{width: 110}} />
+                          </Form.Item>
+                          <MinusCircleOutlined onClick={() => remove(name)} style={{color: "#ff4d4f", cursor: "pointer"}} />
+                        </Space>
+                      ))}
+                      <Button type="dashed" onClick={() => add({protocol: "TCP", port: 80, targetPort: "80"})} icon={<PlusOutlined />} size="small" style={{marginTop: 4}}>
+                        Add Port
+                      </Button>
+                    </>
+                  )}
+                </Form.List>
 
-            {/* Selector */}
-            <Form.List name="selectorEntries">
-              {(fields, {add, remove}) => (
-                <>
-                  <div style={{marginBottom: 8, marginTop: 16, fontWeight: 500}}>Selector (key-value)</div>
-                  {fields.map(({key, name, ...rest}) => (
-                    <Space key={key} align="baseline" style={{display: "flex", marginBottom: 4}}>
-                      <Form.Item {...rest} name={[name, "key"]} rules={[{required: true, message: "Key required"}]} style={{marginBottom: 0}}>
-                        <Input placeholder="key" style={{width: 180}} />
-                      </Form.Item>
-                      <Form.Item {...rest} name={[name, "value"]} style={{marginBottom: 0}}>
-                        <Input placeholder="value" style={{width: 200}} />
-                      </Form.Item>
-                      <MinusCircleOutlined onClick={() => remove(name)} style={{color: "#ff4d4f", cursor: "pointer"}} />
-                    </Space>
-                  ))}
-                  <Button type="dashed" onClick={() => add()} icon={<PlusOutlined />} size="small" style={{marginTop: 4}}>
-                    Add Selector
-                  </Button>
-                </>
-              )}
-            </Form.List>
+                <Form.List name="selectorEntries">
+                  {(fields, {add, remove}) => (
+                    <>
+                      <div style={{marginBottom: 8, marginTop: 16, fontWeight: 500}}>Selector (key-value)</div>
+                      {fields.map(({key, name, ...rest}) => (
+                        <Space key={key} align="baseline" style={{display: "flex", marginBottom: 4}}>
+                          <Form.Item {...rest} name={[name, "key"]} rules={[{required: true, message: "Key required"}]} style={{marginBottom: 0}}>
+                            <Input placeholder="key" style={{width: 180}} />
+                          </Form.Item>
+                          <Form.Item {...rest} name={[name, "value"]} style={{marginBottom: 0}}>
+                            <Input placeholder="value" style={{width: 200}} />
+                          </Form.Item>
+                          <MinusCircleOutlined onClick={() => remove(name)} style={{color: "#ff4d4f", cursor: "pointer"}} />
+                        </Space>
+                      ))}
+                      <Button type="dashed" onClick={() => add()} icon={<PlusOutlined />} size="small" style={{marginTop: 4}}>
+                        Add Selector
+                      </Button>
+                    </>
+                  )}
+                </Form.List>
+              </>
+            )}
           </Form>
         </Modal>
       </div>


### PR DESCRIPTION
## Problem

The Service management page allowed users to select `ExternalName`, but this Service type was not actually usable.

The frontend did not provide the required `externalName` field, and the backend did not handle `spec.externalName`, so creation failed with Kubernetes validation errors.

## Solution

This PR adds proper `ExternalName` Service support in both frontend and backend.

- add `externalName` to Service request and response models
- validate and normalize `ExternalName` requests on the backend
- clear incompatible fields for `ExternalName` Services
- update the frontend form to collect `externalName`
- hide selector and port fields when `ExternalName` is selected
- show `externalName` in the Service list

## Testing

- passed `go test ./controllers -run "TestNormalizeServiceRequest|TestBuildServiceSpec|TestNormalizeClusterRoleBindingRoleRefKind"`
- passed `yarn build` in `web/`
- manually verified `ExternalName` Service create, update, get, and delete through the API