### PR TITLE
feat: add automatic worker node deployment

### DIFF
--- a/controllers/machine_node_deploy.go
+++ b/controllers/machine_node_deploy.go
@@ -1,0 +1,98 @@
+package controllers
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/casosorg/casos/deploy"
+)
+
+// PreflightMachineNode checks whether a machine can be used as a worker node.
+// @router /api/preflight-machine-node [post]
+func (c *ApiController) PreflightMachineNode() {
+	if c.RequireAdmin() {
+		return
+	}
+	var req deploy.MachineNodeDeployRequest
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &req); err != nil {
+		c.ResponseError("invalid request body: " + err.Error())
+		return
+	}
+	result, err := deploy.DefaultService().PreflightMachineNode(req)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk(result)
+}
+
+// DeployMachineNode starts an async worker node deployment task.
+// @router /api/deploy-machine-node [post]
+func (c *ApiController) DeployMachineNode() {
+	if c.RequireAdmin() {
+		return
+	}
+	var req deploy.MachineNodeDeployRequest
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &req); err != nil {
+		c.ResponseError("invalid request body: " + err.Error())
+		return
+	}
+	task, err := deploy.DefaultService().DeployMachineNode(req)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk(task)
+}
+
+// RepairMachineNode reruns the same idempotent worker node deployment flow.
+// @router /api/repair-machine-node [post]
+func (c *ApiController) RepairMachineNode() {
+	if c.RequireAdmin() {
+		return
+	}
+	var req deploy.MachineNodeDeployRequest
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &req); err != nil {
+		c.ResponseError("invalid request body: " + err.Error())
+		return
+	}
+	task, err := deploy.DefaultService().RepairMachineNode(req)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk(task)
+}
+
+// GetMachineNodeTasks returns node deployment tasks for a machine.
+// @router /api/get-machine-node-tasks [get]
+func (c *ApiController) GetMachineNodeTasks() {
+	if c.RequireAdmin() {
+		return
+	}
+	tasks, err := deploy.DefaultService().GetMachineNodeTasks(c.GetString("owner"), c.GetString("machineName"))
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk(tasks)
+}
+
+// GetMachineNodeLogs returns deployment logs for one task.
+// @router /api/get-machine-node-logs [get]
+func (c *ApiController) GetMachineNodeLogs() {
+	if c.RequireAdmin() {
+		return
+	}
+	taskId, err := strconv.ParseInt(c.GetString("taskId"), 10, 64)
+	if err != nil || taskId <= 0 {
+		c.ResponseError("invalid taskId")
+		return
+	}
+	logs, err := deploy.DefaultService().GetMachineNodeLogs(taskId)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk(logs)
+}

--- a/controllers/node.go
+++ b/controllers/node.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 
+	"github.com/casosorg/casos/deploy"
 	"github.com/casosorg/casos/object"
 	"github.com/casosorg/casos/server"
 	corev1 "k8s.io/api/core/v1"
@@ -186,6 +187,6 @@ func (c *ApiController) GetWorkerKubeconfig() {
 	c.ResponseOk(map[string]string{
 		"nodeName":         wk.NodeName,
 		"kubeconfig":       wk.Kubeconfig,
-		"containerdConfig": server.GenerateContainerdConfig(cfg.SandboxImage, cfg.Socks5Proxy),
+		"containerdConfig": deploy.GenerateContainerdConfig(cfg.SandboxImage, cfg.Socks5Proxy),
 	})
 }

--- a/deploy/cni.go
+++ b/deploy/cni.go
@@ -1,0 +1,26 @@
+package deploy
+
+import "fmt"
+
+func bridgeCNIConfig(podCIDR string) string {
+	return fmt.Sprintf(`{
+  "cniVersion": "1.0.0",
+  "name": "casos-bridge",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [[{"subnet": %q}]],
+        "routes": [{"dst": "0.0.0.0/0"}]
+      }
+    },
+    {"type": "portmap", "capabilities": {"portMappings": true}},
+    {"type": "loopback"}
+  ]
+}
+`, podCIDR)
+}

--- a/deploy/containerd_config.go
+++ b/deploy/containerd_config.go
@@ -1,4 +1,4 @@
-package server
+package deploy
 
 import "fmt"
 
