### PR TITLE
fix: trigger e2e ui failure demo

### DIFF
--- a/web/src/SiteEditPage.js
+++ b/web/src/SiteEditPage.js
@@ -81,7 +81,7 @@ class SiteEditPage extends React.Component {
     return (
       <div>
         <div style={{marginBottom: "16px", display: "flex", justifyContent: "space-between", alignItems: "center"}}>
-          <span style={{fontSize: "22px", fontWeight: 600}}>{i18next.t("site:Edit Site")}</span>
+          <span style={{fontSize: "22px", fontWeight: 600}}>Broken Site Editor</span>
           <Space>
             <Button onClick={() => this.submitSiteEdit()}>{i18next.t("general:Save")}</Button>
             <Button type="primary" onClick={() => this.submitSiteEdit()}>{i18next.t("general:Save")}</Button>


### PR DESCRIPTION
Temporary PR to verify the merged GitHub Actions UI test failure diagnostics.

This intentionally changes the built-in site editor title so the Playwright UI test fails at the visible page assertion. The expected result is a failed `UI tests` job with an uploaded Playwright report, test-results, screenshot, video, trace, and `ui-test.log` artifact.

This PR is not intended to be merged.