### PR TITLE
fix: restore local access for NodePort services

### DIFF
--- a/controllers/service.go
+++ b/controllers/service.go
@@ -1,16 +1,26 @@
 package controllers
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 
 	"github.com/casosorg/casos/object"
+	"github.com/casosorg/casos/server"
 )
 
 type portSummary struct {
@@ -29,6 +39,9 @@ type serviceSummary struct {
 	ExternalName    string            `json:"externalName"`
 	Selector        map[string]string `json:"selector"`
 	Ports           []portSummary     `json:"ports"`
+	AccessReady     bool              `json:"accessReady"`
+	AccessURL       string            `json:"accessUrl"`
+	AccessMessage   string            `json:"accessMessage"`
 	CreatedAt       string            `json:"createdAt"`
 	ResourceVersion string            `json:"resourceVersion"`
 }
@@ -57,6 +70,37 @@ func toSvcSummary(svc corev1.Service) serviceSummary {
 	}
 }
 
+func toServiceAccessStatus(summary *serviceSummary, hasEndpoints bool) {
+	if summary == nil {
+		return
+	}
+	if summary.Type != string(corev1.ServiceTypeNodePort) && summary.Type != string(corev1.ServiceTypeLoadBalancer) {
+		return
+	}
+	if !hasEndpoints {
+		summary.AccessReady = false
+		summary.AccessMessage = "No ready endpoints behind this Service"
+		return
+	}
+	for _, p := range summary.Ports {
+		if p.NodePort > 0 {
+			if accessURL, ok := server.LocalNodePortAccessURL(p.NodePort); ok {
+				summary.AccessReady = true
+				summary.AccessURL = accessURL
+				summary.AccessMessage = ""
+				return
+			}
+		}
+		if p.Port > 0 {
+			summary.AccessReady = true
+			summary.AccessURL = fmt.Sprintf("/api/proxy-service/%s/%s/%d/", summary.Namespace, summary.Name, p.Port)
+			summary.AccessMessage = ""
+			return
+		}
+	}
+	summary.AccessMessage = "Service has no routable ports"
+}
+
 // GetServices
 // @router /api/get-services [get]
 func (c *ApiController) GetServices() {
@@ -73,7 +117,18 @@ func (c *ApiController) GetServices() {
 	}
 	result := make([]serviceSummary, 0, len(svcs))
 	for _, svc := range svcs {
-		result = append(result, toSvcSummary(svc))
+		summary := toSvcSummary(svc)
+		hasEndpoints := false
+		if ep, err := object.GetEndpoints(cfg, svc.Namespace, svc.Name); err == nil {
+			hasEndpoints = endpointsHasAddresses(ep)
+		} else if apierrors.IsNotFound(err) {
+			summary.AccessReady = false
+			summary.AccessMessage = "This Service has no Endpoints object"
+		}
+		if summary.AccessMessage == "" {
+			toServiceAccessStatus(&summary, hasEndpoints)
+		}
+		result = append(result, summary)
 	}
 	c.ResponseOk(result)
 }
@@ -93,7 +148,14 @@ func (c *ApiController) GetService() {
 		c.ResponseError(err.Error())
 		return
 	}