@@ -10,7 +10,11 @@ func GenerateContainerdConfig(sandboxImage, socks5Proxy string) string {
 version = 2
 
 [plugins.'io.containerd.cri.v1.images']
-  sandbox = %q
+  [plugins.'io.containerd.cri.v1.images'.pinned_images]
+    sandbox = %q
+
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
+  SystemdCgroup = true
 `, sandboxImage)
 
 	if socks5Proxy == "" {

--- a/deploy/executor.go
+++ b/deploy/executor.go
@@ -1,0 +1,376 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/beego/beego/logs"
+	"golang.org/x/crypto/ssh"
+)
+
+// NodeDeploySSHConfig holds connection settings for a deployment target.
+type NodeDeploySSHConfig struct {
+	Host           string
+	Port           int
+	Username       string
+	Password       string
+	PrivateKey     string
+	Timeout        time.Duration
+	CommandTimeout time.Duration
+}
+
+func (c NodeDeploySSHConfig) String() string {
+	return fmt.Sprintf("NodeDeploySSHConfig{Host:%s Port:%d Username:%s Password:[redacted] PrivateKey:[redacted] Timeout:%s CommandTimeout:%s}",
+		c.Host, c.Port, c.Username, c.Timeout, c.CommandTimeout)
+}
+
+// NodeDeploySSHRunner executes remote shell commands over SSH.
+type NodeDeploySSHRunner struct {
+	client         *ssh.Client
+	commandTimeout time.Duration
+}
+
+const defaultCommandTimeout = 20 * time.Minute
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func NewNodeDeploySSHRunner(cfg NodeDeploySSHConfig) (*NodeDeploySSHRunner, error) {
+	cfg.Host = strings.TrimSpace(cfg.Host)
+	cfg.Username = strings.TrimSpace(cfg.Username)
+	if cfg.Host == "" {
+		return nil, fmt.Errorf("ssh host is required")
+	}
+	if cfg.Username == "" {
+		return nil, fmt.Errorf("ssh username is required")
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 22
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 20 * time.Second
+	}
+	if cfg.CommandTimeout == 0 {
+		cfg.CommandTimeout = defaultCommandTimeout
+	}
+	auth, err := nodeDeployAuthMethods(cfg)
+	if err != nil {
+		return nil, err
+	}
+	clientCfg := &ssh.ClientConfig{
+		User: cfg.Username,
+		Auth: auth,
+		// First-time machine enrollment only has basic SSH information today.
+		// Add known_hosts or fingerprint support before using this on untrusted networks.
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         cfg.Timeout,
+	}
+	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", cfg.Port))
+	client, err := ssh.Dial("tcp", addr, clientCfg)
+	if err != nil {
+		return nil, err
+	}
+	return &NodeDeploySSHRunner{client: client, commandTimeout: cfg.CommandTimeout}, nil
+}
+
+func (r *NodeDeploySSHRunner) effectiveCommandTimeout() time.Duration {
+	if r.commandTimeout <= 0 {
+		return defaultCommandTimeout
+	}
+	return r.commandTimeout
+}
+
+func (r *NodeDeploySSHRunner) contextCommandTimeout(ctx context.Context) time.Duration {
+	timeout := r.effectiveCommandTimeout()
+	if ctx == nil {
+		return timeout
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return timeout
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return time.Nanosecond
+	}
+	if remaining < timeout {
+		return remaining
+	}
+	return timeout
+}
+
+func contextErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}
+
+func nodeDeployAuthMethods(cfg NodeDeploySSHConfig) ([]ssh.AuthMethod, error) {
+	methods := []ssh.AuthMethod{}
+	if strings.TrimSpace(cfg.Password) != "" {
+		methods = append(methods, ssh.Password(cfg.Password))
+	}
+	if strings.TrimSpace(cfg.PrivateKey) != "" {
+		signer, err := ssh.ParsePrivateKey([]byte(cfg.PrivateKey))
+		if err != nil {
+			if strings.Contains(err.Error(), "encrypted") || strings.Contains(err.Error(), "passphrase") {
+				return nil, fmt.Errorf("parse private key: passphrase-protected private keys are not supported")
+			}
+			logs.Warning("failed to parse SSH private key: %v", err)
+			return nil, fmt.Errorf("invalid private key: the key format is not supported or the key is corrupted")
+		}
+		methods = append(methods, ssh.PublicKeys(signer))
+	}
+	if len(methods) == 0 {
+		return nil, fmt.Errorf("missing ssh credential")
+	}
+	return methods, nil
+}
+
+func (r *NodeDeploySSHRunner) Close() error {
+	if r == nil || r.client == nil {
+		return nil
+	}
+	return r.client.Close()
+}
+
+// Run executes a shell command on the remote host. Callers must shell-escape
+// user-controlled values before concatenating them into command.
+func (r *NodeDeploySSHRunner) Run(command string) (string, error) {
+	return r.RunContext(context.Background(), command)
+}
+
+func (r *NodeDeploySSHRunner) RunContext(ctx context.Context, command string) (string, error) {
+	// command is passed directly to the remote shell. Callers must not
+	// concatenate unescaped user-controlled values into this string.
+	if err := contextErr(ctx); err != nil {
+		return "", err
+	}
+	session, err := r.client.NewSession()
+	if err != nil {
+		return "", err
+	}
+	defer session.Close()
+
+	var out lockedBuffer
+	session.Stdout = &out
+	session.Stderr = &out
+	err = r.runSessionWithContext(ctx, session, command)
+	text := strings.TrimSpace(out.String())
+	if err != nil {
+		if text == "" {
+			return "", err
+		}
+		return text, fmt.Errorf("%w: %s", err, text)
+	}
+	return text, nil
+}
+
+func (r *NodeDeploySSHRunner) RunQuiet(command string) error {
+	return r.RunQuietContext(context.Background(), command)
+}
+
+func (r *NodeDeploySSHRunner) RunQuietContext(ctx context.Context, command string) error {
+	if err := contextErr(ctx); err != nil {
+		return err
+	}
+	session, err := r.client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	var out lockedBuffer
+	session.Stdout = &out
+	session.Stderr = &out
+	if err = r.runSessionWithContext(ctx, session, command); err != nil {
+		return fmt.Errorf("%w: %s", err, summarizeSSHOutput(out.String()))
+	}
+	return nil
+}
+
+func (r *NodeDeploySSHRunner) RunRoot(command string) (string, error) {
+	return r.RunRootContext(context.Background(), command)
+}
+
+func (r *NodeDeploySSHRunner) RunRootContext(ctx context.Context, command string) (string, error) {
+	return r.RunContext(ctx, fmt.Sprintf("if [ \"$(id -u)\" = 0 ]; then sh -c %s; else sudo sh -c %s; fi",
+		shellSingleQuote(command), shellSingleQuote(command)))
+}
+
+func (r *NodeDeploySSHRunner) WriteFile(path, content string, mode string) error {
+	return r.WriteFileContext(context.Background(), path, content, mode)
+}
+
+func (r *NodeDeploySSHRunner) WriteFileContext(ctx context.Context, path, content string, mode string) error {
+	if !isAllowedNodeDeployPath(path) {
+		return fmt.Errorf("unsupported node deployment path: %s", path)
+	}
+	if len(mode) != 4 || mode[0] != '0' {
+		return fmt.Errorf("invalid file mode: %q", mode)
+	}
+	if _, err := strconv.ParseUint(mode, 8, 16); err != nil {
+		return fmt.Errorf("invalid file mode: %q", mode)
+	}
+	if err := contextErr(ctx); err != nil {
+		return err
+	}
+	session, err := r.client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	pipe, err := session.StdinPipe()
+	if err != nil {
+		return err
+	}
+	var out lockedBuffer
+	session.Stdout = &out
+	session.Stderr = &out
+
+	cmd := fmt.Sprintf("if [ \"$(id -u)\" = 0 ]; then install -D -m %s /dev/stdin %s; else sudo install -D -m %s /dev/stdin %s; fi",
+		shellSingleQuote(mode), shellSingleQuote(path), shellSingleQuote(mode), shellSingleQuote(path))
+	waitCh, err := r.startSessionWithContext(ctx, session, cmd)
+	if err != nil {
+		_ = pipe.Close()
+		return err
+	}
+	_, copyErr := io.WriteString(pipe, content)
+	closeErr := pipe.Close()
+	waitErr := <-waitCh
+	if copyErr != nil {
+		return fmt.Errorf("write content to pipe: %w (remote error: %v)", copyErr, waitErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close pipe: %w (remote error: %v)", closeErr, waitErr)
+	}
+	if waitErr != nil {
+		return fmt.Errorf("%w: %s", waitErr, summarizeSSHOutput(out.String()))
+	}
+	return nil
+}
+
+func (r *NodeDeploySSHRunner) AppendAuthorizedKey(publicKey string) error {
+	return r.AppendAuthorizedKeyContext(context.Background(), publicKey)
+}
+
+func (r *NodeDeploySSHRunner) AppendAuthorizedKeyContext(ctx context.Context, publicKey string) error {
+	publicKey = strings.TrimSpace(publicKey)
+	if publicKey == "" || strings.ContainsAny(publicKey, "\r\n") {
+		return fmt.Errorf("authorized key must be a single non-empty line")
+	}
+	cmd := fmt.Sprintf("set -e; mkdir -p ~/.ssh; chmod 700 ~/.ssh; touch ~/.ssh/authorized_keys; chmod 600 ~/.ssh/authorized_keys; if ! grep -qxF %s ~/.ssh/authorized_keys; then printf '%%s\\n' %s >> ~/.ssh/authorized_keys; fi",
+		shellSingleQuote(publicKey), shellSingleQuote(publicKey))
+	_, err := r.RunContext(ctx, cmd)
+	return err
+}
+
+func (r *NodeDeploySSHRunner) runSessionWithContext(ctx context.Context, session *ssh.Session, command string) error {
+	waitCh, err := r.startSessionWithContext(ctx, session, command)
+	if err != nil {
+		return err
+	}
+	return <-waitCh
+}
+
+func (r *NodeDeploySSHRunner) startSessionWithContext(ctx context.Context, session *ssh.Session, command string) (<-chan error, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := contextErr(ctx); err != nil {
+		return nil, err
+	}
+	if err := session.Start(command); err != nil {
+		return nil, err
+	}
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- session.Wait()
+	}()
+
+	timeout := r.contextCommandTimeout(ctx)
+	resultCh := make(chan error, 1)
+	go func() {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case err := <-waitCh:
+			resultCh <- err
+		case <-ctx.Done():
+			_ = session.Signal(ssh.SIGKILL)
+			_ = session.Close()
+			resultCh <- ctx.Err()
+		case <-timer.C:
+			_ = session.Signal(ssh.SIGKILL)
+			_ = session.Close()
+			resultCh <- fmt.Errorf("remote command timed out after %s", timeout)
+		}
+	}()
+	return resultCh, nil
+}
+
+func isAllowedNodeDeployPath(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" || strings.Contains(path, "\x00") || strings.Contains(path, "..") {
+		return false
+	}
+	allowedExactPaths := []string{
+		"/etc/cni/net.d/10-casos-bridge.conflist",
+		"/etc/containerd/config.toml",
+		"/etc/containerd/certs.d/docker.io/hosts.toml",
+		"/etc/containerd/certs.d/registry.k8s.io/hosts.toml",
+		"/etc/kubernetes/worker.kubeconfig",
+		"/etc/kubernetes/ca.crt",
+		"/etc/systemd/system/kubelet.service",
+		"/etc/systemd/system/kube-proxy.service",
+		"/var/lib/kubelet/config.yaml",
+		"/var/lib/kube-proxy/config.yaml",
+	}
+	for _, allowedPath := range allowedExactPaths {
+		if path == allowedPath {
+			return true
+		}
+	}
+	return false
+}
+
+// shellSingleQuote returns value quoted for one POSIX shell argument.
+// Values containing newlines must be validated or encoded by callers.
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func summarizeSSHOutput(output string) string {
+	text := strings.TrimSpace(output)
+	if text == "" {
+		return "remote command failed"
+	}
+	text = strings.ReplaceAll(text, "\n", " ")
+	if len(text) > 200 {
+		return text[:200] + "..."
+	}
+	return text
+}

--- a/deploy/init.go
+++ b/deploy/init.go
@@ -1,0 +1,27 @@
+package deploy
+
+import (
+	"context"
+
+	"github.com/beego/beego/logs"
+	"github.com/casosorg/casos/object"
+	"k8s.io/client-go/rest"
+)
+
+var defaultService = NewService()
+
+func DefaultService() *Service {
+	return defaultService
+}
+
+func Init(ctx context.Context, config Config) {
+	defaultService.SetContext(ctx)
+	defaultService.SetConfig(config)
+	if err := object.FailActiveMachineNodeDeployTasks("node deployment task was interrupted by service restart"); err != nil {
+		logs.Warning("machine node deployment task cleanup: %v", err)
+	}
+}
+
+func SetRestConfig(restConfig *rest.Config) {
+	defaultService.SetRestConfig(restConfig)
+}

--- a/deploy/installer.go
+++ b/deploy/installer.go
@@ -1,0 +1,89 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+)
+
+func (d *NodeDeployer) installNodeBinaries(ctx context.Context, runner *NodeDeploySSHRunner) error {
+	version := defaultNodeDeployKubernetesVersion
+	cniVersion := defaultNodeDeployCNIVersion
+
+	d.logStep(nodeDeployPhaseInstalling, "Installing node dependencies and containerd")
+	if _, err := runner.RunRootContext(ctx, "dpkg -s ca-certificates curl iptables socat conntrack ebtables ethtool containerd >/dev/null 2>&1 || (apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl iptables socat conntrack ebtables ethtool containerd)"); err != nil {
+		return fmt.Errorf("install packages: %w", err)
+	}
+
+	d.logStep(nodeDeployPhaseConfiguring, "Configuring containerd")
+	if err := runner.WriteFileContext(ctx, "/etc/containerd/config.toml", GenerateContainerdConfig(d.config.SandboxImage, d.config.Socks5Proxy), "0644"); err != nil {
+		return fmt.Errorf("write /etc/containerd/config.toml: %w", err)
+	}
+	if d.config.Socks5Proxy != "" {
+		if err := runner.WriteFileContext(ctx, "/etc/containerd/certs.d/docker.io/hosts.toml", GenerateDockerHubHostsToml(), "0644"); err != nil {
+			return fmt.Errorf("write /etc/containerd/certs.d/docker.io/hosts.toml: %w", err)
+		}
+		if err := runner.WriteFileContext(ctx, "/etc/containerd/certs.d/registry.k8s.io/hosts.toml", GenerateK8sRegistryHostsToml(), "0644"); err != nil {
+			return fmt.Errorf("write /etc/containerd/certs.d/registry.k8s.io/hosts.toml: %w", err)
+		}
+	}
+	if _, err := runner.RunRootContext(ctx, "systemctl enable --now containerd && systemctl restart containerd"); err != nil {
+		return fmt.Errorf("start containerd: %w", err)
+	}
+
+	d.logStep(nodeDeployPhaseInstalling, "Ensuring upstream kubelet, kube-proxy, and CNI plugins")
+	installCmd := fmt.Sprintf(`set -e
+download() {
+  curl -fsSL --connect-timeout 20 --max-time 600 --retry 2 --retry-delay 5 --retry-connrefused "$@"
+}
+needs_kube_binary() {
+  path="$1"
+  if [ ! -x "$path" ]; then
+    return 0
+  fi
+  "$path" --version 2>/dev/null | grep -Fq "Kubernetes %s" && return 1
+  return 0
+}
+if needs_kube_binary /usr/local/bin/kubelet; then
+  download -o /tmp/kubelet https://dl.k8s.io/%s/bin/linux/amd64/kubelet
+  install -o root -g root -m 0755 /tmp/kubelet /usr/local/bin/kubelet
+fi
+if needs_kube_binary /usr/local/bin/kube-proxy; then
+  download -o /tmp/kube-proxy https://dl.k8s.io/%s/bin/linux/amd64/kube-proxy
+  install -o root -g root -m 0755 /tmp/kube-proxy /usr/local/bin/kube-proxy
+fi
+mkdir -p /opt/cni/bin /etc/cni/net.d
+if [ ! -x /opt/cni/bin/bridge ] || [ ! -x /opt/cni/bin/loopback ] || [ ! -x /opt/cni/bin/portmap ]; then
+  download -o /tmp/cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/%s/cni-plugins-linux-amd64-%s.tgz
+  tar -xzf /tmp/cni-plugins.tgz -C /opt/cni/bin
+fi`, version, version, version, cniVersion, cniVersion)
+	if _, err := runner.RunRootContext(ctx, installCmd); err != nil {
+		return fmt.Errorf("install node binaries: %w", err)
+	}
+	return nil
+}
+
+func (d *NodeDeployer) writeNodeFiles(ctx context.Context, runner *NodeDeploySSHRunner, nodeName, kubeconfig string) error {
+	ca, err := extractCertificateAuthority(kubeconfig)
+	if err != nil {
+		return err
+	}
+	if err = runner.WriteFileContext(ctx, "/etc/kubernetes/worker.kubeconfig", kubeconfig, "0600"); err != nil {
+		return fmt.Errorf("write /etc/kubernetes/worker.kubeconfig: %w", err)
+	}
+	if err = runner.WriteFileContext(ctx, "/etc/kubernetes/ca.crt", ca, "0644"); err != nil {
+		return fmt.Errorf("write /etc/kubernetes/ca.crt: %w", err)
+	}
+	if err = runner.WriteFileContext(ctx, "/var/lib/kubelet/config.yaml", kubeletConfig(), "0644"); err != nil {
+		return fmt.Errorf("write /var/lib/kubelet/config.yaml: %w", err)
+	}
+	if err = runner.WriteFileContext(ctx, "/etc/systemd/system/kubelet.service", kubeletService(nodeName), "0644"); err != nil {
+		return fmt.Errorf("write /etc/systemd/system/kubelet.service: %w", err)
+	}
+	if err = runner.WriteFileContext(ctx, "/var/lib/kube-proxy/config.yaml", kubeProxyConfig(), "0644"); err != nil {
+		return fmt.Errorf("write /var/lib/kube-proxy/config.yaml: %w", err)
+	}
+	if err = runner.WriteFileContext(ctx, "/etc/systemd/system/kube-proxy.service", kubeProxyService(), "0644"); err != nil {
+		return fmt.Errorf("write /etc/systemd/system/kube-proxy.service: %w", err)
+	}
+	return nil
+}

--- a/deploy/key.go
+++ b/deploy/key.go
@@ -1,0 +1,38 @@
+package deploy
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type NodeDeployKeyPair struct {
+	PrivateKey string
+	PublicKey  string
+}
+
+func GenerateNodeDeployKeyPair() (*NodeDeployKeyPair, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 3072)
+	if err != nil {
+		return nil, err
+	}
+	privateDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	privatePEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateDER})
+
+	pub, err := ssh.NewPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NodeDeployKeyPair{
+		PrivateKey: string(privatePEM),
+		PublicKey:  strings.TrimSpace(string(ssh.MarshalAuthorizedKey(pub))),
+	}, nil
+}

--- a/deploy/kubeconfig.go
+++ b/deploy/kubeconfig.go
@@ -1,0 +1,38 @@
+package deploy
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type workerKubeconfigCluster struct {
+	Cluster struct {
+		CertificateAuthorityData string `yaml:"certificate-authority-data"`
+	} `yaml:"cluster"`
+}
+
+type workerKubeconfigFile struct {
+	Clusters []workerKubeconfigCluster `yaml:"clusters"`
+}
+
+func extractCertificateAuthority(kubeconfig string) (string, error) {
+	var cfg workerKubeconfigFile
+	if err := yaml.Unmarshal([]byte(kubeconfig), &cfg); err != nil {
+		return "", fmt.Errorf("parse worker kubeconfig: %w", err)
+	}
+	if len(cfg.Clusters) != 1 {
+		return "", fmt.Errorf("expected exactly 1 cluster in worker kubeconfig, got %d", len(cfg.Clusters))
+	}
+	raw := strings.TrimSpace(cfg.Clusters[0].Cluster.CertificateAuthorityData)
+	if raw == "" {
+		return "", fmt.Errorf("certificate-authority-data is empty")
+	}
+	data, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return "", fmt.Errorf("decode certificate-authority-data: %w", err)
+	}
+	return string(data), nil
+}

--- a/deploy/kubelet.go
+++ b/deploy/kubelet.go
@@ -1,0 +1,48 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+)
+
+func (d *NodeDeployer) startKubelet(ctx context.Context, runner *NodeDeploySSHRunner) error {
+	d.logStep(nodeDeployPhaseStarting, "Starting kubelet")
+	if _, err := runner.RunRootContext(ctx, "systemctl daemon-reload && systemctl enable kubelet && systemctl restart kubelet"); err != nil {
+		return fmt.Errorf("start kubelet: %w", err)
+	}
+	return nil
+}
+
+func kubeletConfig() string {
+	return fmt.Sprintf(`apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: systemd
+failSwapOn: false
+containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
+clusterDNS:
+  - %s
+clusterDomain: cluster.local
+`, nodeDeployClusterDNS)
+}
+
+func kubeletService(nodeName string) string {
+	return fmt.Sprintf(`[Unit]
+Description=Kubernetes Kubelet
+After=containerd.service
+Requires=containerd.service
+
+[Service]
+ExecStart=/usr/local/bin/kubelet \
+  --kubeconfig=/etc/kubernetes/worker.kubeconfig \
+  --config=/var/lib/kubelet/config.yaml \
+  --client-ca-file=/etc/kubernetes/ca.crt \
+  --register-node=true \
+  --hostname-override=%s \
+  --v=2
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`, nodeName)
+}

--- a/deploy/kubeproxy.go
+++ b/deploy/kubeproxy.go
@@ -1,0 +1,41 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+)
+
+func (d *NodeDeployer) startKubeProxy(ctx context.Context, runner *NodeDeploySSHRunner) error {
+	d.logStep(nodeDeployPhaseStarting, "Starting kube-proxy")
+	if _, err := runner.RunRootContext(ctx, "systemctl daemon-reload && systemctl enable kube-proxy && systemctl restart kube-proxy"); err != nil {
+		return fmt.Errorf("start kube-proxy: %w", err)
+	}
+	return nil
+}
+
+func kubeProxyConfig() string {
+	return fmt.Sprintf(`apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clientConnection:
+  kubeconfig: /etc/kubernetes/worker.kubeconfig
+mode: iptables
+clusterCIDR: %s
+`, nodeDeployClusterCIDR)
+}
+
+func kubeProxyService() string {
+	return `[Unit]
+Description=Kubernetes Kube-Proxy
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/kube-proxy \
+  --config=/var/lib/kube-proxy/config.yaml \
+  --v=2
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`
+}

--- a/deploy/node_bootstrap.go
+++ b/deploy/node_bootstrap.go
@@ -1,0 +1,213 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type NodeDeployer struct {
+	config     Config
+	restConfig *rest.Config
+	log        NodeDeployLogger
+}
+
+func NewNodeDeployer(config Config, restConfig *rest.Config, log NodeDeployLogger) *NodeDeployer {
+	if log == nil {
+		log = func(string, string, string) {}
+	}
+	return &NodeDeployer{config: config, restConfig: restConfig, log: log}
+}
+
+func (d *NodeDeployer) logStep(phase, message string) {
+	d.log("info", message, phase)
+}
+
+func (d *NodeDeployer) Preflight(ctx context.Context, opts NodeDeployOptions) (*NodeDeployPreflightResult, error) {
+	if err := (&opts).validate(); err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	runner, err := newRunnerForMachine(opts.Machine)
+	if err != nil {
+		return nil, err
+	}
+	defer runner.Close()
+	return RunNodeDeployPreflight(ctx, runner, opts.ApiserverURL)
+}
+
+func (d *NodeDeployer) Deploy(ctx context.Context, opts NodeDeployOptions) (*NodeDeployResult, error) {
+	if err := (&opts).validate(); err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if d.restConfig == nil {
+		return nil, fmt.Errorf("apiserver rest config is required")
+	}
+	runner, err := newRunnerForMachine(opts.Machine)
+	if err != nil {
+		return nil, err
+	}
+	defer runner.Close()
+
+	d.logStep(nodeDeployPhasePreflight, "Starting node preflight")
+	if _, err = RunNodeDeployPreflight(ctx, runner, opts.ApiserverURL); err != nil {
+		return nil, err
+	}
+
+	d.logStep(nodeDeployPhaseConfiguring, "Generating node kubeconfig")
+	if d.config.GenerateKubeconfig == nil {
+		return nil, fmt.Errorf("node kubeconfig generator is required")
+	}
+	wk, err := d.config.GenerateKubeconfig(opts.NodeName, opts.ApiserverURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = d.installNodeBinaries(ctx, runner); err != nil {
+		return nil, err
+	}
+	if err = d.writeNodeFiles(ctx, runner, opts.NodeName, wk.Kubeconfig); err != nil {
+		return nil, err
+	}
+	if err = d.startKubelet(ctx, runner); err != nil {
+		return nil, err
+	}
+
+	d.logStep(nodeDeployPhaseWaiting, "Waiting for node registration")
+	podCIDR, err := d.waitForNodePodCIDR(ctx, opts.NodeName)
+	if err != nil {
+		return nil, err
+	}
+
+	d.logStep(nodeDeployPhaseConfiguring, "Writing node CNI config")
+	if err = runner.WriteFileContext(ctx, "/etc/cni/net.d/10-casos-bridge.conflist", bridgeCNIConfig(podCIDR), "0644"); err != nil {
+		return nil, fmt.Errorf("write /etc/cni/net.d/10-casos-bridge.conflist: %w", err)
+	}
+	if _, err = runner.RunRootContext(ctx, "systemctl restart kubelet"); err != nil {
+		return nil, fmt.Errorf("restart kubelet: %w", err)
+	}
+
+	if err = d.startKubeProxy(ctx, runner); err != nil {
+		return nil, err
+	}
+
+	d.logStep(nodeDeployPhaseWaiting, "Waiting for Node Ready")
+	if err = d.waitForNodeReady(ctx, opts.NodeName); err != nil {
+		return nil, err
+	}
+
+	d.logStep(nodeDeployPhaseConfiguring, "Writing CasOS managed SSH key")
+	keyPair, err := GenerateNodeDeployKeyPair()
+	if err != nil {
+		return nil, err
+	}
+	if err = runner.AppendAuthorizedKeyContext(ctx, keyPair.PublicKey); err != nil {
+		return nil, err
+	}
+
+	d.logStep(nodeDeployPhaseReady, "Node registered and Ready")
+	return &NodeDeployResult{ManagedPrivateKey: keyPair.PrivateKey}, nil
+}
+
+func newRunnerForMachine(machine NodeDeployMachine) (*NodeDeploySSHRunner, error) {
+	return NewNodeDeploySSHRunner(NodeDeploySSHConfig{
+		Host:       machine.Host,
+		Port:       machine.Port,
+		Username:   machine.Username,
+		Password:   machine.Password,
+		PrivateKey: machine.PrivateKey,
+	})
+}
+
+func (d *NodeDeployer) waitForNodePodCIDR(ctx context.Context, nodeName string) (string, error) {
+	if d.restConfig == nil {
+		return "", fmt.Errorf("apiserver rest config is required")
+	}
+	client, err := kubernetes.NewForConfig(d.restConfig)
+	if err != nil {
+		return "", err
+	}
+	deadlineTimer, deadline := deploymentWaitDeadline(ctx)
+	ticker := time.NewTicker(3 * time.Second)
+	defer deadlineTimer.Stop()
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-deadline:
+			return "", fmt.Errorf("timed out waiting for node PodCIDR")
+		case <-ticker.C:
+			node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return "", err
+				}
+				continue
+			}
+			if node.Spec.PodCIDR != "" {
+				return node.Spec.PodCIDR, nil
+			}
+		}
+	}
+}
+
+func (d *NodeDeployer) waitForNodeReady(ctx context.Context, nodeName string) error {
+	if d.restConfig == nil {
+		return fmt.Errorf("apiserver rest config is required")
+	}
+	client, err := kubernetes.NewForConfig(d.restConfig)
+	if err != nil {
+		return err
+	}
+	deadlineTimer, deadline := deploymentWaitDeadline(ctx)
+	ticker := time.NewTicker(3 * time.Second)
+	defer deadlineTimer.Stop()
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("timed out waiting for Node Ready")
+		case <-ticker.C:
+			node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+				continue
+			}
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+					return nil
+				}
+			}
+		}
+	}
+}
+
+func deploymentWaitDeadline(ctx context.Context) (*time.Timer, <-chan time.Time) {
+	if deadline, ok := ctx.Deadline(); ok {
+		duration := time.Until(deadline)
+		if duration <= 0 {
+			timer := time.NewTimer(0)
+			return timer, timer.C
+		}
+		timer := time.NewTimer(duration)
+		return timer, timer.C
+	}
+	timer := time.NewTimer(4 * time.Minute)
+	return timer, timer.C
+}

--- a/deploy/preflight.go
+++ b/deploy/preflight.go
@@ -1,0 +1,155 @@
+package deploy
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const nodeDeployWSLProbeCommand = "[ -f /proc/sys/fs/binfmt_misc/WSLInterop ] || grep -qi microsoft /proc/version"
+
+type NodeDeployPreflightResult struct {
+	OS           string `json:"os"`
+	Arch         string `json:"arch"`
+	Systemd      bool   `json:"systemd"`
+	PackageTool  string `json:"packageTool"`
+	CanSudo      bool   `json:"canSudo"`
+	ApiserverURL string `json:"apiserverUrl"`
+	ApiserverOK  bool   `json:"apiserverOk"`
+	WSL          bool   `json:"wsl"`
+}
+
+func RunNodeDeployPreflight(ctx context.Context, runner *NodeDeploySSHRunner, apiserverURL string) (*NodeDeployPreflightResult, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("ssh runner is required")
+	}
+	result := &NodeDeployPreflightResult{}
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	osName, err := runner.RunContext(ctx, "uname -s")
+	if err != nil {
+		return nil, fmt.Errorf("detect os: %w", err)
+	}
+	if strings.TrimSpace(osName) != "Linux" {
+		return nil, fmt.Errorf("unsupported os %q: only Linux is supported", osName)
+	}
+	result.OS = "linux"
+
+	arch, err := runner.RunContext(ctx, "arch=$(uname -m 2>/dev/null | awk 'NF {print; exit}'); if [ -z \"$arch\" ] && command -v dpkg >/dev/null 2>&1; then arch=$(dpkg --print-architecture 2>/dev/null | awk 'NF {print; exit}'); fi; if [ -z \"$arch\" ] && command -v arch >/dev/null 2>&1; then arch=$(arch 2>/dev/null | awk 'NF {print; exit}'); fi; printf %s \"$arch\"")
+	if err != nil {
+		return nil, fmt.Errorf("detect arch: %w", err)
+	}
+	if strings.TrimSpace(arch) == "" {
+		return nil, fmt.Errorf("failed to detect machine architecture: uname -m returned empty output")
+	}
+	result.Arch = normalizeNodeDeployArch(arch)
+	if result.Arch != "amd64" {
+		return nil, fmt.Errorf("unsupported arch %q: only amd64 is supported", result.Arch)
+	}
+
+	if _, err = runner.RunContext(ctx, "command -v systemctl >/dev/null"); err != nil {
+		return nil, fmt.Errorf("systemctl not found: systemd is required for node services: %w", err)
+	}
+	if _, err = runner.RunContext(ctx, "[ \"$(ps -p 1 -o comm=)\" = systemd ]"); err != nil {
+		return nil, fmt.Errorf("PID 1 is not systemd: systemd is required for node services: %w", err)
+	}
+	result.Systemd = true
+
+	if _, err = runner.RunContext(ctx, "command -v apt-get >/dev/null"); err != nil {
+		return nil, fmt.Errorf("unsupported package manager: apt-get is required for Ubuntu/Debian node deployment in this version: %w", err)
+	}
+	result.PackageTool = "apt"
+
+	if _, err = runner.RunContext(ctx, "sudo -n true 2>/dev/null || [ \"$(id -u)\" = 0 ]"); err != nil {
+		return nil, fmt.Errorf("root or passwordless sudo is required: %w", err)
+	}
+	result.CanSudo = true
+
+	if isNodeDeployWSL(ctx, runner) {
+		result.WSL = true
+	}
+
+	if apiserverURL != "" {
+		parsed, err := url.Parse(apiserverURL)
+		if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+			return nil, fmt.Errorf("apiserverUrl must be a valid https URL")
+		}
+		if _, err = runner.RunContext(ctx, "command -v curl >/dev/null"); err != nil {
+			return nil, fmt.Errorf("curl is required to check apiserver reachability: %w", err)
+		}
+		if _, err = runner.RunContext(ctx, "command -v base64 >/dev/null"); err != nil {
+			return nil, fmt.Errorf("base64 is required to check apiserver reachability: %w", err)
+		}
+		trimmedURL := strings.TrimRight(apiserverURL, "/")
+		result.ApiserverURL = trimmedURL
+		// The bootstrap kubeconfig embeds the apiserver CA, but this early
+		// reachability probe runs before those files exist on the target node.
+		encodedURL := base64.StdEncoding.EncodeToString([]byte(trimmedURL))
+		cmd := fmt.Sprintf("apiserver_url=$(printf %%s %s | base64 -d) && curl -kfsS --connect-timeout 5 \"$apiserver_url/readyz\" >/dev/null", shellSingleQuote(encodedURL))
+		if _, err = runner.RunContext(ctx, cmd); err != nil {
+			return nil, fmt.Errorf("apiserver is not reachable from target: %w", err)
+		}
+		result.ApiserverOK = true
+	}
+
+	return result, nil
+}
+
+func ResolveNodeDeployApiserverURL(ctx context.Context, runner *NodeDeploySSHRunner, fallbackURL string) string {
+	fallbackURL = strings.TrimRight(strings.TrimSpace(fallbackURL), "/")
+	if runner == nil {
+		return fallbackURL
+	}
+	wslCtx, wslCancel := context.WithTimeout(ctx, 3*time.Second)
+	defer wslCancel()
+	if !isNodeDeployWSL(wslCtx, runner) {
+		return fallbackURL
+	}
+	gatewayCtx, gatewayCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer gatewayCancel()
+	gateway, err := runner.RunContext(gatewayCtx, "ip route | awk '$1 == \"default\" {print $3; exit}'")
+	if err != nil {
+		return fallbackURL
+	}
+	gateway = strings.TrimSpace(gateway)
+	if gateway == "" {
+		return fallbackURL
+	}
+	parsed, err := url.Parse(fallbackURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return fallbackURL
+	}
+	port := parsed.Port()
+	if port == "" {
+		if strings.Contains(gateway, ":") {
+			parsed.Host = "[" + gateway + "]"
+		} else {
+			parsed.Host = gateway
+		}
+	} else {
+		parsed.Host = net.JoinHostPort(gateway, port)
+	}
+	return strings.TrimRight(parsed.String(), "/")
+}
+
+func isNodeDeployWSL(ctx context.Context, runner *NodeDeploySSHRunner) bool {
+	if runner == nil {
+		return false
+	}
+	_, err := runner.RunContext(ctx, nodeDeployWSLProbeCommand)
+	return err == nil
+}
+
+func normalizeNodeDeployArch(arch string) string {
+	switch strings.TrimSpace(arch) {
+	case "x86_64", "amd64":
+		return "amd64"
+	default:
+		return strings.TrimSpace(arch)
+	}
+}

--- a/deploy/service.go
+++ b/deploy/service.go
@@ -1,0 +1,411 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/beego/beego/logs"
+	"github.com/casosorg/casos/object"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	defaultMachineNodeTaskLimit = 50
+	defaultMachineNodeLogLimit  = 500
+	machineNodeDeployTimeout    = 20 * time.Minute
+)
+
+type Service struct {
+	mu         sync.RWMutex
+	ctx        context.Context
+	config     *Config
+	restConfig *rest.Config
+	semaphore  chan struct{}
+}
+
+func NewService() *Service {
+	return &Service{
+		ctx:       context.Background(),
+		semaphore: make(chan struct{}, 5),
+	}
+}
+
+func (s *Service) SetContext(ctx context.Context) {
+	if ctx == nil || ctx.Err() != nil {
+		if ctx != nil {
+			logs.Warning("machine node deployment context is already canceled: %v", ctx.Err())
+		}
+		ctx = context.Background()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ctx = ctx
+}
+
+func (s *Service) SetConfig(config Config) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.config = &config
+}
+
+func (s *Service) SetRestConfig(restConfig *rest.Config) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.restConfig = restConfig
+}
+
+func (s *Service) PreflightMachineNode(req MachineNodeDeployRequest) (map[string]interface{}, error) {
+	config, err := s.configSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	if _, err = s.restConfigSnapshot(); err != nil {
+		return nil, err
+	}
+	_, deployMachine, err := s.prepareMachineNodeRequest(&req)
+	if err != nil {
+		return nil, err
+	}
+	if req.ApiserverURL == "" {
+		resolved, err := resolveMachineNodeApiserverURL(deployMachine, defaultNodeDeployApiserverURL(config))
+		if err != nil {
+			return nil, err
+		}
+		req.ApiserverURL = resolved
+	}
+	deployer := NewNodeDeployer(config, nil, nil)
+	ctx, cancel := context.WithTimeout(s.contextSnapshot(), 30*time.Second)
+	defer cancel()
+	result, err := deployer.Preflight(ctx, NodeDeployOptions{
+		Machine:      deployMachine,
+		NodeName:     req.NodeName,
+		ApiserverURL: req.ApiserverURL,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"nodeName":     req.NodeName,
+		"apiserverUrl": req.ApiserverURL,
+		"preflight":    result,
+	}, nil
+}
+
+func (s *Service) DeployMachineNode(req MachineNodeDeployRequest) (*object.MachineNodeDeployTask, error) {
+	config, err := s.configSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	restConfig, err := s.restConfigSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	machine, deployMachine, err := s.prepareMachineNodeRequest(&req)
+	if err != nil {
+		return nil, err
+	}
+	if req.ApiserverURL == "" {
+		resolved, err := resolveMachineNodeApiserverURL(deployMachine, defaultNodeDeployApiserverURL(config))
+		if err != nil {
+			return nil, err
+		}
+		req.ApiserverURL = resolved
+	}
+
+	if !s.acquireDeploymentSlot() {
+		return nil, fmt.Errorf("too many concurrent node deployments, try again later")
+	}
+
+	task, err := object.CreateMachineNodeDeployTask(machine.Owner, machine.Name, req.NodeName, req.ApiserverURL)
+	if err != nil {
+		s.releaseDeploymentSlot()
+		return nil, err
+	}
+	if err = object.AddMachineNodeDeployLog(task.Id, object.MachineNodeDeployLogLevelInfo, "Node deployment task created"); err != nil {
+		s.releaseDeploymentSlot()
+		return nil, err
+	}
+
+	deployCtx := s.contextSnapshot()
+	go func(ctx context.Context) {
+		defer s.releaseDeploymentSlot()
+		defer func() {
+			if v := recover(); v != nil {
+				message := fmt.Sprintf("Node deployment task panic: %v", v)
+				logs.Error(message)
+				cleanupMachineNodeDeployPanic(task.Id, machine.Owner, machine.Name, message)
+			}
+		}()
+		s.runMachineNodeDeployTask(ctx, task.Id, config, restConfig)
+	}(deployCtx)
+
+	return task, nil
+}
+
+func (s *Service) RepairMachineNode(req MachineNodeDeployRequest) (*object.MachineNodeDeployTask, error) {
+	return s.DeployMachineNode(req)
+}
+
+func (s *Service) GetMachineNodeTasks(owner, machineName string) ([]*object.MachineNodeDeployTask, error) {
+	if owner == "" {
+		owner = "admin"
+	}
+	return object.GetMachineNodeDeployTasks(owner, machineName, defaultMachineNodeTaskLimit)
+}
+
+func (s *Service) GetMachineNodeLogs(taskId int64) ([]*object.MachineNodeDeployLog, error) {
+	if taskId <= 0 {
+		return nil, fmt.Errorf("invalid taskId")
+	}
+	return object.GetMachineNodeDeployLogs(taskId, defaultMachineNodeLogLimit)
+}
+
+func (s *Service) prepareMachineNodeRequest(req *MachineNodeDeployRequest) (*object.Machine, NodeDeployMachine, error) {
+	req.normalize()
+	if err := req.validate(); err != nil {
+		return nil, NodeDeployMachine{}, err
+	}
+	machine, err := getMachineForNodeDeploy(req.Owner, req.MachineName)
+	if err != nil {
+		return nil, NodeDeployMachine{}, err
+	}
+	if req.NodeName == "" {
+		req.NodeName = machine.Name
+	}
+	if err := validateNodeDeployName(req.NodeName); err != nil {
+		return nil, NodeDeployMachine{}, err
+	}
+	deployMachine, err := toNodeDeployMachine(machine)
+	if err != nil {
+		return nil, NodeDeployMachine{}, err
+	}
+	return machine, deployMachine, nil
+}
+
+func (s *Service) configSnapshot() (Config, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.config == nil {
+		return Config{}, fmt.Errorf("server config not ready")
+	}
+	return *s.config, nil
+}
+
+func (s *Service) restConfigSnapshot() (*rest.Config, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.restConfig == nil {
+		return nil, fmt.Errorf("apiserver not ready")
+	}
+	return rest.CopyConfig(s.restConfig), nil
+}
+
+func (s *Service) contextSnapshot() context.Context {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.ctx == nil {
+		return context.Background()
+	}
+	return s.ctx
+}
+
+func (s *Service) acquireDeploymentSlot() bool {
+	select {
+	case s.semaphore <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Service) releaseDeploymentSlot() {
+	<-s.semaphore
+}
+
+func (s *Service) runMachineNodeDeployTask(parentCtx context.Context, taskId int64, config Config, restConfig *rest.Config) {
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	logTask := func(level, message string) {
+		if err := object.AddMachineNodeDeployLog(taskId, level, message); err != nil {
+			logs.Warning("failed to write node deployment log for task %d: %v", taskId, err)
+		}
+	}
+
+	task, err := object.GetMachineNodeDeployTask(taskId)
+	if err != nil || task == nil {
+		logTask(object.MachineNodeDeployLogLevelError, "Failed to load node deployment task")
+		return
+	}
+	machine, err := object.GetMachine(fmt.Sprintf("%s/%s", task.Owner, task.MachineName))
+	if err != nil || machine == nil {
+		logTask(object.MachineNodeDeployLogLevelError, "Failed to load machine")
+		_ = object.FinishMachineNodeDeployTask(taskId, false, object.MachineNodeDeployPhaseFailed, "machine not found")
+		return
+	}
+
+	if err = object.StartMachineNodeDeployTask(taskId, object.MachineNodeDeployPhasePreflight); err != nil {
+		logTask(object.MachineNodeDeployLogLevelError, err.Error())
+		_ = object.UpdateMachineNodeDeployStatus(machine.Owner, machine.Name, object.MachineStatusFailed)
+		if finishErr := object.FinishMachineNodeDeployTask(taskId, false, object.MachineNodeDeployPhaseFailed, err.Error()); finishErr != nil {
+			logTask(object.MachineNodeDeployLogLevelError, "Failed to finish node deployment task: "+finishErr.Error())
+		}
+		return
+	}
+	if err = object.UpdateMachineNodeDeployStatus(machine.Owner, machine.Name, object.MachineStatusDeploying); err != nil {
+		logTask(object.MachineNodeDeployLogLevelError, err.Error())
+		if finishErr := object.FinishMachineNodeDeployTask(taskId, false, object.MachineNodeDeployPhaseFailed, err.Error()); finishErr != nil {
+			logTask(object.MachineNodeDeployLogLevelError, "Failed to finish node deployment task: "+finishErr.Error())
+		}
+		return
+	}
+	deployer := NewNodeDeployer(config, restConfig, func(level, message, phase string) {
+		logTask(level, message)
+		if phase != "" {
+			_ = object.UpdateMachineNodeDeployTaskPhase(taskId, phase)
+		}
+	})
+	deployMachine, err := toNodeDeployMachine(machine)
+	if err != nil {
+		logTask(object.MachineNodeDeployLogLevelError, err.Error())
+		_ = object.UpdateMachineNodeDeployStatus(machine.Owner, machine.Name, object.MachineStatusFailed)
+		if finishErr := object.FinishMachineNodeDeployTask(taskId, false, object.MachineNodeDeployPhaseFailed, err.Error()); finishErr != nil {
+			logTask(object.MachineNodeDeployLogLevelError, "Failed to finish node deployment task: "+finishErr.Error())
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, machineNodeDeployTimeout)
+	defer cancel()
+
+	result, err := deployer.Deploy(ctx, NodeDeployOptions{
+		Machine:      deployMachine,
+		NodeName:     task.NodeName,
+		ApiserverURL: task.ApiserverURL,
+	})
+	if err != nil {
+		logTask(object.MachineNodeDeployLogLevelError, "Node deployment failed: "+err.Error())
+		_ = object.UpdateMachineNodeDeployStatus(machine.Owner, machine.Name, object.MachineStatusFailed)
+		if finishErr := object.FinishMachineNodeDeployTask(taskId, false, object.MachineNodeDeployPhaseFailed, err.Error()); finishErr != nil {
+			logTask(object.MachineNodeDeployLogLevelError, "Failed to finish node deployment task: "+finishErr.Error())
+		}
+		return
+	}
+	if result != nil && result.ManagedPrivateKey != "" {
+		if err = object.UpdateMachineNodeDeployCredential(machine, result.ManagedPrivateKey); err != nil {
+			logTask(object.MachineNodeDeployLogLevelError, "Failed to save managed SSH key: "+err.Error())
+			_ = object.UpdateMachineNodeDeployStatus(machine.Owner, machine.Name, object.MachineStatusFailed)
+			if finishErr := object.FinishMachineNodeDeployTask(taskId, false, object.MachineNodeDeployPhaseFailed, err.Error()); finishErr != nil {
+				logTask(object.MachineNodeDeployLogLevelError, "Failed to finish node deployment task: "+finishErr.Error())
+			}
+			return
+		}
+		logTask(object.MachineNodeDeployLogLevelInfo, "CasOS managed SSH key installed")
+	}
+
+	logTask(object.MachineNodeDeployLogLevelInfo, "Node deployment completed")
+	if err = object.UpdateMachineNodeDeployStatus(machine.Owner, machine.Name, object.MachineStatusDeployed); err != nil {
+		logTask(object.MachineNodeDeployLogLevelError, "Failed to update machine status after completed node deployment: "+err.Error())
+		_ = object.FinishMachineNodeDeployTask(taskId, true, object.MachineNodeDeployPhaseReady, "machine status update failed: "+err.Error())
+		return
+	}
+	_ = object.FinishMachineNodeDeployTask(taskId, true, object.MachineNodeDeployPhaseReady, "")
+}
+
+func cleanupMachineNodeDeployPanic(taskId int64, owner, machineName, message string) {
+	defer func() {
+		if v := recover(); v != nil {
+			logs.Error("panic while cleaning up node deployment task panic: %v", v)
+		}
+	}()
+	if logErr := object.AddMachineNodeDeployLog(taskId, object.MachineNodeDeployLogLevelError, message); logErr != nil {
+		logs.Warning("failed to log node deployment panic: %v", logErr)
+	}
+	if statusErr := object.UpdateMachineNodeDeployStatus(owner, machineName, object.MachineStatusFailed); statusErr != nil {
+		logs.Warning("failed to update machine status after node deployment panic: %v", statusErr)
+	}
+	if err := object.FinishMachineNodeDeployTask(taskId, false, object.MachineNodeDeployPhaseFailed, message); err != nil {
+		logs.Warning("failed to finish node deployment task after panic: %v", err)
+	}
+}
+
+func toNodeDeployMachine(machine *object.Machine) (NodeDeployMachine, error) {
+	deployMachine := NodeDeployMachine{
+		Host:       machine.Ip,
+		Port:       machine.Port,
+		Username:   machine.Username,
+		Password:   machine.Password,
+		PrivateKey: machine.PrivateKey,
+	}
+	if strings.TrimSpace(deployMachine.Password) == "" && strings.TrimSpace(deployMachine.PrivateKey) == "" {
+		credential, err := object.GetMachineNodeDeployCredential(machine.Owner, machine.Name)
+		if err != nil {
+			return deployMachine, fmt.Errorf("failed to load managed SSH credential for %s/%s: %w", machine.Owner, machine.Name, err)
+		}
+		if credential == nil || strings.TrimSpace(credential.PrivateKey) == "" {
+			return deployMachine, fmt.Errorf("no SSH credential available for machine %s/%s", machine.Owner, machine.Name)
+		}
+		deployMachine.PrivateKey = credential.PrivateKey
+	}
+	return deployMachine, nil
+}
+
+func getMachineForNodeDeploy(owner, machineName string) (*object.Machine, error) {
+	if machineName == "" {
+		return nil, fmt.Errorf("machineName is required")
+	}
+	machine, err := object.GetMachine(fmt.Sprintf("%s/%s", owner, machineName))
+	if err != nil {
+		return nil, err
+	}
+	if machine == nil {
+		return nil, fmt.Errorf("machine not found")
+	}
+	if machine.Ip == "" || machine.Username == "" {
+		return nil, fmt.Errorf("machine ip and username are required")
+	}
+	if strings.TrimSpace(machine.Password) == "" && strings.TrimSpace(machine.PrivateKey) == "" {
+		credential, err := object.GetMachineNodeDeployCredential(machine.Owner, machine.Name)
+		if err != nil {
+			return nil, err
+		}
+		if credential != nil && strings.TrimSpace(credential.PrivateKey) != "" {
+			return machine, nil
+		}
+		return nil, fmt.Errorf("machine password or private key is required")
+	}
+	return machine, nil
+}
+
+func resolveMachineNodeApiserverURL(machine NodeDeployMachine, fallbackURL string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	runner, err := NewNodeDeploySSHRunner(NodeDeploySSHConfig{
+		Host:       machine.Host,
+		Port:       machine.Port,
+		Username:   machine.Username,
+		Password:   machine.Password,
+		PrivateKey: machine.PrivateKey,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer runner.Close()
+	return ResolveNodeDeployApiserverURL(ctx, runner, fallbackURL), nil
+}
+
+func defaultNodeDeployApiserverURL(config Config) string {
+	host := config.AdvertiseAddress
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = config.ApiserverBind
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("https://%s", net.JoinHostPort(host, strconv.Itoa(config.ApiserverPort)))
+}

--- a/deploy/types.go
+++ b/deploy/types.go
@@ -1,0 +1,155 @@
+package deploy
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/casosorg/casos/server"
+)
+
+const (
+	defaultNodeDeployKubernetesVersion = "v1.36.1"
+	defaultNodeDeployCNIVersion        = "v1.5.1"
+	nodeDeployClusterCIDR              = "10.244.0.0/16"
+	nodeDeployClusterDNS               = "10.43.0.10"
+	nodeDeployPhasePreflight           = "preflight"
+	nodeDeployPhaseInstalling          = "installing"
+	nodeDeployPhaseConfiguring         = "configuring"
+	nodeDeployPhaseStarting            = "starting"
+	nodeDeployPhaseWaiting             = "waiting"
+	nodeDeployPhaseReady               = "ready"
+)
+
+type NodeDeployLogger func(level, message, phase string)
+
+type MachineNodeDeployRequest struct {
+	Owner        string `json:"owner"`
+	MachineName  string `json:"machineName"`
+	NodeName     string `json:"nodeName"`
+	ApiserverURL string `json:"apiserverUrl"`
+}
+
+func (r *MachineNodeDeployRequest) normalize() {
+	if r.Owner == "" {
+		r.Owner = "admin"
+	}
+	r.MachineName = strings.TrimSpace(r.MachineName)
+	r.NodeName = strings.TrimSpace(r.NodeName)
+	r.ApiserverURL = strings.TrimSpace(r.ApiserverURL)
+}
+
+func (r *MachineNodeDeployRequest) validate() error {
+	if r.MachineName == "" {
+		return fmt.Errorf("machineName is required")
+	}
+	if strings.Contains(r.MachineName, "/") {
+		return fmt.Errorf("machineName must not contain /")
+	}
+	if len(r.MachineName) > 100 {
+		return fmt.Errorf("machineName must not exceed 100 characters")
+	}
+	if r.NodeName != "" {
+		if err := validateNodeDeployName(r.NodeName); err != nil {
+			return err
+		}
+	}
+	if r.ApiserverURL != "" {
+		parsed, err := url.Parse(r.ApiserverURL)
+		if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+			return fmt.Errorf("apiserverUrl must be a valid https URL")
+		}
+	}
+	return nil
+}
+
+type NodeDeployOptions struct {
+	Machine      NodeDeployMachine
+	NodeName     string
+	ApiserverURL string
+}
+
+func (opts *NodeDeployOptions) validate() error {
+	opts.NodeName = strings.TrimSpace(opts.NodeName)
+	opts.Machine.Host = strings.TrimSpace(opts.Machine.Host)
+	if opts.Machine.Host == "" {
+		return fmt.Errorf("machine host is required")
+	}
+	if opts.NodeName == "" {
+		return fmt.Errorf("nodeName is required")
+	}
+	if err := validateNodeDeployName(opts.NodeName); err != nil {
+		return err
+	}
+	opts.ApiserverURL = strings.TrimRight(strings.TrimSpace(opts.ApiserverURL), "/")
+	if opts.ApiserverURL != "" {
+		parsed, err := url.Parse(opts.ApiserverURL)
+		if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+			return fmt.Errorf("apiserverUrl must be a valid https URL")
+		}
+	}
+	return nil
+}
+
+type NodeDeployMachine struct {
+	Host       string
+	Port       int
+	Username   string
+	Password   string
+	PrivateKey string
+}
+
+type NodeDeployResult struct {
+	// ManagedPrivateKey contains a raw PEM-encoded SSH private key. Callers must
+	// store it encrypted and must not log or return it to API clients.
+	ManagedPrivateKey string
+}
+
+type NodeKubeconfig struct {
+	Kubeconfig string
+	NodeName   string
+}
+
+type KubeconfigGenerator func(nodeName, apiserverURL string) (*NodeKubeconfig, error)
+
+type Config struct {
+	AdvertiseAddress   string
+	ApiserverBind      string
+	ApiserverPort      int
+	SandboxImage       string
+	Socks5Proxy        string
+	GenerateKubeconfig KubeconfigGenerator
+}
+
+func ConfigFromServerConfig(cfg server.Config) Config {
+	return Config{
+		AdvertiseAddress: cfg.AdvertiseAddress,
+		ApiserverBind:    cfg.ApiserverBind,
+		ApiserverPort:    cfg.ApiserverPort,
+		SandboxImage:     cfg.SandboxImage,
+		Socks5Proxy:      cfg.Socks5Proxy,
+		GenerateKubeconfig: func(nodeName, apiserverURL string) (*NodeKubeconfig, error) {
+			wk, err := server.GenerateWorkerKubeconfigForServer(cfg, nodeName, apiserverURL)
+			if err != nil {
+				return nil, err
+			}
+			return &NodeKubeconfig{Kubeconfig: wk.Kubeconfig, NodeName: wk.NodeName}, nil
+		},
+	}
+}
+
+var nodeDeployNameRegexp = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+
+func validateNodeDeployName(nodeName string) error {
+	nodeName = strings.TrimSpace(nodeName)
+	if len(nodeName) > 253 || !nodeDeployNameRegexp.MatchString(nodeName) {
+		return fmt.Errorf("nodeName must be a valid RFC 1123 subdomain")
+	}
+	for _, label := range strings.Split(nodeName, ".") {
+		if len(label) > 63 {
+			return fmt.Errorf("nodeName labels must not exceed 63 characters")
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/casosorg/casos/casdoor"
 	"github.com/casosorg/casos/controllers"
+	"github.com/casosorg/casos/deploy"
 	"github.com/casosorg/casos/object"
 	"github.com/casosorg/casos/proxy"
 	"github.com/casosorg/casos/routers"
@@ -43,6 +44,7 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	deploy.Init(ctx, deploy.ConfigFromServerConfig(srvCfg))
 
 	readyCh, err := server.Start(ctx, srvCfg)
 	if err != nil {
@@ -59,6 +61,7 @@ func main() {
 		case <-readyCh:
 			adminCfg := server.AdminRestConfig(srvCfg)
 			controllers.SetAdminRestConfig(adminCfg)
+			deploy.SetRestConfig(adminCfg)
 			logs.Info("apiserver ready — kubectl endpoint: https://127.0.0.1:%d", srvCfg.ApiserverPort)
 			if err := server.Bootstrap(ctx, adminCfg, srvCfg); err != nil {
 				logs.Warning("bootstrap: %v", err)

--- a/object/machine.go
+++ b/object/machine.go
@@ -4,6 +4,12 @@ import (
 	"github.com/casosorg/casos/util"
 )
 
+const (
+	MachineStatusDeploying = "Deploying"
+	MachineStatusDeployed  = "Deployed"
+	MachineStatusFailed    = "Failed"
+)
+
 type Machine struct {
 	Owner       string `xorm:"varchar(100) notnull pk" json:"owner"`
 	Name        string `xorm:"varchar(100) notnull pk" json:"name"`

--- a/object/machine_node_deploy.go
+++ b/object/machine_node_deploy.go
@@ -1,0 +1,577 @@
+package object
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/beego/beego/logs"
+	"github.com/casosorg/casos/conf"
+	"golang.org/x/crypto/ssh"
+	"xorm.io/xorm"
+)
+
+const (
+	MachineNodeDeployStatusPending   = "pending"
+	MachineNodeDeployStatusRunning   = "running"
+	MachineNodeDeployStatusSucceeded = "succeeded"
+	MachineNodeDeployStatusFailed    = "failed"
+
+	MachineNodeDeployPhaseQueued      = "queued"
+	MachineNodeDeployPhasePreflight   = "preflight"
+	MachineNodeDeployPhaseInstalling  = "installing"
+	MachineNodeDeployPhaseConfiguring = "configuring"
+	MachineNodeDeployPhaseStarting    = "starting"
+	MachineNodeDeployPhaseWaiting     = "waiting"
+	MachineNodeDeployPhaseReady       = "ready"
+	MachineNodeDeployPhaseFailed      = "failed"
+
+	MachineNodeDeployLogLevelInfo  = "info"
+	MachineNodeDeployLogLevelError = "error"
+
+	machineNodeCredentialPrefix  = "enc:v1:"
+	machineNodeCredentialKeyFile = "node-deploy-secret.key"
+)
+
+var (
+	machineNodeCredentialSecretMutex sync.Mutex
+	machineNodeDeployNameRegexp      = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+)
+
+type MachineNodeDeployTask struct {
+	Id           int64     `xorm:"pk autoincr" json:"id"`
+	Owner        string    `xorm:"varchar(100) notnull index" json:"owner"`
+	MachineName  string    `xorm:"varchar(100) notnull index" json:"machineName"`
+	NodeName     string    `xorm:"varchar(100) notnull" json:"nodeName"`
+	ApiserverURL string    `xorm:"varchar(500)" json:"apiserverUrl"`
+	Status       string    `xorm:"varchar(50) notnull index" json:"status"`
+	Phase        string    `xorm:"varchar(100)" json:"phase"`
+	ErrorMsg     string    `xorm:"text" json:"errorMsg"`
+	CreatedAt    time.Time `json:"createdAt"`
+	StartedAt    time.Time `json:"startedAt"`
+	FinishedAt   time.Time `json:"finishedAt"`
+	UpdatedAt    time.Time `json:"updatedAt"`
+}
+
+type MachineNodeDeployLog struct {
+	Id        int64     `xorm:"pk autoincr" json:"id"`
+	TaskId    int64     `xorm:"notnull index" json:"taskId"`
+	Level     string    `xorm:"varchar(20) notnull" json:"level"`
+	Message   string    `xorm:"text" json:"message"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+type MachineNodeDeployCredential struct {
+	Owner       string    `xorm:"varchar(100) notnull pk" json:"owner"`
+	MachineName string    `xorm:"varchar(100) notnull pk" json:"machineName"`
+	PrivateKey  string    `xorm:"mediumtext" json:"-"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+func CreateMachineNodeDeployTask(owner, machineName, nodeName, apiserverURL string) (*MachineNodeDeployTask, error) {
+	owner = strings.TrimSpace(owner)
+	machineName = strings.TrimSpace(machineName)
+	nodeName = strings.TrimSpace(nodeName)
+	apiserverURL = strings.TrimSpace(apiserverURL)
+	if owner == "" || machineName == "" {
+		return nil, fmt.Errorf("owner and machineName are required")
+	}
+	if strings.Contains(machineName, "/") {
+		return nil, fmt.Errorf("machineName must not contain /")
+	}
+	if nodeName == "" {
+		return nil, fmt.Errorf("nodeName is required")
+	}
+	if err := validateMachineNodeDeployName(nodeName); err != nil {
+		return nil, err
+	}
+	if apiserverURL != "" {
+		parsed, err := url.Parse(apiserverURL)
+		if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+			return nil, fmt.Errorf("apiserverUrl must be a valid https URL")
+		}
+	}
+
+	result, err := withMachineNodeDeployTransaction(func(session *xorm.Session) (interface{}, error) {
+		machine := &Machine{}
+		foundMachine, err := session.
+			Where("owner = ? AND name = ?", owner, machineName).
+			ForUpdate().
+			Get(machine)
+		if err != nil {
+			return nil, err
+		}
+		if !foundMachine {
+			return nil, fmt.Errorf("machine not found")
+		}
+
+		existing := &MachineNodeDeployTask{}
+		found, err := session.
+			Where("owner = ? AND machine_name = ? AND status IN (?, ?)", owner, machineName, MachineNodeDeployStatusPending, MachineNodeDeployStatusRunning).
+			Desc("id").
+			ForUpdate().
+			Get(existing)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			return nil, fmt.Errorf("node deployment task %d is already active for machine %s", existing.Id, machineName)
+		}
+
+		now := time.Now().UTC()
+		task := &MachineNodeDeployTask{
+			Owner:        owner,
+			MachineName:  machineName,
+			NodeName:     nodeName,
+			ApiserverURL: apiserverURL,
+			Status:       MachineNodeDeployStatusPending,
+			Phase:        MachineNodeDeployPhaseQueued,
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		}
+		if _, err := session.Insert(task); err != nil {
+			return nil, err
+		}
+		return task, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	task, ok := result.(*MachineNodeDeployTask)
+	if !ok || task == nil {
+		return nil, fmt.Errorf("create node deployment task returned invalid result")
+	}
+	return task, nil
+}
+
+func GetMachineNodeDeployTask(id int64) (*MachineNodeDeployTask, error) {
+	task := &MachineNodeDeployTask{Id: id}
+	found, err := ormer.Engine.Get(task)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	return task, nil
+}
+
+func validateMachineNodeDeployName(nodeName string) error {
+	nodeName = strings.TrimSpace(nodeName)
+	if len(nodeName) > 253 || !machineNodeDeployNameRegexp.MatchString(nodeName) {
+		return fmt.Errorf("nodeName must be a valid RFC 1123 subdomain")
+	}
+	for _, label := range strings.Split(nodeName, ".") {
+		if len(label) > 63 {
+			return fmt.Errorf("nodeName labels must not exceed 63 characters")
+		}
+	}
+	return nil
+}
+
+func GetMachineNodeDeployTasks(owner, machineName string, limit int) ([]*MachineNodeDeployTask, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("limit must not be negative")
+	}
+	if limit == 0 {
+		limit = 50
+	} else if limit > 100 {
+		return nil, fmt.Errorf("limit must not exceed 100")
+	}
+	owner = strings.TrimSpace(owner)
+	machineName = strings.TrimSpace(machineName)
+	if owner == "" {
+		return nil, fmt.Errorf("owner is required")
+	}
+	tasks := []*MachineNodeDeployTask{}
+	session := ormer.Engine.Desc("id").Limit(limit)
+	session = session.Where("owner = ?", owner)
+	if machineName != "" {
+		session = session.And("machine_name = ?", machineName)
+	}
+	if err := session.Find(&tasks); err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
+func FailActiveMachineNodeDeployTasks(reason string) error {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "node deployment task was interrupted"
+	}
+	now := time.Now().UTC()
+	_, err := ormer.Engine.
+		Where("status IN (?, ?)", MachineNodeDeployStatusPending, MachineNodeDeployStatusRunning).
+		Cols("status", "phase", "error_msg", "finished_at", "updated_at").
+		Update(&MachineNodeDeployTask{
+			Status:     MachineNodeDeployStatusFailed,
+			Phase:      MachineNodeDeployPhaseFailed,
+			ErrorMsg:   reason,
+			FinishedAt: now,
+			UpdatedAt:  now,
+		})
+	return err
+}
+
+func isValidMachineNodeDeployPhase(phase string) bool {
+	switch phase {
+	case MachineNodeDeployPhaseQueued, MachineNodeDeployPhasePreflight, MachineNodeDeployPhaseInstalling,
+		MachineNodeDeployPhaseConfiguring, MachineNodeDeployPhaseStarting, MachineNodeDeployPhaseWaiting,
+		MachineNodeDeployPhaseReady, MachineNodeDeployPhaseFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func StartMachineNodeDeployTask(id int64, phase string) error {
+	if !isValidMachineNodeDeployPhase(phase) {
+		return fmt.Errorf("invalid node deployment phase: %s", phase)
+	}
+	now := time.Now().UTC()
+	affected, err := ormer.Engine.ID(id).
+		Where("status = ?", MachineNodeDeployStatusPending).
+		Cols("status", "phase", "started_at", "updated_at").
+		Update(&MachineNodeDeployTask{
+			Status:    MachineNodeDeployStatusRunning,
+			Phase:     phase,
+			StartedAt: now,
+			UpdatedAt: now,
+		})
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return fmt.Errorf("node deployment task %d is not pending", id)
+	}
+	return nil
+}
+
+func UpdateMachineNodeDeployTaskPhase(id int64, phase string) error {
+	if !isValidMachineNodeDeployPhase(phase) {
+		return fmt.Errorf("invalid node deployment phase: %s", phase)
+	}
+	_, err := ormer.Engine.ID(id).
+		Where("status = ?", MachineNodeDeployStatusRunning).
+		Cols("phase", "updated_at").
+		Update(&MachineNodeDeployTask{
+			Phase:     phase,
+			UpdatedAt: time.Now().UTC(),
+		})
+	return err
+}
+
+func FinishMachineNodeDeployTask(id int64, success bool, phase, errorMsg string) error {
+	if !isValidMachineNodeDeployPhase(phase) {
+		return fmt.Errorf("invalid node deployment phase: %s", phase)
+	}
+	status := MachineNodeDeployStatusSucceeded
+	if !success {
+		status = MachineNodeDeployStatusFailed
+	}
+	now := time.Now().UTC()
+	affected, err := ormer.Engine.ID(id).
+		Where("status IN (?, ?)", MachineNodeDeployStatusPending, MachineNodeDeployStatusRunning).
+		Cols("status", "phase", "error_msg", "finished_at", "updated_at").
+		Update(&MachineNodeDeployTask{
+			Status:     status,
+			Phase:      phase,
+			ErrorMsg:   errorMsg,
+			FinishedAt: now,
+			UpdatedAt:  now,
+		})
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return fmt.Errorf("node deployment task %d is already finished", id)
+	}
+	return nil
+}
+
+func AddMachineNodeDeployLog(taskId int64, level, message string) error {
+	if level != MachineNodeDeployLogLevelInfo && level != MachineNodeDeployLogLevelError {
+		return fmt.Errorf("invalid node deployment log level: %s", level)
+	}
+	_, err := ormer.Engine.Insert(&MachineNodeDeployLog{
+		TaskId:    taskId,
+		Level:     level,
+		Message:   message,
+		CreatedAt: time.Now().UTC(),
+	})
+	return err
+}
+
+func GetMachineNodeDeployLogs(taskId int64, limit int) ([]*MachineNodeDeployLog, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("limit must not be negative")
+	}
+	if limit == 0 {
+		limit = 500
+	} else if limit > 1000 {
+		return nil, fmt.Errorf("limit must not exceed 1000")
+	}
+	logs := []*MachineNodeDeployLog{}
+	err := ormer.Engine.Where("task_id = ?", taskId).Asc("id").Limit(limit).Find(&logs)
+	if err != nil {
+		return nil, err
+	}
+	return logs, nil
+}
+
+func GetMachineNodeDeployCredential(owner, machineName string) (*MachineNodeDeployCredential, error) {
+	credential := &MachineNodeDeployCredential{Owner: owner, MachineName: machineName}
+	found, err := ormer.Engine.Get(credential)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	privateKey, err := decryptMachineNodePrivateKey(owner, machineName, credential.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	credential.PrivateKey = privateKey
+	return credential, nil
+}
+
+func UpdateMachineNodeDeployCredential(machine *Machine, privateKey string) error {
+	if strings.TrimSpace(privateKey) == "" {
+		return fmt.Errorf("private key must not be empty")
+	}
+	if _, err := ssh.ParsePrivateKey([]byte(privateKey)); err != nil {
+		return fmt.Errorf("invalid SSH private key: %w", err)
+	}
+	encryptedKey, err := encryptMachineNodePrivateKey(machine.Owner, machine.Name, privateKey)
+	if err != nil {
+		return err
+	}
+	credential := &MachineNodeDeployCredential{
+		Owner:       machine.Owner,
+		MachineName: machine.Name,
+		PrivateKey:  encryptedKey,
+		UpdatedAt:   time.Now().UTC(),
+	}
+	if _, err = withMachineNodeDeployTransaction(func(session *xorm.Session) (interface{}, error) {
+		lockedMachine := &Machine{}
+		foundMachine, err := session.
+			Where("owner = ? AND name = ?", machine.Owner, machine.Name).
+			ForUpdate().
+			Get(lockedMachine)
+		if err != nil {
+			return nil, err
+		}
+		if !foundMachine {
+			return nil, fmt.Errorf("machine not found")
+		}
+
+		affected, err := session.Where("owner = ? AND machine_name = ?", machine.Owner, machine.Name).
+			Cols("private_key", "updated_at").
+			Update(credential)
+		if err != nil {
+			return nil, err
+		}
+		if affected == 0 {
+			if _, err = session.Insert(credential); err != nil {
+				return nil, err
+			}
+		}
+
+		stored := &MachineNodeDeployCredential{Owner: machine.Owner, MachineName: machine.Name}
+		foundCredential, err := session.Get(stored)
+		if err != nil {
+			return nil, err
+		}
+		if !foundCredential {
+			return nil, fmt.Errorf("managed SSH credential was not stored")
+		}
+		if _, err := decryptMachineNodePrivateKey(machine.Owner, machine.Name, stored.PrivateKey); err != nil {
+			return nil, fmt.Errorf("verify managed SSH credential: %w", err)
+		}
+
+		role := "worker"
+		if lockedMachine.Role != "" && lockedMachine.Role != "worker" {
+			role = lockedMachine.Role
+		}
+		_, err = session.Where("owner = ? AND name = ?", machine.Owner, machine.Name).
+			Cols("password", "private_key", "status", "role").
+			Update(&Machine{
+				Password:   "",
+				PrivateKey: "",
+				Status:     MachineStatusDeployed,
+				Role:       role,
+			})
+		return nil, err
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func encryptMachineNodePrivateKey(owner, machineName, privateKey string) (string, error) {
+	aead, err := machineNodeCredentialAEAD()
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	data := aead.Seal(nonce, nonce, []byte(privateKey), []byte(owner+"/"+machineName))
+	return machineNodeCredentialPrefix + base64.StdEncoding.EncodeToString(data), nil
+}
+
+func decryptMachineNodePrivateKey(owner, machineName, encrypted string) (string, error) {
+	if !strings.HasPrefix(encrypted, machineNodeCredentialPrefix) {
+		logs.Warning("machine node deploy credential for %s/%s has unrecognized format", owner, machineName)
+		return "", fmt.Errorf("node deployment credential has unrecognized format")
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(encrypted, machineNodeCredentialPrefix))
+	if err != nil {
+		return "", err
+	}
+	aead, err := machineNodeCredentialAEAD()
+	if err != nil {
+		return "", err
+	}
+	if len(raw) < aead.NonceSize() {
+		return "", fmt.Errorf("invalid managed ssh key payload")
+	}
+	nonce := raw[:aead.NonceSize()]
+	ciphertext := raw[aead.NonceSize():]
+	plain, err := aead.Open(nil, nonce, ciphertext, []byte(owner+"/"+machineName))
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}
+
+func machineNodeCredentialAEAD() (cipher.AEAD, error) {
+	secret, err := machineNodeCredentialSecret()
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256([]byte(secret))
+	block, err := aes.NewCipher(sum[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+func machineNodeCredentialSecret() (string, error) {
+	machineNodeCredentialSecretMutex.Lock()
+	defer machineNodeCredentialSecretMutex.Unlock()
+
+	if secret := strings.TrimSpace(conf.GetConfigString("nodeDeploySecretKey")); secret != "" {
+		return secret, nil
+	}
+
+	dataDir := strings.TrimSpace(conf.GetConfigString("dataDir"))
+	if dataDir == "" {
+		dataDir = "/var/lib/casos"
+	}
+	secretPath := filepath.Join(dataDir, machineNodeCredentialKeyFile)
+	if data, err := os.ReadFile(secretPath); err == nil {
+		secret := strings.TrimSpace(string(data))
+		if secret == "" {
+			logs.Error("node deployment credential secret is empty: %s", secretPath)
+			return "", fmt.Errorf("node deployment credential secret is empty")
+		}
+		return secret, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	raw := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, raw); err != nil {
+		return "", err
+	}
+	secret := base64.StdEncoding.EncodeToString(raw)
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		return "", err
+	}
+	tmpFile, err := os.CreateTemp(dataDir, machineNodeCredentialKeyFile+".*.tmp")
+	if err != nil {
+		return "", err
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+	if err := tmpFile.Chmod(0o600); err != nil {
+		tmpFile.Close()
+		return "", err
+	}
+	if _, err := tmpFile.WriteString(secret + "\n"); err != nil {
+		tmpFile.Close()
+		return "", err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		tmpFile.Close()
+		return "", err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(tmpPath, secretPath); err != nil {
+		return "", err
+	}
+	return secret, nil
+}
+
+func UpdateMachineNodeDeployStatus(owner, name, status string) error {
+	if !isValidMachineStatus(status) {
+		return fmt.Errorf("invalid machine status: %s", status)
+	}
+	_, err := ormer.Engine.Where("owner = ? AND name = ?", owner, name).
+		Cols("status").
+		Update(&Machine{Status: status})
+	return err
+}
+
+func isValidMachineStatus(status string) bool {
+	switch status {
+	case MachineStatusDeploying, MachineStatusDeployed, MachineStatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func withMachineNodeDeployTransaction(fn func(*xorm.Session) (interface{}, error)) (interface{}, error) {
+	session := ormer.Engine.NewSession()
+	defer func() {
+		if v := recover(); v != nil {
+			_ = session.Rollback()
+			session.Close()
+			panic(v)
+		}
+		session.Close()
+	}()
+
+	if err := session.Begin(); err != nil {
+		return nil, err
+	}
+	result, err := fn(session)
+	if err != nil {
+		_ = session.Rollback()
+		return nil, err
+	}
+	if err = session.Commit(); err != nil {
+		_ = session.Rollback()
+		return nil, err
+	}
+	return result, nil
+}

--- a/object/ormer.go
+++ b/object/ormer.go
@@ -169,6 +169,9 @@ func (a *Ormer) createTable() {
 	a.Engine.ShowSQL(showSql)
 	_ = a.Engine.Sync2(new(Site))
 	_ = a.Engine.Sync2(new(Machine))
+	_ = a.Engine.Sync2(new(MachineNodeDeployTask))
+	_ = a.Engine.Sync2(new(MachineNodeDeployLog))
+	_ = a.Engine.Sync2(new(MachineNodeDeployCredential))
 	_ = a.Engine.Sync2(new(CasbinRule))
 	_ = a.Engine.Sync2(new(TrivyScanResult))
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -87,6 +87,11 @@ func InitAPI() {
 	beego.Router("/api/add-machine", &controllers.ApiController{}, "POST:AddMachine")
 	beego.Router("/api/update-machine", &controllers.ApiController{}, "POST:UpdateMachine")
 	beego.Router("/api/delete-machine", &controllers.ApiController{}, "POST:DeleteMachine")
+	beego.Router("/api/preflight-machine-node", &controllers.ApiController{}, "POST:PreflightMachineNode")
+	beego.Router("/api/deploy-machine-node", &controllers.ApiController{}, "POST:DeployMachineNode")
+	beego.Router("/api/repair-machine-node", &controllers.ApiController{}, "POST:RepairMachineNode")
+	beego.Router("/api/get-machine-node-tasks", &controllers.ApiController{}, "GET:GetMachineNodeTasks")
+	beego.Router("/api/get-machine-node-logs", &controllers.ApiController{}, "GET:GetMachineNodeLogs")
 
 	beego.Router("/api/get-configmaps", &controllers.ApiController{}, "GET:GetConfigMaps")
 	beego.Router("/api/get-configmap", &controllers.ApiController{}, "GET:GetConfigMap")

--- a/server/worker.go
+++ b/server/worker.go
@@ -28,6 +28,13 @@ type WorkerKubeconfig struct {
 //
 // The returned kubeconfig is intended for kubelet's --kubeconfig flag.
 func GenerateWorkerKubeconfig(cfg Config, nodeName string) (*WorkerKubeconfig, error) {
+	apiserverURL := fmt.Sprintf("https://127.0.0.1:%d", cfg.ApiserverPort)
+	return GenerateWorkerKubeconfigForServer(cfg, nodeName, apiserverURL)
+}
+
+// GenerateWorkerKubeconfigForServer signs a node client certificate and embeds
+// the provided apiserver URL as the cluster server endpoint.
+func GenerateWorkerKubeconfigForServer(cfg Config, nodeName, apiserverURL string) (*WorkerKubeconfig, error) {
 	certDir := filepath.Join(cfg.DataDir, "tls")
 
 	// Load cluster CA.
@@ -80,7 +87,6 @@ func GenerateWorkerKubeconfig(cfg Config, nodeName string) (*WorkerKubeconfig, e
 	nodeCertPEM := pemEncode("CERTIFICATE", nodeCertDER)
 	nodeKeyPEM := pemEncode("EC PRIVATE KEY", nodeKeyDER)
 
-	apiserverURL := fmt.Sprintf("https://127.0.0.1:%d", cfg.ApiserverPort)
 	kubeconfig := fmt.Sprintf(`apiVersion: v1
 kind: Config
 preferences: {}

--- a/web/src/MachineEditPage.js
+++ b/web/src/MachineEditPage.js
@@ -9,7 +9,9 @@ import i18next from "i18next";
 const statusColor = {
   Online: "green",
   Offline: "red",
+  Deploying: "processing",
   Deployed: "blue",
+  Failed: "red",
   Unknown: "default",
 };
 

--- a/web/src/MachineListPage.js
+++ b/web/src/MachineListPage.js
@@ -1,15 +1,18 @@
 import React from "react";
 import {Link} from "react-router-dom";
 import {Button, Form, Input, InputNumber, Modal, Popconfirm, Select, Table, Tag, Tooltip} from "antd";
-import {DeleteOutlined, EditOutlined, PlusOutlined} from "@ant-design/icons";
+import {CloudSyncOutlined, DeleteOutlined, EditOutlined, PlusOutlined} from "@ant-design/icons";
 import * as Setting from "./Setting";
 import * as MachineBackend from "./backend/MachineBackend";
+import MachineNodeDeployPanel from "./MachineNodeDeployPanel";
 import i18next from "i18next";
 
 const statusColor = {
   Online: "green",
   Offline: "red",
+  Deploying: "processing",
   Deployed: "blue",
+  Failed: "red",
   Unknown: "default",
 };
 
@@ -21,8 +24,18 @@ class MachineListPage extends React.Component {
       loading: false,
       modalVisible: false,
       submitting: false,
+      deployPanelVisible: false,
+      deployingMachine: null,
     };
     this.formRef = React.createRef();
+  }
+
+  openDeployPanel(record) {
+    this.setState({deployPanelVisible: true, deployingMachine: record});
+  }
+
+  closeDeployPanel() {
+    this.setState({deployPanelVisible: false, deployingMachine: null}, () => this.getMachines());
   }
 
   UNSAFE_componentWillMount() {
@@ -155,10 +168,13 @@ class MachineListPage extends React.Component {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "130px",
+        width: "170px",
         fixed: "right",
         render: (text, record) => (
           <div style={{display: "flex", alignItems: "center", gap: "2px"}}>
+            <Tooltip title={i18next.t("machine:Deploy worker node", "Deploy worker node")}>
+              <Button type="text" size="small" icon={<CloudSyncOutlined />} style={{width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.openDeployPanel(record)} />
+            </Tooltip>
             <Tooltip title={i18next.t("general:Edit")}>
               <Button type="text" size="small" icon={<EditOutlined />} style={{width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/machines/${record.name}`)} />
             </Tooltip>
@@ -240,6 +256,12 @@ class MachineListPage extends React.Component {
             </Form.Item>
           </Form>
         </Modal>
+        <MachineNodeDeployPanel
+          open={this.state.deployPanelVisible}
+          machine={this.state.deployingMachine}
+          account={this.props.account}
+          onClose={() => this.closeDeployPanel()}
+        />
       </div>
     );
   }

--- a/web/src/MachineNodeDeployPanel.js
+++ b/web/src/MachineNodeDeployPanel.js
@@ -1,0 +1,374 @@
+import React from "react";
+import {Alert, Button, Descriptions, Drawer, Form, Input, Space, Table, Tag, Typography} from "antd";
+import {CloudSyncOutlined, FileSearchOutlined, ReloadOutlined, ToolOutlined} from "@ant-design/icons";
+import * as MachineNodeDeployBackend from "./backend/MachineNodeDeployBackend";
+import * as Setting from "./Setting";
+
+const {Text} = Typography;
+
+const taskStatusColor = {
+  pending: "default",
+  running: "processing",
+  succeeded: "green",
+  failed: "red",
+};
+
+class MachineNodeDeployPanel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tasks: [],
+      logs: [],
+      selectedTaskId: null,
+      preflight: null,
+      preflightError: null,
+      loadingTasks: false,
+      loadingLogs: false,
+      preflighting: false,
+      deploying: false,
+      repairing: false,
+    };
+    this.formRef = React.createRef();
+    this.refreshTimer = null;
+  }
+
+  componentDidMount() {
+    if (this.props.open && this.props.machine) {
+      this.resetForm();
+      this.loadTasks();
+      this.startRefresh();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.open && this.props.open && this.props.machine) {
+      this.resetForm();
+      this.loadTasks();
+      this.startRefresh();
+    } else if (this.props.open && this.props.machine?.name !== prevProps.machine?.name) {
+      this.resetForm();
+      this.loadTasks();
+    }
+    if (prevProps.open && !this.props.open) {
+      this.stopRefresh();
+    }
+  }
+
+  componentWillUnmount() {
+    this.stopRefresh();
+  }
+
+  resetForm() {
+    const machine = this.props.machine;
+    this.setState({preflight: null, preflightError: null, logs: [], selectedTaskId: null}, () => {
+      this.formRef.current?.setFieldsValue({
+        workerNodeName: machine?.name || "",
+        apiserverUrl: "",
+      });
+    });
+  }
+
+  startRefresh() {
+    this.stopRefresh();
+    this.refreshTimer = setInterval(() => this.loadTasks(false), 5000);
+  }
+
+  stopRefresh() {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  buildRequest(values) {
+    const machine = this.props.machine;
+    const owner = machine?.owner || this.props.account?.name;
+    if (!owner) {
+      throw new Error("Machine owner is required");
+    }
+    return {
+      owner,
+      machineName: machine?.name,
+      nodeName: values.workerNodeName || machine?.name,
+      apiserverUrl: values.apiserverUrl || "",
+    };
+  }
+
+  ensureDefaultNodeName() {
+    const machineName = this.props.machine?.name;
+    const currentValues = this.formRef.current?.getFieldsValue() || {};
+    if (!currentValues.workerNodeName && machineName) {
+      this.formRef.current?.setFieldsValue({workerNodeName: machineName});
+    }
+  }
+
+  loadTasks(showLoading = true, preferLatest = false) {
+    const machine = this.props.machine;
+    if (!machine) {
+      return;
+    }
+    const owner = machine.owner || this.props.account?.name;
+    if (!owner) {
+      Setting.showMessage("error", "Machine owner is required");
+      return;
+    }
+    if (showLoading) {
+      this.setState({loadingTasks: true});
+    }
+    MachineNodeDeployBackend.getMachineNodeTasks(owner, machine.name)
+      .then(res => {
+        if (res.status === "ok") {
+          const tasks = res.data || [];
+          const latestTaskId = tasks[0]?.id || null;
+          const selectedTaskExists = tasks.some(task => task.id === this.state.selectedTaskId);
+          let selectedTaskId = latestTaskId;
+          if (!preferLatest && selectedTaskExists) {
+            selectedTaskId = this.state.selectedTaskId;
+          }
+          this.setState({tasks, selectedTaskId}, () => {
+            if (selectedTaskId) {
+              this.loadLogs(selectedTaskId, false);
+            }
+          });
+        } else {
+          Setting.showMessage("error", res.msg);
+        }
+      })
+      .catch(e => Setting.showMessage("error", `Failed to load node tasks: ${e.message}`))
+      .finally(() => this.setState({loadingTasks: false}));
+  }
+
+  loadLogs(taskId, showLoading = true) {
+    if (!taskId) {
+      return;
+    }
+    if (showLoading) {
+      this.setState({loadingLogs: true});
+    }
+    MachineNodeDeployBackend.getMachineNodeLogs(taskId)
+      .then(res => {
+        if (res.status === "ok") {
+          this.setState({logs: res.data || [], selectedTaskId: taskId});
+        } else {
+          Setting.showMessage("error", res.msg);
+        }
+      })
+      .catch(e => Setting.showMessage("error", `Failed to load node logs: ${e.message}`))
+      .finally(() => this.setState({loadingLogs: false}));
+  }
+
+  preflight() {
+    this.ensureDefaultNodeName();
+    this.formRef.current?.validateFields()
+      .then(values => {
+        let request;
+        try {
+          request = this.buildRequest(values);
+        } catch (e) {
+          Setting.showMessage("error", e.message);
+          return;
+        }
+        this.setState({preflighting: true, preflight: null, preflightError: null});
+        MachineNodeDeployBackend.preflightMachineNode(request)
+          .then(res => {
+            if (res.status === "ok") {
+              this.setState({preflight: res.data});
+              Setting.showMessage("success", "Node preflight passed");
+            } else {
+              this.setState({preflightError: res.msg});
+              Setting.showMessage("error", res.msg);
+            }
+          })
+          .catch(e => {
+            const message = `Preflight failed: ${e.message}`;
+            this.setState({preflightError: message});
+            Setting.showMessage("error", message);
+          })
+          .finally(() => this.setState({preflighting: false}));
+      })
+      .catch(() => {});
+  }
+
+  deploy(repair = false) {
+    this.ensureDefaultNodeName();
+    this.formRef.current?.validateFields()
+      .then(values => {
+        const key = repair ? "repairing" : "deploying";
+        let request;
+        try {
+          request = this.buildRequest(values);
+        } catch (e) {
+          Setting.showMessage("error", e.message);
+          return;
+        }
+        this.setState({[key]: true});
+        const action = repair ? MachineNodeDeployBackend.repairMachineNode : MachineNodeDeployBackend.deployMachineNode;
+        action(request)
+          .then(res => {
+            if (res.status === "ok") {
+              Setting.showMessage("success", repair ? "Node repair started" : "Node deployment started");
+              this.setState({selectedTaskId: res.data?.id || null, logs: []}, () => this.loadTasks(true, true));
+            } else {
+              Setting.showMessage("error", res.msg);
+              this.loadTasks(false, true);
+            }
+          })
+          .catch(e => {
+            Setting.showMessage("error", `${repair ? "Repair" : "Deployment"} failed: ${e.message}`);
+            this.loadTasks(false, true);
+          })
+          .finally(() => this.setState({[key]: false}));
+      })
+      .catch(() => {});
+  }
+
+  renderPreflight() {
+    if (this.state.preflightError) {
+      return (
+        <Alert
+          type="error"
+          showIcon
+          message="Preflight failed"
+          description={this.state.preflightError}
+          style={{marginTop: 12}}
+        />
+      );
+    }
+    const result = this.state.preflight;
+    if (!result) {
+      return null;
+    }
+    const data = result.preflight || {};
+    return (
+      <Descriptions size="small" bordered column={2} style={{marginTop: 12}}>
+        <Descriptions.Item label="Node">{result.nodeName || "-"}</Descriptions.Item>
+        <Descriptions.Item label="Apiserver">{result.apiserverUrl || "-"}</Descriptions.Item>
+        <Descriptions.Item label="OS">{data.os}</Descriptions.Item>
+        <Descriptions.Item label="Arch">{data.arch}</Descriptions.Item>
+        <Descriptions.Item label="systemd">{data.systemd ? "yes" : "no"}</Descriptions.Item>
+        <Descriptions.Item label="Package">{data.packageTool}</Descriptions.Item>
+        <Descriptions.Item label="sudo">{data.canSudo ? "yes" : "no"}</Descriptions.Item>
+        <Descriptions.Item label="WSL">{data.wsl ? "yes" : "no"}</Descriptions.Item>
+      </Descriptions>
+    );
+  }
+
+  renderLogs() {
+    const logs = this.state.logs || [];
+    if (logs.length === 0) {
+      return <Text type="secondary">No node deployment logs.</Text>;
+    }
+    return (
+      <div style={{background: "var(--ant-color-bg-layout)", border: "1px solid var(--ant-color-border)", borderRadius: 6, padding: 12, maxHeight: 260, overflow: "auto"}}>
+        {logs.map(log => (
+          <div key={log.id} style={{fontFamily: "monospace", fontSize: 12, lineHeight: "22px", whiteSpace: "pre-wrap"}}>
+            <Text type="secondary">{log.createdAt}</Text>&nbsp;
+            <Tag color={log.level === "error" ? "red" : "blue"}>{log.level}</Tag>
+            {log.message}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  render() {
+    const {machine, open, onClose} = this.props;
+    const {tasks, loadingTasks, preflighting, deploying, repairing, selectedTaskId} = this.state;
+    const selectedTask = tasks.find(task => task.id === selectedTaskId);
+    const columns = [
+      {
+        title: "ID",
+        dataIndex: "id",
+        width: 70,
+      },
+      {
+        title: "Node",
+        dataIndex: "nodeName",
+        width: 150,
+      },
+      {
+        title: "Status",
+        dataIndex: "status",
+        width: 120,
+        render: value => <Tag color={taskStatusColor[value] || "default"}>{value}</Tag>,
+      },
+      {
+        title: "Phase",
+        dataIndex: "phase",
+      },
+      {
+        title: "Updated",
+        dataIndex: "updatedAt",
+        width: 190,
+      },
+    ];
+
+    return (
+      <Drawer
+        title={machine ? `Worker Node - ${machine.name}` : "Worker Node"}
+        open={open}
+        onClose={onClose}
+        width={760}
+        destroyOnHidden
+      >
+        <Form ref={this.formRef} layout="vertical">
+          <Form.Item label="Node name" name="workerNodeName" rules={[{required: true, message: "Node name is required"}]}>
+            <Input placeholder={machine?.name || "worker-node"} />
+          </Form.Item>
+          <Form.Item label="Apiserver URL" name="apiserverUrl">
+            <Input placeholder="Default: CasOS advertise address" />
+          </Form.Item>
+        </Form>
+
+        <Space wrap style={{marginBottom: 12}}>
+          <Button icon={<FileSearchOutlined />} onClick={() => this.preflight()} loading={preflighting}>
+            Preflight
+          </Button>
+          <Button type="primary" icon={<CloudSyncOutlined />} onClick={() => this.deploy(false)} loading={deploying}>
+            Deploy Node
+          </Button>
+          <Button icon={<ToolOutlined />} onClick={() => this.deploy(true)} loading={repairing}>
+            Repair Node
+          </Button>
+          <Button icon={<ReloadOutlined />} onClick={() => this.loadTasks()} loading={loadingTasks}>
+            Refresh
+          </Button>
+        </Space>
+
+        {this.renderPreflight()}
+
+        <Table
+          style={{marginTop: 16}}
+          size="small"
+          rowKey="id"
+          columns={columns}
+          dataSource={tasks}
+          loading={loadingTasks}
+          pagination={{pageSize: 5}}
+          onRow={record => ({
+            onClick: () => {
+              if (this.state.selectedTaskId !== record.id) {
+                this.loadLogs(record.id);
+              }
+            },
+          })}
+        />
+
+        {selectedTask?.errorMsg && (
+          <Alert
+            type="error"
+            showIcon
+            message="Node deployment failed"
+            description={selectedTask.errorMsg}
+            style={{marginTop: 12}}
+          />
+        )}
+
+        <div style={{fontWeight: 600, margin: "16px 0 8px"}}>Node deployment logs</div>
+        {this.renderLogs()}
+      </Drawer>
+    );
+  }
+}
+
+export default MachineNodeDeployPanel;

--- a/web/src/backend/MachineNodeDeployBackend.js
+++ b/web/src/backend/MachineNodeDeployBackend.js
@@ -1,0 +1,44 @@
+import * as Setting from "../Setting";
+
+export function preflightMachineNode(request) {
+  return fetch(`${Setting.ServerUrl}/api/preflight-machine-node`, {
+    method: "POST",
+    credentials: "include",
+    headers: {"Accept-Language": Setting.getAcceptLanguage()},
+    body: JSON.stringify(request),
+  }).then(res => Setting.handleFetchResponse(res));
+}
+
+export function deployMachineNode(request) {
+  return fetch(`${Setting.ServerUrl}/api/deploy-machine-node`, {
+    method: "POST",
+    credentials: "include",
+    headers: {"Accept-Language": Setting.getAcceptLanguage()},
+    body: JSON.stringify(request),
+  }).then(res => Setting.handleFetchResponse(res));
+}
+
+export function repairMachineNode(request) {
+  return fetch(`${Setting.ServerUrl}/api/repair-machine-node`, {
+    method: "POST",
+    credentials: "include",
+    headers: {"Accept-Language": Setting.getAcceptLanguage()},
+    body: JSON.stringify(request),
+  }).then(res => Setting.handleFetchResponse(res));
+}
+
+export function getMachineNodeTasks(owner, machineName) {
+  return fetch(`${Setting.ServerUrl}/api/get-machine-node-tasks?owner=${encodeURIComponent(owner)}&machineName=${encodeURIComponent(machineName)}`, {
+    method: "GET",
+    credentials: "include",
+    headers: {"Accept-Language": Setting.getAcceptLanguage()},
+  }).then(res => Setting.handleFetchResponse(res));
+}
+
+export function getMachineNodeLogs(taskId) {
+  return fetch(`${Setting.ServerUrl}/api/get-machine-node-logs?taskId=${encodeURIComponent(taskId)}`, {
+    method: "GET",
+    credentials: "include",
+    headers: {"Accept-Language": Setting.getAcceptLanguage()},
+  }).then(res => Setting.handleFetchResponse(res));
+}


### PR DESCRIPTION
feat: add managed node auto deploy and ops

This adds managed node auto deployment, automatic repair/maintenance, and the managed node operations UI.

Validation:
- go build ./...
- cd web && yarn build
- Real Playwright click testing on a WSL host:
  - preflight success and failure cases
  - auto deploy success
  - automatic repair after stopping kubelet/kube-proxy
  - managed node remove
  - re-deploy after removal