-	c.ResponseOk(toSvcSummary(*svc))
+	summary := toSvcSummary(*svc)
+	if ep, err := object.GetEndpoints(cfg, svc.Namespace, svc.Name); err == nil {
+		toServiceAccessStatus(&summary, endpointsHasAddresses(ep))
+	} else if apierrors.IsNotFound(err) {
+		summary.AccessReady = false
+		summary.AccessMessage = "This Service has no Endpoints object"
+	}
+	c.ResponseOk(summary)
 }
 
 type portRequest struct {
@@ -267,4 +329,170 @@ func (c *ApiController) DeleteService() {
 		return
 	}
 	c.ResponseOk()
+}
+
+func endpointsHasAddresses(ep *corev1.Endpoints) bool {
+	if ep == nil {
+		return false
+	}
+	for _, subset := range ep.Subsets {
+		if len(subset.Addresses) > 0 || len(subset.NotReadyAddresses) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// ProxyService
+// @router /api/proxy-service/:namespace/:name/:port [get]
+func (c *ApiController) ProxyService() {
+	cfg := getAdminRestConfig()
+	if cfg == nil {
+		c.ResponseError("apiserver not ready")
+		return
+	}
+	namespace := c.Ctx.Input.Param(":namespace")
+	name := c.Ctx.Input.Param(":name")
+	portValue := c.Ctx.Input.Param(":port")
+	if namespace == "" || name == "" || portValue == "" {
+		c.CustomAbort(400, "missing service proxy parameters")
+		return
+	}
+	port, err := strconv.Atoi(portValue)
+	if err != nil || port <= 0 {
+		c.CustomAbort(400, "invalid service port")
+		return
+	}
+	service, err := object.GetService(cfg, namespace, name)
+	if err != nil {
+		c.CustomAbort(404, err.Error())
+		return
+	}
+	endpoints, err := object.GetEndpoints(cfg, namespace, name)
+	if err != nil || !endpointsHasAddresses(endpoints) {
+		c.CustomAbort(503, "service has no ready endpoints")
+		return
+	}
+	targetPort := int32(port)
+	for _, p := range service.Spec.Ports {
+		if p.Port == int32(port) {
+			if p.TargetPort.IntValue() > 0 {
+				targetPort = int32(p.TargetPort.IntValue())
+			}
+			break
+		}
+	}
+	podName, podPort := firstEndpointTargetPod(endpoints, targetPort)
+	if podName == "" || podPort == 0 {
+		c.CustomAbort(503, "service endpoints do not expose the requested port")
+		return
+	}
+
+	localPort, stopChan, err := startPodPortForward(cfg, namespace, podName, podPort)
+	if err != nil {
+		c.CustomAbort(502, err.Error())
+		return
+	}
+	defer close(stopChan)
+
+	proxyPath := strings.TrimPrefix(c.Ctx.Request.URL.Path, fmt.Sprintf("/api/proxy-service/%s/%s/%d", namespace, name, port))
+	if proxyPath == "" {
+		proxyPath = "/"
+	}
+	targetURL := fmt.Sprintf("http://127.0.0.1:%d%s", localPort, proxyPath)
+	if rawQuery := c.Ctx.Request.URL.RawQuery; rawQuery != "" {
+		targetURL += "?" + rawQuery
+	}
+	req, err := http.NewRequest(c.Ctx.Request.Method, targetURL, c.Ctx.Request.Body)
+	if err != nil {
+		c.CustomAbort(502, err.Error())
+		return
+	}
+	copyHeaders(req.Header, c.Ctx.Request.Header)
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		c.CustomAbort(502, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+	copyHeaders(c.Ctx.ResponseWriter.Header(), resp.Header)
+	c.Ctx.ResponseWriter.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(c.Ctx.ResponseWriter, resp.Body)
+}
+
+func firstEndpointTargetPod(ep *corev1.Endpoints, targetPort int32) (string, int32) {
+	for _, subset := range ep.Subsets {
+		portMatched := false
+		for _, p := range subset.Ports {
+			if p.Port == targetPort {
+				portMatched = true
+				break
+			}
+		}
+		if !portMatched {
+			continue
+		}
+		for _, addr := range subset.Addresses {
+			if addr.TargetRef != nil && addr.TargetRef.Kind == "Pod" && addr.TargetRef.Name != "" {
+				return addr.TargetRef.Name, targetPort
+			}
+		}
+		for _, addr := range subset.NotReadyAddresses {
+			if addr.TargetRef != nil && addr.TargetRef.Kind == "Pod" && addr.TargetRef.Name != "" {
+				return addr.TargetRef.Name, targetPort
+			}
+		}
+	}
+	return "", 0
+}
+
+func startPodPortForward(cfg *rest.Config, namespace, podName string, remotePort int32) (uint16, chan struct{}, error) {
+	transport, upgrader, err := spdy.RoundTripperFor(cfg)
+	if err != nil {
+		return 0, nil, err
+	}
+	serverURL := cfg.Host + fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", namespace, podName)
+	url, err := url.Parse(serverURL)
+	if err != nil {
+		return 0, nil, err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, url)
+	stopChan := make(chan struct{}, 1)
+	readyChan := make(chan struct{})
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf("0:%d", remotePort)}, stopChan, readyChan, out, errOut)
+	if err != nil {
+		return 0, nil, err
+	}
+	go func() {
+		_ = forwarder.ForwardPorts()
+	}()
+	select {
+	case <-readyChan:
+	case <-time.After(10 * time.Second):
+		close(stopChan)
+		if errOut.Len() > 0 {
+			return 0, nil, fmt.Errorf("%s", strings.TrimSpace(errOut.String()))
+		}
+		return 0, nil, fmt.Errorf("timed out waiting for pod port-forward")
+	}
+	ports, err := forwarder.GetPorts()
+	if err != nil {
+		close(stopChan)
+		return 0, nil, err
+	}
+	if len(ports) == 0 {
+		close(stopChan)
+		return 0, nil, fmt.Errorf("port-forward did not allocate a local port")
+	}
+	return ports[0].Local, stopChan, nil
+}
+
+func copyHeaders(dst, src http.Header) {
+	for key, values := range src {
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	port := beego.AppConfig.DefaultInt("httpport", 9000)
 
 	readyCh, err := server.Start(ctx, srvCfg)
 	if err != nil {
@@ -69,6 +70,9 @@ func main() {
 			if err := server.StartControllerManager(ctx, srvCfg); err != nil {
 				logs.Warning("start controller-manager: %v", err)
 			}
+			if err := server.StartLocalNodePortProxyManager(ctx, adminCfg, fmt.Sprintf("http://127.0.0.1:%d", port)); err != nil {
+				logs.Warning("start local nodeport proxy manager: %v", err)
+			}
 		case <-ctx.Done():
 		}
 	}()
@@ -89,7 +93,6 @@ func main() {
 	beego.BConfig.WebConfig.Session.SessionProviderConfig = "./tmp"
 	beego.BConfig.WebConfig.Session.SessionGCMaxLifetime = 3600 * 24 * 365
 
-	port := beego.AppConfig.DefaultInt("httpport", 9000)
 	logs.Info("casos listening on :%d", port)
 	beego.Run(fmt.Sprintf(":%v", port))
 }

--- a/object/endpoints.go
+++ b/object/endpoints.go
@@ -1,0 +1,17 @@
+package object
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+func GetEndpoints(cfg *rest.Config, namespace, name string) (*corev1.Endpoints, error) {
+	client, err := newClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return client.CoreV1().Endpoints(namespace).Get(context.Background(), name, metav1.GetOptions{})
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -58,6 +58,8 @@ func InitAPI() {
 	beego.Router("/api/add-service", &controllers.ApiController{}, "POST:AddService")
 	beego.Router("/api/update-service", &controllers.ApiController{}, "POST:UpdateService")
 	beego.Router("/api/delete-service", &controllers.ApiController{}, "POST:DeleteService")
+	beego.Router("/api/proxy-service/:namespace/:name/:port", &controllers.ApiController{}, "GET:ProxyService")
+	beego.Router("/api/proxy-service/:namespace/:name/:port/*", &controllers.ApiController{}, "GET:ProxyService")
 
 	beego.Router("/api/get-rolebindings", &controllers.ApiController{}, "GET:GetRoleBindings")
 	beego.Router("/api/get-rolebinding", &controllers.ApiController{}, "GET:GetRoleBinding")

--- a/server/local_nodeport.go
+++ b/server/local_nodeport.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type localNodePortSpec struct {
+	Namespace   string
+	ServiceName string
+	ServicePort int32
+	NodePort    int32
+}
+
+type localNodePortProxyManager struct {
+	baseURL   string
+	mu        sync.Mutex
+	listeners map[int32]net.Listener
+}
+
+var defaultLocalNodePortManager = &localNodePortProxyManager{
+	listeners: map[int32]net.Listener{},
+}
+
+func StartLocalNodePortProxyManager(ctx context.Context, cfg *rest.Config, baseURL string) error {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("local nodeport proxy client: %w", err)
+	}
+	defaultLocalNodePortManager.baseURL = strings.TrimRight(baseURL, "/")
+	go defaultLocalNodePortManager.run(ctx, client)
+	return nil
+}
+
+func LocalNodePortAccessURL(nodePort int32) (string, bool) {
+	if runtime.GOOS != "windows" || nodePort <= 0 {
+		return "", false
+	}
+	return fmt.Sprintf("http://127.0.0.1:%d/", nodePort), defaultLocalNodePortManager.hasListener(nodePort)
+}
+
+func (m *localNodePortProxyManager) hasListener(nodePort int32) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.listeners[nodePort]
+	return ok
+}
+
+func (m *localNodePortProxyManager) run(ctx context.Context, client kubernetes.Interface) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		m.syncOnce(ctx, client)
+		select {
+		case <-ctx.Done():
+			m.closeAll()
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *localNodePortProxyManager) syncOnce(ctx context.Context, client kubernetes.Interface) {
+	list, err := client.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+
+	want := map[int32]localNodePortSpec{}
+	for _, svc := range list.Items {
+		if svc.Spec.Type != corev1.ServiceTypeNodePort && svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+			continue
+		}
+		for _, port := range svc.Spec.Ports {
+			if port.NodePort <= 0 || port.Port <= 0 {
+				continue
+			}
+			if _, exists := want[port.NodePort]; exists {
+				continue
+			}
+			want[port.NodePort] = localNodePortSpec{
+				Namespace:   svc.Namespace,
+				ServiceName: svc.Name,
+				ServicePort: port.Port,
+				NodePort:    port.NodePort,
+			}
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for nodePort, spec := range want {
+		if _, ok := m.listeners[nodePort]; ok {
+			continue
+		}
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", nodePort))
+		if err != nil {
+			continue
+		}
+		m.listeners[nodePort] = ln
+		handler := newLocalNodePortProxyHandler(m.baseURL, spec)
+		go func(listener net.Listener) {
+			_ = (&http.Server{Handler: handler}).Serve(listener)
+		}(ln)
+	}
+
+	for nodePort, ln := range m.listeners {
+		if _, ok := want[nodePort]; ok {
+			continue
+		}
+		_ = ln.Close()
+		delete(m.listeners, nodePort)
+	}
+}
+
+func (m *localNodePortProxyManager) closeAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for nodePort, ln := range m.listeners {
+		_ = ln.Close()
+		delete(m.listeners, nodePort)
+	}
+}
+
+func newLocalNodePortProxyHandler(baseURL string, spec localNodePortSpec) http.Handler {
+	target, _ := url.Parse(strings.TrimRight(baseURL, "/"))
+	rp := httputil.NewSingleHostReverseProxy(target)
+	originalDirector := rp.Director
+	rp.Director = func(r *http.Request) {
+		originalDirector(r)
+		basePath := fmt.Sprintf("/api/proxy-service/%s/%s/%d", spec.Namespace, spec.ServiceName, spec.ServicePort)
+		if r.URL.Path == "" || r.URL.Path == "/" {
+			r.URL.Path = basePath + "/"
+		} else {
+			r.URL.Path = basePath + r.URL.Path
+		}
+		r.Host = target.Host
+	}
+	return rp
+}

--- a/web/src/DeployAppModal.js
+++ b/web/src/DeployAppModal.js
@@ -4,8 +4,8 @@ import {InfoCircleOutlined, LockOutlined} from "@ant-design/icons";
 import i18next from "i18next";
 import * as AppBackend from "./backend/AppBackend";
 import * as NamespaceBackend from "./backend/NamespaceBackend";
-import * as NodeBackend from "./backend/NodeBackend";
 import EnvVarEditor from "./EnvVarEditor";
+import {getServiceAccessInfo} from "./K8sAccess";
 
 const {Text} = Typography;
 
@@ -60,7 +60,6 @@ class DeployAppModal extends React.Component {
     super(props);
     this.state = {
       namespaces: [],
-      nodeIP: null,
       envVars: [],
       submitting: false,
       result: null,
@@ -73,7 +72,6 @@ class DeployAppModal extends React.Component {
     if (this.props.open && !prevProps.open && this.props.template) {
       this.setState({result: null, error: null, envVars: []});
       this.fetchNamespaces();
-      this.fetchNodeIP();
     }
   }
 
@@ -93,26 +91,6 @@ class DeployAppModal extends React.Component {
             serviceType: "NodePort",
           });
         }, 0);
-      }
-    }).catch(() => {});
-  }
-
-  fetchNodeIP() {
-    NodeBackend.getNodes().then(res => {
-      if (res.status === "ok") {
-        const nodes = res.data ?? [];
-        for (const node of nodes) {
-          if (node.externalIP) {
-            this.setState({nodeIP: node.externalIP});
-            return;
-          }
-        }
-        for (const node of nodes) {
-          if (node.internalIP) {
-            this.setState({nodeIP: node.internalIP});
-            return;
-          }
-        }
       }
     }).catch(() => {});
   }
@@ -195,12 +173,10 @@ class DeployAppModal extends React.Component {
   }
 
   renderResult() {
-    const {result, nodeIP} = this.state;
+    const {result} = this.state;
     if (!result) {return null;}
     const svc = result.service;
-    const accessUrls = svc && nodeIP
-      ? (svc.ports ?? []).filter(p => p.nodePort).map(p => `http://${nodeIP}:${p.nodePort}`)
-      : [];
+    const access = getServiceAccessInfo(svc);
     return (
       <Alert
         type="success"
@@ -211,19 +187,21 @@ class DeployAppModal extends React.Component {
             <div>
               Deployment <Text code>{result.deployment.name}</Text> {t("appStore:Deployment started")}
             </div>
-            {accessUrls.length > 0 && (
+            {access.urls.length > 0 && (
               <div style={{marginTop: 6}}>
                 Access URL:
-                {accessUrls.map((url, i) => (
+                {access.urls.map((url, i) => (
                   <a key={i} href={url} target="_blank" rel="noopener noreferrer" style={{marginLeft: 8}}>
                     {url}
                   </a>
                 ))}
               </div>
             )}
-            {svc && accessUrls.length === 0 && (
+            {svc && access.urls.length === 0 && (
               <div style={{marginTop: 6}}>
-                {t("appStore:Service info prefix")} <Text code>{svc.name}</Text> {t("appStore:Service info suffix")}
+                {access.message || (
+                  <span>{t("appStore:Service info prefix")} <Text code>{svc.name}</Text> {t("appStore:Service info suffix")}</span>
+                )}
                 {svc.ports?.map(p => (
                   <Tag key={p.name} style={{marginLeft: 4}}>{svc.name}:{p.port}</Tag>
                 ))}

--- a/web/src/DeploymentListPage.js
+++ b/web/src/DeploymentListPage.js
@@ -8,7 +8,6 @@ import * as NamespaceBackend from "./backend/NamespaceBackend";
 import * as ConfigMapBackend from "./backend/ConfigMapBackend";
 import * as SecretBackend from "./backend/SecretBackend";
 import * as ServiceBackend from "./backend/ServiceBackend";
-import * as NodeBackend from "./backend/NodeBackend";
 import * as MetricsBackend from "./backend/MetricsBackend";
 import * as IngressBackend from "./backend/IngressBackend";
 import * as Setting from "./Setting";
@@ -18,6 +17,7 @@ import DeploymentDomainModal from "./DeploymentDomainModal";
 import DeploymentStorageEditor from "./DeploymentStorageEditor";
 import EnvVarEditor, {ENV_SOURCE_CONFIGMAP, ENV_SOURCE_PLAIN, ENV_SOURCE_SECRET} from "./EnvVarEditor";
 import ReplicasControl from "./ReplicasControl";
+import {getDeploymentAccessInfo} from "./K8sAccess";
 
 const {Text} = Typography;
 
@@ -57,7 +57,6 @@ class DeploymentListPage extends React.Component {
       secrets: [],
       services: [],
       ingresses: [],
-      nodeIP: null,
       loading: true,
       error: null,
       modalVisible: false,
@@ -78,7 +77,6 @@ class DeploymentListPage extends React.Component {
     this.fetchDeployments();
     this.fetchNamespaces();
     this.fetchServices();
-    this.fetchNodeIP();
     this.fetchPodMetrics();
     this.fetchIngresses();
   }
@@ -98,20 +96,6 @@ class DeploymentListPage extends React.Component {
   fetchIngresses() {
     IngressBackend.getIngresses().then(res => {
       if (res.status === "ok") {this.setState({ingresses: res.data ?? []});}
-    }).catch(() => {});
-  }
-
-  fetchNodeIP() {
-    NodeBackend.getNodes().then(res => {
-      if (res.status === "ok") {
-        const nodes = res.data ?? [];
-        for (const node of nodes) {
-          if (node.externalIP) {this.setState({nodeIP: node.externalIP}); return;}
-        }
-        for (const node of nodes) {
-          if (node.internalIP) {this.setState({nodeIP: node.internalIP}); return;}
-        }
-      }
     }).catch(() => {});
   }
 
@@ -150,17 +134,9 @@ class DeploymentListPage extends React.Component {
   }
 
   getAccessUrls(deploy) {
-    const {services, ingresses, nodeIP} = this.state;
-    const urls = [];
-
-    if (nodeIP) {
-      const svc = services.find(s => s.name === deploy.name && s.namespace === deploy.namespace && s.type === "NodePort");
-      if (svc) {
-        (svc.ports ?? []).filter(p => p.nodePort).forEach(p => {
-          urls.push({url: `http://${nodeIP}:${p.nodePort}`, type: "nodeport"});
-        });
-      }
-    }
+    const {services, ingresses} = this.state;
+    const serviceAccess = getDeploymentAccessInfo(deploy, services);
+    const urls = serviceAccess.urls.map(url => ({url, type: "service"}));
 
     const deployServiceNames = new Set(
       (services ?? [])
@@ -180,7 +156,10 @@ class DeploymentListPage extends React.Component {
         });
       });
 
-    return urls;
+    return {
+      urls,
+      message: urls.length === 0 ? serviceAccess.message : "",
+    };
   }
 
   openAddModal() {
@@ -362,9 +341,11 @@ class DeploymentListPage extends React.Component {
         title: "Access URL",
         key: "accessUrl",
         render: (_, record) => {
-          const urls = this.getAccessUrls(record);
-          if (urls.length === 0) {return null;}
-          return urls.map(({url, type}, i) => (
+          const access = this.getAccessUrls(record);
+          if (access.urls.length === 0) {
+            return access.message ? <Text type="secondary">{access.message}</Text> : null;
+          }
+          return access.urls.map(({url, type}, i) => (
             <div key={i} style={{display: "flex", alignItems: "center", gap: 4, marginBottom: 2}}>
               {type === "domain" && <LinkOutlined style={{color: "#1677ff", fontSize: 11}} />}
               <a href={url} target="_blank" rel="noopener noreferrer" style={{fontSize: 13}}>{url}</a>

--- a/web/src/K8sAccess.js
+++ b/web/src/K8sAccess.js
@@ -1,0 +1,33 @@
+import * as Setting from "./Setting";
+
+function toAbsoluteUrl(path) {
+  if (!path) {
+    return "";
+  }
+  if (path.startsWith("http://") || path.startsWith("https://")) {
+    return path;
+  }
+  return `${Setting.ServerUrl}${path}`;
+}
+
+export function getServiceAccessInfo(service) {
+  if (!service) {
+    return {urls: [], message: ""};
+  }
+  return {
+    urls: service.accessReady && service.accessUrl ? [toAbsoluteUrl(service.accessUrl)] : [],
+    message: service.accessMessage ?? "",
+  };
+}
+
+export function getDeploymentAccessInfo(deployment, services) {
+  if (!deployment) {
+    return {urls: [], message: ""};
+  }
+  const service = (services ?? []).find(s =>
+    s.namespace === deployment.namespace &&
+    s.name === deployment.name &&
+    (s.type === "NodePort" || s.type === "LoadBalancer")
+  );
+  return getServiceAccessInfo(service);
+}

--- a/web/src/ServiceListPage.js
+++ b/web/src/ServiceListPage.js
@@ -1,15 +1,16 @@
 import React from "react";
 import {
-  Alert, Button, Form, Input, InputNumber, Modal, Popconfirm, Select, Space, Table, Tag
+  Alert, Button, Form, Input, InputNumber, Modal, Popconfirm, Select, Space, Table, Tag, Typography
 } from "antd";
 import {DeleteOutlined, EditOutlined, MinusCircleOutlined, PlusOutlined, ReloadOutlined} from "@ant-design/icons";
 import * as ServiceBackend from "./backend/ServiceBackend";
 import * as NamespaceBackend from "./backend/NamespaceBackend";
-import * as NodeBackend from "./backend/NodeBackend";
 import * as Setting from "./Setting";
+import {getServiceAccessInfo} from "./K8sAccess";
 
 const SERVICE_TYPES = ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"];
 const PROTOCOLS = ["TCP", "UDP", "SCTP"];
+const {Text} = Typography;
 
 const typeColor = {
   ClusterIP: "blue",
@@ -65,7 +66,6 @@ class ServiceListPage extends React.Component {
     this.state = {
       services: [],
       namespaces: [],
-      nodes: [],
       loading: true,
       error: null,
       modalVisible: false,
@@ -79,7 +79,6 @@ class ServiceListPage extends React.Component {
   componentDidMount() {
     this.fetchServices();
     this.fetchNamespaces();
-    this.fetchNodes();
   }
 
   fetchNamespaces() {
@@ -88,29 +87,6 @@ class ServiceListPage extends React.Component {
         this.setState({namespaces: res.data ?? []});
       }
     }).catch(() => {});
-  }
-
-  fetchNodes() {
-    NodeBackend.getNodes().then(res => {
-      if (res.status === "ok") {
-        this.setState({nodes: res.data ?? []});
-      }
-    }).catch(() => {});
-  }
-
-  getNodeIP() {
-    const {nodes} = this.state;
-    for (const n of nodes) {
-      if (n.externalIP) {
-        return n.externalIP;
-      }
-    }
-    for (const n of nodes) {
-      if (n.internalIP) {
-        return n.internalIP;
-      }
-    }
-    return null;
   }
 
   fetchServices() {
@@ -221,7 +197,6 @@ class ServiceListPage extends React.Component {
 
   render() {
     const {services, namespaces, loading, error, modalVisible, modalMode, submitting} = this.state;
-    const nodeIP = this.getNodeIP();
     const currentType = this.formRef.current?.getFieldValue("type") || "ClusterIP";
     const isExternalName = currentType === "ExternalName";
 
@@ -257,17 +232,15 @@ class ServiceListPage extends React.Component {
         title: "Access URL",
         key: "accessUrl",
         render: (_, record) => {
-          if (record.type !== "NodePort" || !nodeIP) {
-            return null;
+          const {urls, message} = getServiceAccessInfo(record);
+          if (urls.length === 0) {
+            return message ? <Text type="secondary">{message}</Text> : null;
           }
-          return (record.ports ?? []).filter(p => p.nodePort).map((p, i) => {
-            const url = `http://${nodeIP}:${p.nodePort}`;
-            return (
-              <a key={i} href={url} target="_blank" rel="noopener noreferrer" style={{display: "block"}}>
-                {url}
-              </a>
-            );
-          });
+          return urls.map((url, i) => (
+            <a key={i} href={url} target="_blank" rel="noopener noreferrer" style={{display: "block"}}>
+              {url}
+            </a>
+          ));
         },
       },
       {title: "Created", dataIndex: "createdAt", key: "createdAt", width: 180},


### PR DESCRIPTION
## Summary

This PR fixes the access path for Kubernetes resources exposed through NodePort services.

Previously, workloads and Services could be created successfully, but the access URL shown by the platform was not reliably usable from the local Windows host environment. The UI displayed an address, but the backend did not provide a working local access path consistently.

## Changes

- add backend access status fields for Service responses:
  - `accessReady`
  - `accessUrl`
  - `accessMessage`
- add endpoint-aware access detection for Services
- add a backend proxy route for Service access
- add a local NodePort access manager for host-side access
- make frontend pages consume backend-provided access information instead of building URLs from node IP directly

## Result

After this change, resources exposed through NodePort can provide a usable local access entry from the platform, and the frontend no longer depends on guessing a node IP that may not be reachable from the host.

## Verification

- `cd web && yarn build`