### PR TITLE
feat: add app store access url CI automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - feat/app-store-access-url-ci
   pull_request:
 
 jobs:
@@ -50,7 +51,7 @@ jobs:
     permissions:
       contents: read
       actions: write
-    timeout-minutes: 30
+    timeout-minutes: 60
     services:
       mysql:
         image: mysql:8
@@ -89,6 +90,8 @@ jobs:
         working-directory: ./web
       - run: yarn run ui:test:selector:check
         working-directory: ./web
+      - run: yarn run ui:test:access-url-diagnostics:check
+        working-directory: ./web
       - run: yarn playwright install --with-deps chromium
         working-directory: ./web
       - name: Run UI smoke tests
@@ -113,31 +116,267 @@ jobs:
           else
             git diff-tree --no-commit-id --name-only -r HEAD > web/ui-changed-files.txt
           fi
-          node web/scripts/select-ui-tests.js web/ui-changed-files.txt > web/ui-regression-tests.txt
+          node web/scripts/select-ui-tests.js --split web/ui-changed-files.txt web/ui-regression-tests.txt web/ui-standard-regression-tests.txt web/ui-app-store-access-tests.txt
           echo "Changed files considered for UI regression:"
           cat web/ui-changed-files.txt
           echo "Selected UI regression tests:"
           if [[ -s web/ui-regression-tests.txt ]]; then
             cat web/ui-regression-tests.txt
-            echo "has_tests=true" >> "$GITHUB_OUTPUT"
           else
             echo "(none; fixed smoke already ran)"
-            echo "has_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Standard UI regression tests:"
+          if [[ -s web/ui-standard-regression-tests.txt ]]; then
+            cat web/ui-standard-regression-tests.txt
+            echo "has_standard_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "(none)"
+            echo "has_standard_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "App Store Access URL regression tests:"
+          if [[ -s web/ui-app-store-access-tests.txt ]]; then
+            cat web/ui-app-store-access-tests.txt
+            echo "has_app_store_access_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "(none)"
+            echo "has_app_store_access_tests=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Run UI regression tests
-        if: steps.ui-regression-tests.outputs.has_tests == 'true'
+        if: steps.ui-regression-tests.outputs.has_standard_tests == 'true'
         working-directory: ./web
         shell: bash
         run: |
           set -o pipefail
-          mapfile -t ui_test_files < ui-regression-tests.txt
+          mapfile -t ui_test_files < ui-standard-regression-tests.txt
           yarn run ui:test:regression -- "${ui_test_files[@]}" 2>&1 | tee ui-test.log
       - name: Skip UI regression tests
-        if: steps.ui-regression-tests.outputs.has_tests != 'true'
+        if: steps.ui-regression-tests.outputs.has_standard_tests != 'true'
         working-directory: ./web
         shell: bash
         run: |
-          echo "No changed-path UI regression tests selected; fixed smoke already ran." | tee ui-test.log
+          echo "No standard changed-path UI regression tests selected; fixed smoke already ran." | tee ui-test.log
+      - name: Prepare QEMU Ubuntu worker VM
+        id: prepare-app-store-worker-vm
+        if: steps.ui-regression-tests.outputs.has_app_store_access_tests == 'true'
+        continue-on-error: true
+        timeout-minutes: 15
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            cloud-image-utils \
+            iproute2 \
+            iptables \
+            qemu-system-x86 \
+            qemu-utils
+
+          sudo modprobe kvm || true
+          if [[ ! -e /dev/kvm ]]; then
+            echo "KVM device is unavailable on this runner; cannot start a real worker VM." >&2
+            exit 1
+          fi
+          sudo chown "${USER}:$(id -gn)" /dev/kvm
+          sudo chmod 660 /dev/kvm
+
+          vm_dir="$RUNNER_TEMP/casos-worker-vm"
+          mkdir -p "$vm_dir"
+          key_path="$RUNNER_TEMP/casos-worker-key"
+          ssh-keygen -t ed25519 -N "" -f "$key_path"
+
+          run_hash="$(printf '%s' "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" | sha256sum | awk '{print $1}')"
+          run_suffix="${run_hash:0:6}"
+          subnet_octet=$((16#${run_hash:0:2} % 50 + 200))
+          bridge_name="cbr${run_suffix}"
+          tap_name="ctap${run_suffix}"
+          host_bridge_ip="192.168.${subnet_octet}.1"
+          worker_vm_ip="192.168.${subnet_octet}.2"
+          worker_cidr="192.168.${subnet_octet}.0/24"
+          worker_mac="52:54:00:${run_hash:0:2}:${run_hash:2:2}:${run_hash:4:2}"
+          default_iface="$(ip -4 route list default | awk 'NR == 1 {print $5}')"
+
+          sudo ip link add "$bridge_name" type bridge
+          sudo ip addr add "${host_bridge_ip}/24" dev "$bridge_name"
+          sudo ip link set dev "$bridge_name" type bridge stp_state 0 forward_delay 0
+          sudo ip link set "$bridge_name" up
+          sudo ip tuntap add dev "$tap_name" mode tap user "$USER"
+          sudo ip link set "$tap_name" master "$bridge_name"
+          sudo ip link set "$tap_name" up
+          sudo sysctl -w net.ipv4.ip_forward=1
+          sudo iptables -t nat -A POSTROUTING -s "$worker_cidr" -o "$default_iface" -j MASQUERADE
+          sudo iptables -A FORWARD -i "$bridge_name" -o "$default_iface" -j ACCEPT
+          sudo iptables -A FORWARD -i "$default_iface" -o "$bridge_name" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+
+          image_url="https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+          base_image="$vm_dir/ubuntu-jammy-server-cloudimg-amd64.img"
+          worker_disk="$vm_dir/worker.qcow2"
+          seed_image="$vm_dir/seed.img"
+          user_data="$vm_dir/user-data"
+          meta_data="$vm_dir/meta-data"
+          network_config="$vm_dir/network-config"
+
+          curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused "$image_url" -o "$base_image"
+          qemu-img create -f qcow2 -F qcow2 -b "$base_image" "$worker_disk" 40G
+
+          cat > "$user_data" <<EOF
+          #cloud-config
+          users:
+            - name: root
+              lock_passwd: true
+              ssh_authorized_keys:
+                - $(cat "$key_path.pub")
+          disable_root: false
+          ssh_pwauth: false
+          package_update: true
+          packages:
+            - ca-certificates
+            - curl
+            - openssh-server
+          write_files:
+            - path: /etc/ssh/sshd_config.d/casos-worker.conf
+              permissions: '0644'
+              content: |
+                PermitRootLogin prohibit-password
+                PasswordAuthentication no
+          runcmd:
+            - systemctl restart ssh
+          EOF
+          cat > "$meta_data" <<EOF
+          instance-id: casos-worker-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+          local-hostname: casos-worker
+          EOF
+          cat > "$network_config" <<EOF
+          version: 2
+          ethernets:
+            worker0:
+              match:
+                macaddress: "$worker_mac"
+              addresses:
+                - ${worker_vm_ip}/24
+              routes:
+                - to: default
+                  via: $host_bridge_ip
+              nameservers:
+                addresses:
+                  - 1.1.1.1
+                  - 8.8.8.8
+          EOF
+          cloud-localds --network-config="$network_config" "$seed_image" "$user_data" "$meta_data"
+
+          qemu-system-x86_64 \
+            -daemonize \
+            -enable-kvm \
+            -cpu host \
+            -smp 2 \
+            -m 2048 \
+            -drive "file=$worker_disk,if=virtio,format=qcow2" \
+            -drive "file=$seed_image,if=virtio,format=raw,readonly=on" \
+            -netdev "tap,id=net0,ifname=$tap_name,script=no,downscript=no" \
+            -device "virtio-net-pci,netdev=net0,mac=$worker_mac" \
+            -display none \
+            -serial "file:$vm_dir/serial.log" \
+            -pidfile "$vm_dir/qemu.pid"
+
+          ssh_ready=false
+          for i in {1..90}; do
+            echo "VM SSH connectivity check: attempt $i/90..." >&2
+            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -i "$key_path" root@"$worker_vm_ip" "timeout 600 cloud-init status --wait >/dev/null && true" 2>/dev/null; then
+              ssh_ready=true
+              echo "VM SSH connectivity check: succeeded on attempt $i/90" >&2
+              break
+            fi
+            sleep 5
+          done
+          if [[ "$ssh_ready" != "true" ]]; then
+            echo "QEMU worker VM did not become ready after 90 attempts" >&2
+            echo "---- VM serial log ----" >&2
+            sudo cat "$vm_dir/serial.log" >&2 || true
+            exit 1
+          fi
+
+          echo "E2E_APP_STORE_SSH_HOST=$worker_vm_ip" >> "$GITHUB_ENV"
+          echo "E2E_APP_STORE_SSH_PORT=22" >> "$GITHUB_ENV"
+          echo "E2E_APP_STORE_SSH_USER=root" >> "$GITHUB_ENV"
+          echo "E2E_APP_STORE_SSH_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+          echo "E2E_APISERVER_URL=https://${host_bridge_ip}:${E2E_APISERVER_PORT}" >> "$GITHUB_ENV"
+          echo "apiserverBind=0.0.0.0" >> "$GITHUB_ENV"
+      - name: Run App Store Access URL UI test
+        id: app-store-access-experiment
+        if: steps.ui-regression-tests.outputs.has_app_store_access_tests == 'true' && steps.prepare-app-store-worker-vm.outcome == 'success'
+        working-directory: ./web
+        timeout-minutes: 22
+        shell: bash
+        env:
+          E2E_DATA_DIR: /tmp/casos-e2e-${{ github.run_id }}-${{ github.run_attempt }}-app-store
+          E2E_APP_STORE_WORKER_TIMEOUT_MS: 600000
+          E2E_APP_STORE_HELM_TIMEOUT_MS: 180000
+          E2E_APP_STORE_ACCESS_TIMEOUT_MS: 120000
+          E2E_APP_STORE_EXPERIMENT_ACCESS_TIMEOUT_MS: 30000
+        run: |
+          set +e
+          set -o pipefail
+          mapfile -t ui_test_files < ui-app-store-access-tests.txt
+          echo "Running App Store Access URL UI experiment with retries disabled and a 20 minute command timeout..."
+          timeout --foreground 20m yarn playwright test --grep-invert @smoke --workers=1 --retries=0 --reporter=list "${ui_test_files[@]}" 2>&1 | tee ui-app-store-access-test.log
+          app_store_access_exit_code="${PIPESTATUS[0]}"
+          echo "$app_store_access_exit_code" > ui-app-store-access-exit-code.txt
+          app_store_access_gate_exit_code=0
+          node scripts/app-store-access-url-gate.js ui-app-store-access-summary.json || app_store_access_gate_exit_code="$?"
+          if [[ "$app_store_access_gate_exit_code" -ne 0 ]]; then
+            echo "App Store Access URL UI test detected rendered URL failures; cleanup, diagnostics, gate, and artifact upload will still run." >&2
+          fi
+          exit "$app_store_access_gate_exit_code"
+      - name: Cleanup QEMU Ubuntu worker VM
+        if: always() && steps.ui-regression-tests.outputs.has_app_store_access_tests == 'true'
+        shell: bash
+        run: |
+          set +e
+          vm_dir="$RUNNER_TEMP/casos-worker-vm"
+          run_hash="$(printf '%s' "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" | sha256sum | awk '{print $1}')"
+          run_suffix="${run_hash:0:6}"
+          subnet_octet=$((16#${run_hash:0:2} % 50 + 200))
+          bridge_name="cbr${run_suffix}"
+          tap_name="ctap${run_suffix}"
+          worker_cidr="192.168.${subnet_octet}.0/24"
+          default_iface="$(ip -4 route list default | awk 'NR == 1 {print $5}')"
+
+          if [[ -f "$vm_dir/qemu.pid" ]]; then
+            qemu_pid="$(cat "$vm_dir/qemu.pid")"
+            kill "$qemu_pid" 2>/dev/null || true
+            for i in {1..10}; do
+              kill -0 "$qemu_pid" 2>/dev/null || break
+              sleep 1
+            done
+            kill -9 "$qemu_pid" 2>/dev/null || true
+          fi
+          sudo iptables -t nat -D POSTROUTING -s "$worker_cidr" -o "$default_iface" -j MASQUERADE 2>/dev/null || true
+          sudo iptables -D FORWARD -i "$bridge_name" -o "$default_iface" -j ACCEPT 2>/dev/null || true
+          sudo iptables -D FORWARD -i "$default_iface" -o "$bridge_name" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || true
+          sudo ip link delete "$tap_name" 2>/dev/null || true
+          sudo ip link delete "$bridge_name" 2>/dev/null || true
+      - name: Print App Store worker diagnostics
+        if: always() && steps.ui-regression-tests.outputs.has_app_store_access_tests == 'true'
+        working-directory: ./web
+        shell: bash
+        run: |
+          if [[ -f ui-app-store-worker-diagnostics.log ]]; then
+            echo "---- ui-app-store-worker-diagnostics.log ----"
+            tail -n 400 ui-app-store-worker-diagnostics.log
+          else
+            echo "No App Store worker diagnostics log was produced."
+          fi
+      - name: Run App Store Access URL product gate
+        if: always()
+        working-directory: ./web
+        shell: bash
+        env:
+          HAS_APP_STORE_ACCESS_TESTS: ${{ steps.ui-regression-tests.outputs.has_app_store_access_tests }}
+          PREPARE_APP_STORE_WORKER_OUTCOME: ${{ steps.prepare-app-store-worker-vm.outcome }}
+          APP_STORE_ACCESS_EXIT_CODE_PATH: ui-app-store-access-exit-code.txt
+        run: |
+          set -euo pipefail
+          node scripts/app-store-access-url-gate.js ui-app-store-access-summary.json 2>&1 | tee ui-app-store-access-gate.log
       - name: Upload Playwright artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -148,8 +387,17 @@ jobs:
             ./web/test-results
             ./web/ui-changed-files.txt
             ./web/ui-regression-tests.txt
+            ./web/ui-standard-regression-tests.txt
+            ./web/ui-app-store-access-tests.txt
             ./web/ui-smoke-test.log
             ./web/ui-test.log
+            ./web/ui-app-store-access-test.log
+            ./web/ui-app-store-access-exit-code.txt
+            ./web/ui-app-store-access-gate.log
+            ./web/ui-app-store-access-summary.json
+            ./web/ui-app-store-access-summary.json.original
+            ./web/ui-app-store-worker-diagnostics.log
+            ${{ runner.temp }}/casos-worker-vm/serial.log
           if-no-files-found: ignore
 
   backend:

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "build": "craco build",
     "ui:test": "playwright test",
     "ui:test:selector:check": "node scripts/select-ui-tests-check.js",
+    "ui:test:access-url-diagnostics:check": "node tests/ui/access-url-diagnostics-check.js && node tests/ui/access-url-gate-check.js && node tests/ui/app-store-access-url-probe-check.js && node tests/ui/app-store-access-url-visual-evidence-check.js",
     "ui:test:smoke": "playwright test --grep @smoke",
     "ui:test:regression": "playwright test --grep-invert @smoke",
     "ui:test:headed": "playwright test --headed",

--- a/web/scripts/access-url-diagnostics.js
+++ b/web/scripts/access-url-diagnostics.js
@@ -1,0 +1,478 @@
+const ACCESS_URL_FAILURE_CATEGORIES = Object.freeze({
+  SERVICE_ACCESS_URL_NOT_RENDERED: "service-access-url-not-rendered",
+  NODE_PORT_UNREACHABLE: "node-port-unreachable",
+  DOMAIN_ACCESS_URL_UNREACHABLE: "domain-access-url-unreachable",
+  CI_OR_NETWORK_DIAGNOSTIC: "ci-or-network-diagnostic",
+  APP_WORKLOAD_DIAGNOSTIC: "app-workload-diagnostic",
+  TEST_HARNESS_DIAGNOSTIC: "test-harness-diagnostic",
+});
+
+const ACCESS_URL_TYPES = Object.freeze({
+  DOMAIN: "domain",
+  NODEPORT: "nodeport",
+});
+
+const ACCESS_URL_FAILURE_SCOPES = Object.freeze({
+  APP_STORE_CASOS_CANDIDATE: "app-store-casos-candidate",
+  APP_WORKLOAD: "app-workload",
+  CI_OR_ENVIRONMENT: "ci-or-environment",
+  TEST_HARNESS: "test-harness",
+});
+
+const CATEGORY_HINTS = Object.freeze({
+  [ACCESS_URL_FAILURE_CATEGORIES.SERVICE_ACCESS_URL_NOT_RENDERED]: "The app-store release did not produce a visible Access URL in the Deployments page Access URL column.",
+  [ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE]: "The worker node IP was reachable, but the NodePort listener or kube-proxy routing rejected the connection.",
+  [ACCESS_URL_FAILURE_CATEGORIES.DOMAIN_ACCESS_URL_UNREACHABLE]: "The Deployments page rendered a domain Access URL, but the browser could not open it; check the Ingress host, DNS, ingress controller, and routing to the worker cluster.",
+  [ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC]: "The browser did not get a stable HTTP response for an environment-shaped reason; check VM/runner routing, DNS, bridge/tap, firewall, and browser navigation details.",
+  [ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC]: "The installed chart did not expose a healthy workload response; check the service type, selector, pod logs, endpoints, and response body.",
+  [ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC]: "The response reached the test but did not match the expected success condition; check the test expectation and access-url validation logic.",
+});
+
+const CATEGORY_METADATA = Object.freeze({
+  [ACCESS_URL_FAILURE_CATEGORIES.SERVICE_ACCESS_URL_NOT_RENDERED]: {
+    scope: ACCESS_URL_FAILURE_SCOPES.APP_STORE_CASOS_CANDIDATE,
+    reportable: true,
+    reportReason: "The app-store install completed, but CasOS did not expose an Access URL for the installed service shape in the Deployments page.",
+  },
+  [ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE]: {
+    scope: ACCESS_URL_FAILURE_SCOPES.APP_STORE_CASOS_CANDIDATE,
+    reportable: true,
+    reportReason: "The node IP and port were reachable enough to reject the connection, so this is inside the deployed cluster/service path rather than a runner routing timeout.",
+  },
+  [ACCESS_URL_FAILURE_CATEGORIES.DOMAIN_ACCESS_URL_UNREACHABLE]: {
+    scope: ACCESS_URL_FAILURE_SCOPES.APP_WORKLOAD,
+    reportable: false,
+    reportReason: "The URL was rendered from Ingress/domain evidence, but DNS, ingress-controller, or host routing evidence is needed before treating it as a CasOS product issue.",
+  },
+  [ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC]: {
+    scope: ACCESS_URL_FAILURE_SCOPES.CI_OR_ENVIRONMENT,
+    reportable: false,
+    reportReason: "Runner, VM, browser, DNS, and generic no-response failures are too noisy to count as CasOS issues without extra evidence.",
+  },
+  [ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC]: {
+    scope: ACCESS_URL_FAILURE_SCOPES.APP_WORKLOAD,
+    reportable: false,
+    reportReason: "The observed evidence belongs to the installed chart workload or service shape unless separate CasOS routing evidence exists.",
+  },
+  [ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC]: {
+    scope: ACCESS_URL_FAILURE_SCOPES.TEST_HARNESS,
+    reportable: false,
+    reportReason: "This means the test expectation did not match a reachable response, so it is a test harness signal rather than an app-store issue.",
+  },
+});
+
+const ACCESS_URL_FAILURE_CATEGORY_VALUES = new Set(Object.values(ACCESS_URL_FAILURE_CATEGORIES));
+
+function classifyAccessUrlFailure(input) {
+  input = input || {};
+  const message = readFailureMessage(input);
+  const lowerMessage = message.toLowerCase();
+  const status = normalizeResponseStatus(input.responseStatus);
+  const body = String(input.body || "");
+
+  // Explicit evidence gathered from Services/Pods or the harness beats browser-level symptoms.
+  if (input.appWorkloadDiagnostic) {
+    return failureCategory(
+      ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC,
+      input.detail || "installed chart workload did not expose a healthy NodePort response"
+    );
+  }
+
+  if (input.testHarnessDiagnostic) {
+    return failureCategory(
+      ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC,
+      input.detail || "access URL test harness reported an internal diagnostic"
+    );
+  }
+
+  if (input.serviceUrlMissing) {
+    if (isDomainAccessUrlInput(input)) {
+      return failureCategory(
+        ACCESS_URL_FAILURE_CATEGORIES.SERVICE_ACCESS_URL_NOT_RENDERED,
+        input.detail ?? "Ingress domain Access URL did not render in the Deployments page"
+      );
+    }
+    const serviceType = normalizeServiceType(input.serviceType);
+    if (serviceType && serviceType !== "nodeport") {
+      const detail = input.detail || `service type ${input.serviceType} does not expose a NodePort Access URL`;
+      return failureCategory(ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC, detail);
+    }
+    return failureCategory(
+      ACCESS_URL_FAILURE_CATEGORIES.SERVICE_ACCESS_URL_NOT_RENDERED,
+      input.detail ?? "NodePort service row did not expose a matching Access URL"
+    );
+  }
+
+  // Keep specific failures before broad ones when browser messages contain multiple indicators.
+  // This order is intentional and covered by diagnostics checks.
+  if (input.domainAccessUrlDiagnostic) {
+    return failureCategory(
+      ACCESS_URL_FAILURE_CATEGORIES.DOMAIN_ACCESS_URL_UNREACHABLE,
+      input.detail || message || "domain Access URL could not be opened"
+    );
+  }
+
+  const domainNavigationFailure = classifyDomainAccessUrlNavigationFailure(input, lowerMessage, status, message);
+  if (domainNavigationFailure) {
+    return domainNavigationFailure;
+  }
+
+  if (/connection refused|err_connection_refused|connection reset|err_connection_reset|socket hang up|econnrefused|econnreset/.test(lowerMessage)) {
+    return failureCategory(ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE, message);
+  }
+
+  if (/err_name_not_resolved|\bdns\b|name or service not known|invalid url|cannot navigate to invalid url/.test(lowerMessage)) {
+    return failureCategory(ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC, message);
+  }
+
+  if (/timeout|timed out|err_connection_timed_out|net::err_timed_out|no route to host|host unreachable|network is unreachable/.test(lowerMessage)) {
+    return failureCategory(ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC, message);
+  }
+
+  if (status === undefined || status === 0) {
+    if (message) {
+      return failureCategory(ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC, message);
+    }
+    return failureCategory(ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC, "no HTTP response was returned");
+  }
+
+  if (status !== 200) {
+    const detail = body.trim()
+      ? `HTTP ${status}: ${trimDetail(body)}`
+      : `HTTP ${status}`;
+    return failureCategory(ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC, detail);
+  }
+
+  if (!body.trim()) {
+    return failureCategory(ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC, "HTTP 200 with an empty response body");
+  }
+
+  return failureCategory(
+    ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC,
+    message || `response validation reached failure handling after HTTP ${status}`
+  );
+}
+
+function isKnownAccessUrlFailureCategory(category) {
+  return ACCESS_URL_FAILURE_CATEGORY_VALUES.has(category);
+}
+
+function normalizeAccessUrlClassification(classification, fallbackDetail) {
+  if (classification?.category && isKnownAccessUrlFailureCategory(classification.category)) {
+    const metadata = getAccessUrlFailureMetadata(classification.category);
+    const detail = stringifyDiagnosticValue(classification.detail)
+      || stringifyDiagnosticValue(fallbackDetail)
+      || "access URL failure classification reached fallback detail";
+    return {
+      category: classification.category,
+      scope: classification.scope || metadata.scope,
+      reportable: metadata.reportable,
+      reportReason: classification.reportReason || metadata.reportReason,
+      detail: trimDetail(detail),
+      hint: classification.hint || CATEGORY_HINTS[classification.category],
+    };
+  }
+
+  return failureCategory(
+    ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC,
+    stringifyDiagnosticValue(classification?.detail)
+      || stringifyDiagnosticValue(fallbackDetail)
+      || "access URL failure classification was normalized by the test harness"
+  );
+}
+
+function readFailureMessage(input) {
+  return stringifyDiagnosticValue(input.error?.message)
+    || stringifyDiagnosticValue(input.error)
+    || stringifyDiagnosticValue(input.detail);
+}
+
+function normalizeResponseStatus(value) {
+  if (value === null || value === undefined || value === "") {
+    return undefined;
+  }
+  const numberValue = Number(value);
+  return Number.isNaN(numberValue) ? undefined : numberValue;
+}
+
+function normalizeServiceType(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function isDomainAccessUrlInput(input) {
+  return String(input?.accessUrlType || "").toLowerCase() === ACCESS_URL_TYPES.DOMAIN;
+}
+
+function classifyDomainAccessUrlNavigationFailure(input, lowerMessage, status, message) {
+  if (!isDomainAccessUrlInput(input)) {
+    return null;
+  }
+  if (/connection refused|err_connection_refused|connection reset|err_connection_reset|socket hang up|econnrefused|econnreset/.test(lowerMessage) ||
+    /err_name_not_resolved|\bdns\b|name or service not known|invalid url|cannot navigate to invalid url/.test(lowerMessage) ||
+    /timeout|timed out|err_connection_timed_out|net::err_timed_out|no route to host|host unreachable|network is unreachable/.test(lowerMessage) ||
+    status === undefined ||
+    status === 0) {
+    return failureCategory(
+      ACCESS_URL_FAILURE_CATEGORIES.DOMAIN_ACCESS_URL_UNREACHABLE,
+      input.detail || message || "domain Access URL did not return an HTTP response"
+    );
+  }
+  return null;
+}
+
+function shouldFailAccessUrlOutcome(outcome) {
+  if (!outcome || outcome.reachable) {
+    return false;
+  }
+  const classification = normalizeAccessUrlClassification(
+    outcome.classification,
+    outcome.detail || "access URL outcome failed without a classification"
+  );
+  return Boolean(outcome.accessUrl) || classification.reportable;
+}
+
+function stringifyDiagnosticValue(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "object") {
+    if (isErrorLike(value)) {
+      return value.message || value.stack || stringifyFallback(value);
+    }
+    try {
+      const json = stringifyJson(value);
+      if (json && json !== "{}") {
+        return json;
+      }
+      return "";
+    } catch (error) {
+      return stringifyFallback(value);
+    }
+  }
+  return stringifyFallback(value);
+}
+
+function isErrorLike(value) {
+  return value instanceof Error || Boolean(value && typeof value.message === "string");
+}
+
+function stringifyFallback(value) {
+  let fallback;
+  try {
+    fallback = String(value);
+  } catch (error) {
+    return "[Unstringifiable value]";
+  }
+  return fallback === "[object Object]" ? "" : fallback;
+}
+
+function failureCategory(category, detail) {
+  const metadata = getAccessUrlFailureMetadata(category);
+  return {
+    category,
+    scope: metadata.scope,
+    reportable: metadata.reportable,
+    reportReason: metadata.reportReason,
+    detail: trimDetail(detail),
+    hint: CATEGORY_HINTS[category] || CATEGORY_HINTS[ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC],
+  };
+}
+
+function getAccessUrlFailureMetadata(category) {
+  return CATEGORY_METADATA[category] || CATEGORY_METADATA[ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC];
+}
+
+function isReportableAccessUrlCategory(category) {
+  return Boolean(getAccessUrlFailureMetadata(category).reportable);
+}
+
+function formatAccessUrlFailure(params) {
+  params = params || {};
+  const {
+    accessUrl,
+    source,
+    detail,
+    repoName,
+    chartName,
+    chartVersion,
+    releaseName,
+    namespace,
+    deploymentName,
+    serviceName,
+    serviceType,
+    accessUrlType,
+    ingressName,
+    attemptCount,
+    classification,
+  } = params;
+  const safeClassification = normalizeAccessUrlClassification(
+    classification,
+    detail || "access URL failure was formatted without a classification"
+  );
+  const parts = [
+    "Access URL was not reachable",
+    `category=${safeClassification.category}`,
+    `source=${formatLogValue(source || "source-unspecified")}`,
+  ];
+  if (repoName) {
+    parts.push(`repo=${formatLogValue(repoName)}`);
+  }
+  if (chartName) {
+    const chartDisplay = chartVersion ? `${chartName}@${chartVersion}` : chartName;
+    parts.push(`chart=${formatLogValue(chartDisplay)}`);
+  }
+  if (releaseName) {
+    parts.push(`release=${formatLogValue(namespace || "default")}/${formatLogValue(releaseName)}`);
+  }
+  if (deploymentName) {
+    parts.push(`deployment=${formatLogValue(namespace || "default")}/${formatLogValue(deploymentName)}`);
+  }
+  if (serviceName) {
+    const serviceDisplay = serviceType ? `${serviceName}:${serviceType}` : serviceName;
+    parts.push(`service=${formatLogValue(namespace || "default")}/${formatLogValue(serviceDisplay)}`);
+  }
+  if (accessUrlType) {
+    parts.push(`target=${formatLogValue(accessUrlType)}`);
+  }
+  if (ingressName) {
+    parts.push(`ingress=${formatLogValue(namespace || "default")}/${formatLogValue(ingressName)}`);
+  }
+  if (accessUrl) {
+    parts.push(`url=${formatLogValue(accessUrl)}`);
+  }
+  if (attemptCount !== undefined && attemptCount !== null) {
+    parts.push(`attempts=${attemptCount}`);
+  }
+  if (safeClassification.detail) {
+    parts.push(`detail=${formatLogValue(safeClassification.detail)}`);
+  }
+  if (safeClassification.hint) {
+    parts.push(`hint=${formatLogValue(safeClassification.hint)}`);
+  }
+  return parts.join("; ");
+}
+
+function summarizeAccessUrlOutcomes(outcomes) {
+  const summary = {
+    totalCount: 0,
+    reachableCount: 0,
+    failureCount: 0,
+    reportableFailureCount: 0,
+    diagnosticFailureCount: 0,
+    categories: [],
+    diagnosticCategories: [],
+  };
+  const categoriesByName = new Map();
+  const diagnosticCategoriesByName = new Map();
+
+  for (const outcome of outcomes || []) {
+    summary.totalCount += 1;
+    if (outcome?.reachable) {
+      summary.reachableCount += 1;
+      continue;
+    }
+
+    summary.failureCount += 1;
+    const classification = normalizeAccessUrlClassification(
+      outcome?.classification,
+      outcome?.detail || "access URL outcome failed without a classification"
+    );
+    const category = classification.category;
+    const reportable = isReportableAccessUrlCategory(category);
+    if (reportable) {
+      summary.reportableFailureCount += 1;
+    } else {
+      summary.diagnosticFailureCount += 1;
+    }
+
+    const target = reportable ? categoriesByName : diagnosticCategoriesByName;
+    if (!target.has(category)) {
+      target.set(category, {
+        category,
+        scope: classification.scope,
+        reportable,
+        reportReason: classification.reportReason,
+        hint: classification.hint,
+        count: 0,
+        examples: [],
+      });
+    }
+
+    const bucket = target.get(category);
+    bucket.count += 1;
+    if (bucket.examples.length < 5) {
+      bucket.examples.push(compactAccessUrlExample(outcome, classification));
+    }
+  }
+
+  summary.categories = Array.from(categoriesByName.values())
+    .sort((left, right) => left.category.localeCompare(right.category));
+  summary.diagnosticCategories = Array.from(diagnosticCategoriesByName.values())
+    .sort((left, right) => left.category.localeCompare(right.category));
+  return summary;
+}
+
+function compactAccessUrlExample(outcome, classification) {
+  outcome = outcome || {};
+  return {
+    source: outcome.source,
+    repoName: outcome.repoName,
+    chartName: outcome.chartName,
+    chartVersion: outcome.chartVersion,
+    releaseName: outcome.releaseName,
+    namespace: outcome.namespace,
+    deploymentName: outcome.deploymentName,
+    serviceName: outcome.serviceName,
+    serviceType: outcome.serviceType,
+    accessUrlType: outcome.accessUrlType,
+    ingressName: outcome.ingressName,
+    ingressHost: outcome.ingressHost,
+    accessUrl: outcome.accessUrl,
+    attemptCount: outcome.attemptCount,
+    scope: classification.scope,
+    reportable: classification.reportable,
+    detail: classification.detail,
+  };
+}
+
+function formatLogValue(value) {
+  return String(value).replace(/[\\;=\x00-\x1f\x7f-\x9f]/g, char => (
+    `\\x${char.charCodeAt(0).toString(16).padStart(2, "0")}`
+  ));
+}
+
+function stringifyJson(value) {
+  const ancestors = [];
+  return JSON.stringify(value, function(_key, nestedValue) {
+    if (nestedValue && typeof nestedValue === "object") {
+      while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+        ancestors.pop();
+      }
+      if (ancestors.includes(nestedValue)) {
+        return "[Circular]";
+      }
+      ancestors.push(nestedValue);
+    }
+    return nestedValue;
+  });
+}
+
+function trimDetail(value) {
+  return Array.from(String(value || "").replace(/\s+/g, " ").trim()).slice(0, 300).join("");
+}
+
+module.exports = {
+  ACCESS_URL_FAILURE_CATEGORIES,
+  ACCESS_URL_FAILURE_SCOPES,
+  ACCESS_URL_TYPES,
+  classifyAccessUrlFailure,
+  formatAccessUrlFailure,
+  getAccessUrlFailureMetadata,
+  isKnownAccessUrlFailureCategory,
+  isReportableAccessUrlCategory,
+  shouldFailAccessUrlOutcome,
+  summarizeAccessUrlOutcomes,
+};

--- a/web/scripts/app-store-access-url-gate.js
+++ b/web/scripts/app-store-access-url-gate.js
@@ -1,0 +1,326 @@
+const fs = require("fs");
+const path = require("path");
+const {
+  ACCESS_URL_FAILURE_CATEGORIES,
+  shouldFailAccessUrlOutcome,
+  summarizeAccessUrlOutcomes,
+} = require("./access-url-diagnostics");
+const {
+  ACCESS_URL_GATE_SOURCE,
+  buildAccessUrlSummaryPayload,
+  diagnosticOutcome,
+} = require("./app-store-access-url-summary");
+
+const DEFAULT_FALLBACK_CATEGORY = ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC;
+const DEFAULT_FALLBACK_DETAIL = "App Store Access URL experiment did not produce a product-gate summary";
+const SUMMARY_SOURCE_SYNTHETIC = "synthetic-fallback";
+const SUMMARY_SOURCE_WITHOUT_OUTCOMES = "summary-without-outcomes";
+const DIAGNOSTIC_DETAIL_NO_OUTCOMES = "summary file did not include replayable outcomes";
+const DETAIL_MISSING_FROM_SUMMARY_CATEGORY = "summary category did not include detail";
+const DEFAULT_EXIT_CODE_PATH = "ui-app-store-access-exit-code.txt";
+const LOG_VALUE_NOT_RECORDED = "not-recorded";
+
+function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const summaryPath = args.shift();
+  const options = {
+    fallbackCategory: DEFAULT_FALLBACK_CATEGORY,
+    fallbackDetail: DEFAULT_FALLBACK_DETAIL,
+  };
+  while (args.length > 0) {
+    const name = args.shift();
+    if (name === "--fallback-category") {
+      options.fallbackCategory = readOptionValue(name, args);
+      continue;
+    }
+    if (name === "--fallback-detail") {
+      options.fallbackDetail = readOptionValue(name, args);
+      continue;
+    }
+    throw new Error(`Unsupported argument: ${name}`);
+  }
+  return {summaryPath, options};
+}
+
+function readOptionValue(name, args) {
+  const value = args.shift();
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function main(argv = process.argv) {
+  let parsed;
+  try {
+    parsed = parseArgs(argv);
+  } catch (error) {
+    process.stderr.write(`::warning::${escapeCommandText(error.message)}\n`);
+    return 0;
+  }
+
+  if (!parsed.summaryPath) {
+    process.stderr.write("::warning::Usage: node scripts/app-store-access-url-gate.js <summary.json> [--fallback-category category] [--fallback-detail detail]\n");
+    return 0;
+  }
+
+  const options = resolveFallbackOptions(parsed.options);
+  const result = readGateSummary(parsed.summaryPath, options);
+  result.failingAccessUrlSummary = summarizeAccessUrlOutcomes(
+    extractFailingAccessUrlOutcomes(result.payload?.outcomes)
+  );
+  if (result.synthetic) {
+    writeSyntheticSummary(parsed.summaryPath, result.payload);
+  }
+  printGateSummary(result);
+  return result.failingAccessUrlSummary.failureCount > 0 ? 1 : 0;
+}
+
+function resolveFallbackOptions(options = {}, env = process.env) {
+  const resolved = {
+    fallbackCategory: options.fallbackCategory || DEFAULT_FALLBACK_CATEGORY,
+    fallbackDetail: options.fallbackDetail || DEFAULT_FALLBACK_DETAIL,
+  };
+  const hasAppStoreAccessTestsRaw = env.HAS_APP_STORE_ACCESS_TESTS;
+  const hasAppStoreAccessTests = String(hasAppStoreAccessTestsRaw || "").trim().toLowerCase();
+  if (hasAppStoreAccessTestsRaw !== undefined && hasAppStoreAccessTests !== "true") {
+    return {
+      ...resolved,
+      fallbackCategory: ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC,
+      fallbackDetail: "No App Store Access URL UI regression tests were selected by the changed-path selector",
+    };
+  }
+
+  if (hasAppStoreAccessTests === "true") {
+    const prepareOutcome = String(env.PREPARE_APP_STORE_WORKER_OUTCOME || "skipped").trim() || "skipped";
+    if (prepareOutcome !== "success") {
+      return {
+        ...resolved,
+        fallbackCategory: ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC,
+        fallbackDetail: `QEMU worker VM preparation did not complete successfully: ${prepareOutcome}`,
+      };
+    }
+  }
+
+  const exitCodePath = env.APP_STORE_ACCESS_EXIT_CODE_PATH || DEFAULT_EXIT_CODE_PATH;
+  const exitCode = readExperimentExitCode(exitCodePath);
+  if (exitCode !== null) {
+    return {
+      ...resolved,
+      fallbackDetail: `Playwright App Store Access URL experiment exited with code ${exitCode} before writing a product-gate summary`,
+    };
+  }
+  return resolved;
+}
+
+function readExperimentExitCode(exitCodePath) {
+  try {
+    if (!fs.existsSync(exitCodePath)) {
+      return null;
+    }
+    const content = fs.readFileSync(exitCodePath, "utf8").trim();
+    return content || null;
+  } catch (error) {
+    process.stderr.write(`::warning::${escapeCommandText(`failed to read App Store Access URL experiment exit code: ${error.message}`)}\n`);
+    return null;
+  }
+}
+
+function readGateSummary(summaryPath, options = {}) {
+  let payload;
+  try {
+    payload = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+  } catch (error) {
+    const detail = error.code === "ENOENT"
+      ? options.fallbackDetail || DEFAULT_FALLBACK_DETAIL
+      : `${options.fallbackDetail || DEFAULT_FALLBACK_DETAIL}: ${error.message}`;
+    const syntheticPayload = buildAccessUrlSummaryPayload([
+      diagnosticOutcome(options.fallbackCategory, detail, {
+        source: ACCESS_URL_GATE_SOURCE,
+      }),
+    ], {
+      status: "diagnostic",
+      summarySource: SUMMARY_SOURCE_SYNTHETIC,
+    });
+    return {
+      payload: syntheticPayload,
+      summary: syntheticPayload.summary,
+      synthetic: true,
+      source: SUMMARY_SOURCE_SYNTHETIC,
+      detail,
+    };
+  }
+
+  const outcomes = extractOutcomes(payload);
+  if (outcomes.length === 0 && payload?.summary?.totalCount > 0) {
+    const syntheticPayload = buildAccessUrlSummaryPayload([
+      diagnosticOutcome(DEFAULT_FALLBACK_CATEGORY, DIAGNOSTIC_DETAIL_NO_OUTCOMES, {
+        source: ACCESS_URL_GATE_SOURCE,
+      }),
+    ], {
+      status: "diagnostic",
+      summarySource: SUMMARY_SOURCE_WITHOUT_OUTCOMES,
+    });
+    return {
+      payload: syntheticPayload,
+      summary: syntheticPayload.summary,
+      synthetic: true,
+      source: SUMMARY_SOURCE_WITHOUT_OUTCOMES,
+      detail: DIAGNOSTIC_DETAIL_NO_OUTCOMES,
+    };
+  }
+
+  const summary = summarizeAccessUrlOutcomes(outcomes);
+  return {
+    payload: {
+      ...payload,
+      summary,
+      outcomes,
+    },
+    summary,
+    synthetic: false,
+    source: payload?.summarySource || "summary-file",
+    detail: payload?.status || "",
+  };
+}
+
+function extractOutcomes(payload) {
+  if (Array.isArray(payload?.outcomes)) {
+    return payload.outcomes;
+  }
+
+  const categories = [
+    ...arrayOrEmpty(payload?.summary?.categories),
+    ...arrayOrEmpty(payload?.summary?.diagnosticCategories),
+  ];
+  return categories.flatMap(category => {
+    const bucket = category || {};
+    const examples = Array.isArray(bucket.examples) && bucket.examples.length > 0
+      ? bucket.examples
+      : [{}];
+    return examples.map(example => ({
+      ...example,
+      // Category examples are failure buckets. Preserve a future explicit value, default to failed.
+      reachable: example.reachable ?? false,
+      classification: {
+        category: bucket.category || ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC,
+        detail: example.detail || bucket.reportReason || bucket.hint || DETAIL_MISSING_FROM_SUMMARY_CATEGORY,
+      },
+    }));
+  });
+}
+
+function extractFailingAccessUrlOutcomes(outcomes) {
+  return arrayOrEmpty(outcomes).filter(shouldFailAccessUrlOutcome);
+}
+
+function arrayOrEmpty(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function writeSyntheticSummary(summaryPath, payload) {
+  try {
+    fs.mkdirSync(path.dirname(path.resolve(summaryPath)), {recursive: true});
+    if (fs.existsSync(summaryPath)) {
+      fs.copyFileSync(summaryPath, `${summaryPath}.original`);
+    }
+    fs.writeFileSync(summaryPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  } catch (error) {
+    process.stderr.write(`::warning::${escapeCommandText(`failed to write synthetic App Store Access URL summary: ${error.message}`)}\n`);
+  }
+}
+
+function printGateSummary(result) {
+  const summary = result.summary;
+  process.stdout.write([
+    "[app-store-access-gate]",
+    `source=${sanitizeLogValue(result.source)}`,
+    `total=${summary.totalCount}`,
+    `reachable=${summary.reachableCount}`,
+    `failures=${summary.failureCount}`,
+    `reportable=${summary.reportableFailureCount}`,
+    `diagnostic=${summary.diagnosticFailureCount}`,
+    `failedAccessUrls=${result.failingAccessUrlSummary?.failureCount || 0}`,
+  ].join(" ") + "\n");
+
+  for (const category of result.failingAccessUrlSummary?.categories || []) {
+    process.stderr.write(`::error::${escapeCommandText(formatCategoryLine("CasOS Access URL product candidate", category))}\n`);
+  }
+  const failingDiagnosticCategories = new Set((result.failingAccessUrlSummary?.diagnosticCategories || [])
+    .map(category => category.category));
+  for (const category of result.failingAccessUrlSummary?.diagnosticCategories || []) {
+    process.stderr.write(`::error::${escapeCommandText(formatCategoryLine("App Store Access URL UI failure", category))}\n`);
+  }
+  for (const category of summary.diagnosticCategories) {
+    if (failingDiagnosticCategories.has(category.category)) {
+      continue;
+    }
+    process.stderr.write(`::warning::${escapeCommandText(formatCategoryLine("App Store Access URL diagnostic", category))}\n`);
+  }
+  if (summary.failureCount === 0) {
+    process.stderr.write("::warning::App Store Access URL gate found no failed Access URL samples to classify\n");
+  }
+  if (result.synthetic) {
+    process.stderr.write(`::warning::${escapeCommandText(`App Store Access URL gate used fallback summary: ${result.detail || DEFAULT_FALLBACK_DETAIL}`)}\n`);
+  }
+}
+
+function formatCategoryLine(prefix, category) {
+  return [
+    prefix,
+    `category=${category.category || LOG_VALUE_NOT_RECORDED}`,
+    `scope=${category.scope || LOG_VALUE_NOT_RECORDED}`,
+    `count=${category.count}`,
+    `reason=${category.reportReason || LOG_VALUE_NOT_RECORDED}`,
+    `examples=${formatExamples(category.examples)}`,
+  ].join("; ");
+}
+
+function formatExamples(examples = []) {
+  if (examples.length === 0) {
+    return LOG_VALUE_NOT_RECORDED;
+  }
+  return examples.map(example => [
+    `repo=${example.repoName || "repo-not-recorded"}`,
+    `chart=${example.chartName || "chart-not-recorded"}`,
+    `release=${formatNamespacedValue(example.namespace, example.releaseName || "release-not-recorded")}`,
+    `deployment=${formatNamespacedValue(example.namespace, example.deploymentName || "deployment-not-recorded")}`,
+    `service=${formatServiceValue(example)}`,
+    `target=${example.accessUrlType || "target-not-recorded"}`,
+    `ingress=${formatNamespacedValue(example.namespace, example.ingressName || "ingress-not-recorded")}`,
+    `url=${example.accessUrl || "url-not-recorded"}`,
+    `detail=${example.detail || "detail-not-recorded"}`,
+  ].map(sanitizeLogValue).join("|")).join(",");
+}
+
+function formatNamespacedValue(namespace, name) {
+  return `${namespace || "default"}/${name}`;
+}
+
+function formatServiceValue(example) {
+  const serviceName = example.serviceName || "service-not-recorded";
+  const serviceType = example.serviceType ? `:${example.serviceType}` : "";
+  return formatNamespacedValue(example.namespace, `${serviceName}${serviceType}`);
+}
+
+function sanitizeLogValue(value) {
+  return String(value).replace(/[\r\n]/g, " ").trim();
+}
+
+function escapeCommandText(value) {
+  return String(value)
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  extractOutcomes,
+  main,
+  readGateSummary,
+  resolveFallbackOptions,
+};

--- a/web/scripts/app-store-access-url-summary.js
+++ b/web/scripts/app-store-access-url-summary.js
@@ -1,0 +1,121 @@
+const fs = require("fs");
+const path = require("path");
+const {
+  ACCESS_URL_FAILURE_CATEGORIES,
+  isKnownAccessUrlFailureCategory,
+  summarizeAccessUrlOutcomes,
+} = require("./access-url-diagnostics");
+
+const ACCESS_URL_GATE_SOURCE = "app-store-access-gate";
+const CLASSIFICATION_DETAIL_NOT_RECORDED = "classification detail was not recorded";
+const DIAGNOSTIC_DETAIL_NOT_RECORDED = "diagnostic detail was not recorded";
+// CI upload-artifact collects ./web/ui-app-store-access-summary.json.
+const ACCESS_URL_SUMMARY_PATH = path.resolve(__dirname, "../ui-app-store-access-summary.json");
+
+function buildAccessUrlSummaryPayload(outcomes, details = {}) {
+  const safeOutcomes = outcomes ?? [];
+  if (!Array.isArray(safeOutcomes)) {
+    throw new TypeError("buildAccessUrlSummaryPayload: outcomes must be an array");
+  }
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    throw new TypeError("buildAccessUrlSummaryPayload: details must be an object");
+  }
+  const safeDetails = {...details};
+  delete safeDetails.version;
+  delete safeDetails.generatedAt;
+  delete safeDetails.summary;
+  delete safeDetails.outcomes;
+  const compactOutcomes = safeOutcomes.map(compactSummaryOutcome);
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    ...safeDetails,
+    summary: summarizeAccessUrlOutcomes(compactOutcomes),
+    outcomes: compactOutcomes,
+  };
+}
+
+async function writeAccessUrlSummary(outcomes, details = {}, outputPath = ACCESS_URL_SUMMARY_PATH) {
+  let payload;
+  try {
+    payload = buildAccessUrlSummaryPayload(outcomes, details);
+  } catch (error) {
+    throw new Error(`failed to build App Store Access URL summary payload: ${error.message}`);
+  }
+  try {
+    await fs.promises.mkdir(path.dirname(path.resolve(outputPath)), {recursive: true});
+    await fs.promises.writeFile(outputPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  } catch (error) {
+    throw new Error(`failed to write App Store Access URL summary to ${outputPath}: ${error.message}`);
+  }
+  return payload;
+}
+
+function diagnosticOutcome(category, detail, context = {}) {
+  return {
+    source: ACCESS_URL_GATE_SOURCE,
+    chartName: "diagnostic",
+    releaseName: "diagnostic",
+    namespace: "default",
+    ...context,
+    // Keep diagnostic outcomes non-overridable; callers may add context, not change the verdict.
+    reachable: false,
+    attemptCount: 0,
+    classification: {
+      category: normalizeDiagnosticCategory(category),
+      detail: detail || DIAGNOSTIC_DETAIL_NOT_RECORDED,
+    },
+  };
+}
+
+function normalizeDiagnosticCategory(category) {
+  return isKnownAccessUrlFailureCategory(category)
+    ? category
+    : ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC;
+}
+
+function compactSummaryOutcome(outcome) {
+  const safeOutcome = outcome || {};
+  const compact = {
+    source: safeOutcome.source,
+    repoName: safeOutcome.repoName,
+    chartName: safeOutcome.chartName,
+    chartVersion: safeOutcome.chartVersion,
+    releaseName: safeOutcome.releaseName,
+    namespace: safeOutcome.namespace,
+    deploymentName: safeOutcome.deploymentName,
+    serviceName: safeOutcome.serviceName,
+    serviceType: safeOutcome.serviceType,
+    accessUrlType: safeOutcome.accessUrlType,
+    ingressName: safeOutcome.ingressName,
+    ingressHost: safeOutcome.ingressHost,
+    accessUrl: safeOutcome.accessUrl,
+    reachable: Boolean(safeOutcome.reachable),
+    attemptCount: safeOutcome.attemptCount ?? 0,
+    expectReachable: safeOutcome.expectReachable,
+    expectedAccessUrlType: safeOutcome.expectedAccessUrlType,
+    expectedCategory: safeOutcome.expectedCategory,
+    expectedFailureLocation: safeOutcome.expectedFailureLocation,
+    detail: safeOutcome.detail,
+  };
+  if (safeOutcome.classification) {
+    const category = normalizeDiagnosticCategory(safeOutcome.classification.category);
+    compact.classification = {
+      category,
+      scope: safeOutcome.classification.scope,
+      reportable: safeOutcome.classification.reportable,
+      reportReason: safeOutcome.classification.reportReason,
+      detail: safeOutcome.classification.detail || CLASSIFICATION_DETAIL_NOT_RECORDED,
+      hint: safeOutcome.classification.hint,
+    };
+  }
+  return compact;
+}
+
+module.exports = {
+  ACCESS_URL_GATE_SOURCE,
+  ACCESS_URL_SUMMARY_PATH,
+  buildAccessUrlSummaryPayload,
+  diagnosticOutcome,
+  writeAccessUrlSummary,
+};

--- a/web/scripts/select-ui-tests-check.js
+++ b/web/scripts/select-ui-tests-check.js
@@ -1,23 +1,56 @@
 const assert = require("assert");
-const {execFileSync} = require("child_process");
+const {execFileSync, spawnSync} = require("child_process");
 const fs = require("fs");
 const path = require("path");
-const {ALL_REGRESSION_TESTS, selectRegressionTests} = require("./select-ui-tests");
+const {
+  ALL_REGRESSION_TESTS,
+  APP_STORE_ACCESS_TEST,
+  selectRegressionTests,
+  splitHeavyRegressionTests,
+} = require("./select-ui-tests");
 
 function expectSelection(name, changedFiles, expectedTests) {
   assert.deepStrictEqual(selectRegressionTests(changedFiles), expectedTests, name);
 }
 
 expectSelection(
-  "worker node UI changes select worker node regression",
+  "worker node UI changes select worker node regression only",
   ["web/src/MachineNodeDeployPanel.js"],
   ["tests/ui/worker-node.spec.js"]
 );
 
 expectSelection(
-  "worker node backend changes select worker node regression once",
-  ["controllers/machine.go", "object/machine_node_deploy.go", "web/src/MachineListPage.js"],
-  ["tests/ui/worker-node.spec.js"]
+  "worker node deploy backend changes select the heavy access regression too",
+  ["object/machine_node_deploy.go", "web/src/backend/MachineNodeDeployBackend.js"],
+  ["tests/ui/worker-node.spec.js", APP_STORE_ACCESS_TEST]
+);
+
+expectSelection(
+  "app store and helm changes select app store access regression",
+  ["web/src/AppStorePage.js", "web/src/HelmInstallModal.js", "controllers/helm.go", "store/helm.go"],
+  [APP_STORE_ACCESS_TEST]
+);
+
+expectSelection(
+  "access URL display changes select app store access regression",
+  ["web/src/backend/ServiceBackend.js", "web/src/backend/NodeBackend.js", "web/src/DeploymentListPage.js", "web/src/ServiceListPage.js"],
+  [APP_STORE_ACCESS_TEST]
+);
+
+expectSelection(
+  "access URL diagnostics changes select app store access regression",
+  [
+    "web/tests/ui/access-url-diagnostics.js",
+    "web/tests/ui/access-url-diagnostics-check.js",
+    "web/tests/ui/access-url-gate-check.js",
+  ],
+  [APP_STORE_ACCESS_TEST]
+);
+
+expectSelection(
+  "app store access helper changes select app store access regression",
+  ["web/tests/ui/app-store-access-url-worker.js", "web/tests/ui/app-store-access-url-log.js"],
+  [APP_STORE_ACCESS_TEST]
 );
 
 expectSelection(
@@ -41,34 +74,125 @@ expectSelection(
 expectSelection(
   "UI test infrastructure changes run all regression tests",
   ["web/tests/ui/e2e-helpers.js"],
-  ALL_REGRESSION_TESTS
+  [...ALL_REGRESSION_TESTS, APP_STORE_ACCESS_TEST]
+);
+
+expectSelection(
+  "worker node test changes stay on the standard worker regression",
+  ["web/tests/ui/worker-node.spec.js"],
+  ["tests/ui/worker-node.spec.js"]
+);
+
+expectSelection(
+  "machine frontend CRUD changes stay on the standard worker regression",
+  ["web/src/MachineListPage.js", "web/src/MachineEditPage.js", "web/src/backend/MachineBackend.js"],
+  ["tests/ui/worker-node.spec.js"]
 );
 
 expectSelection(
   "unknown frontend code changes run all regression tests",
-  ["web/src/DeploymentListPage.js"],
+  ["web/src/DashboardPage.js"],
   ALL_REGRESSION_TESTS
+);
+
+expectSelection(
+  "worker node controller deployment files still select the heavy access regression",
+  ["controllers/machine_node_deploy.go"],
+  ["tests/ui/worker-node.spec.js", APP_STORE_ACCESS_TEST]
+);
+
+expectSelection(
+  "worker node deployment files only match the targeted deployment helpers",
+  ["deploy/containerd_config.go", "deploy/installer.go"],
+  ["tests/ui/worker-node.spec.js", APP_STORE_ACCESS_TEST]
+);
+
+expectSelection(
+  "standard regression triggers preserve an earlier heavy selection",
+  ["web/src/backend/MachineNodeDeployBackend.js", "conf/app.conf"],
+  [...ALL_REGRESSION_TESTS, APP_STORE_ACCESS_TEST]
 );
 
 expectSelection(
   "UI selector script changes run all regression tests",
   ["web/scripts/select-ui-tests.js"],
-  ALL_REGRESSION_TESTS
+  [...ALL_REGRESSION_TESTS, APP_STORE_ACCESS_TEST]
+);
+
+expectSelection(
+  "App Store Access URL gate script changes run all regression tests",
+  [
+    "web/scripts/access-url-diagnostics.js",
+    "web/scripts/app-store-access-url-gate.js",
+    "web/scripts/app-store-access-url-summary.js",
+  ],
+  [...ALL_REGRESSION_TESTS, APP_STORE_ACCESS_TEST]
 );
 
 expectSelection(
   "non-array inputs fall back to all regression tests",
   null,
-  ALL_REGRESSION_TESTS
+  [...ALL_REGRESSION_TESTS, APP_STORE_ACCESS_TEST]
+);
+
+assert.deepStrictEqual(
+  splitHeavyRegressionTests(["tests/ui/site-e2e.spec.js", APP_STORE_ACCESS_TEST]),
+  {standard: ["tests/ui/site-e2e.spec.js"], heavy: [APP_STORE_ACCESS_TEST]},
+  "heavy app store access test is split from standard regression tests"
 );
 
 const cliInputPath = path.join(__dirname, `.select-ui-tests-${process.pid}.txt`);
-fs.writeFileSync(cliInputPath, "web/src/MachineNodeDeployPanel.js\n", "utf8");
+const cliCombinedOutputPath = path.join(__dirname, `.select-ui-tests-${process.pid}.combined.txt`);
+const cliStandardOutputPath = path.join(__dirname, `.select-ui-tests-${process.pid}.standard.txt`);
+const cliHeavyOutputPath = path.join(__dirname, `.select-ui-tests-${process.pid}.heavy.txt`);
+fs.writeFileSync(cliInputPath, "web/src/backend/MachineNodeDeployBackend.js\n", "utf8");
 try {
   const output = execFileSync(process.execPath, [path.join(__dirname, "select-ui-tests.js"), cliInputPath], {
     encoding: "utf8",
   });
-  assert.strictEqual(output, "tests/ui/worker-node.spec.js\n", "CLI prints selected regression tests");
+  assert.strictEqual(output, `tests/ui/worker-node.spec.js\n${APP_STORE_ACCESS_TEST}\n`, "CLI prints selected regression tests");
+
+  execFileSync(
+    process.execPath,
+    [
+      path.join(__dirname, "select-ui-tests.js"),
+      "--split",
+      cliInputPath,
+      cliCombinedOutputPath,
+      cliStandardOutputPath,
+      cliHeavyOutputPath,
+    ],
+    {encoding: "utf8"}
+  );
+  assert.strictEqual(fs.readFileSync(cliCombinedOutputPath, "utf8"), `tests/ui/worker-node.spec.js\n${APP_STORE_ACCESS_TEST}\n`);
+  assert.strictEqual(fs.readFileSync(cliStandardOutputPath, "utf8"), `tests/ui/worker-node.spec.js\n`);
+  assert.strictEqual(fs.readFileSync(cliHeavyOutputPath, "utf8"), `${APP_STORE_ACCESS_TEST}\n`);
 } finally {
   fs.rmSync(cliInputPath, {force: true});
+  fs.rmSync(cliCombinedOutputPath, {force: true});
+  fs.rmSync(cliStandardOutputPath, {force: true});
+  fs.rmSync(cliHeavyOutputPath, {force: true});
+}
+
+fs.writeFileSync(cliInputPath, "web/src/backend/MachineNodeDeployBackend.js\n", "utf8");
+const missingOutputDir = path.join(__dirname, `.select-ui-tests-${process.pid}-missing`);
+try {
+  const failedSplit = spawnSync(
+    process.execPath,
+    [
+      path.join(__dirname, "select-ui-tests.js"),
+      "--split",
+      cliInputPath,
+      path.join(missingOutputDir, "combined.txt"),
+      cliStandardOutputPath,
+      cliHeavyOutputPath,
+    ],
+    {encoding: "utf8"}
+  );
+  assert.notStrictEqual(failedSplit.status, 0, "CLI split fails when an output file cannot be written");
+  assert.match(failedSplit.stderr, /Error writing selected UI test file:/, "CLI split reports write failures clearly");
+  assert.doesNotMatch(failedSplit.stderr, /\s+at\s+(Object\.|node:fs)/, "CLI split does not print a Node.js stack trace");
+} finally {
+  fs.rmSync(cliInputPath, {force: true});
+  fs.rmSync(missingOutputDir, {force: true, recursive: true});
 }

--- a/web/scripts/select-ui-tests.js
+++ b/web/scripts/select-ui-tests.js
@@ -7,12 +7,42 @@ const ALL_REGRESSION_TESTS = [
   "tests/ui/worker-node.spec.js",
 ];
 
-const WORKER_NODE_PATTERNS = [
-  /^controllers\/machine(_node_deploy)?\.go$/,
-  /^object\/machine(_node_deploy)?\.go$/,
+const APP_STORE_ACCESS_TEST = "tests/ui/app-store-access-url.spec.js";
+const HEAVY_TESTS = [APP_STORE_ACCESS_TEST];
+const ALL_TESTS = [...ALL_REGRESSION_TESTS, ...HEAVY_TESTS];
+
+const WORKER_NODE_UI_PATTERNS = [
+  /^controllers\/machine\.go$/,
+  /^object\/machine\.go$/,
   /^web\/src\/Machine(ListPage|EditPage|NodeDeployPanel)\.js$/,
-  /^web\/src\/backend\/Machine(NodeDeploy)?Backend\.js$/,
+  /^web\/src\/backend\/MachineBackend\.js$/,
   /^web\/tests\/ui\/worker-node\.spec\.js$/,
+];
+
+const WORKER_NODE_DEPLOY_PATTERNS = [
+  /^controllers\/machine_node_deploy\.go$/,
+  /^object\/machine_node_deploy\.go$/,
+  /^deploy\/(cni|containerd_config|executor|init|installer|key|kubeconfig|kubelet|kubeproxy|node_bootstrap|preflight|service|types)\.go$/,
+  /^web\/src\/backend\/MachineNodeDeployBackend\.js$/,
+];
+
+const APP_STORE_ACCESS_PATTERNS = [
+  /^controllers\/helm\.go$/,
+  /^controllers\/node\.go$/,
+  /^controllers\/service\.go$/,
+  /^store\/helm\.go$/,
+  /^web\/src\/AppStorePage\.js$/,
+  /^web\/src\/Helm(InstallModal|ReleasePage)\.js$/,
+  /^web\/src\/backend\/HelmBackend\.js$/,
+  /^web\/src\/backend\/NodeBackend\.js$/,
+  /^web\/src\/backend\/ServiceBackend\.js$/,
+  /^web\/src\/DeploymentListPage\.js$/,
+  /^web\/src\/ServiceListPage\.js$/,
+  /^web\/tests\/ui\/app-store-access-url\.spec\.js$/,
+  /^web\/tests\/ui\/app-store-access-url-[^/]+\.js$/,
+  /^web\/tests\/ui\/access-url-diagnostics\.js$/,
+  /^web\/tests\/ui\/access-url-diagnostics-check\.js$/,
+  /^web\/tests\/ui\/access-url-gate-check\.js$/,
 ];
 
 const SMOKE_COVERED_PATTERNS = [
@@ -28,15 +58,23 @@ const SITE_PATTERNS = [
 ];
 
 const FULL_REGRESSION_PATTERNS = [
-  /^\.github\/workflows\//,
   /^conf\/app\.conf$/,
   /^routers\/router\.go$/,
   /^web\/package\.json$/,
   /^web\/playwright\.config\.js$/,
   /^web\/src\/(Conf|Setting)\.js$/,
   /^web\/src\/locales\//,
-  /^web\/tests\/ui\/e2e-helpers\.js$/,
   /^web\/yarn\.lock$/,
+];
+
+const FULL_HEAVY_REGRESSION_PATTERNS = [
+  /^\.github\/workflows\//,
+  /^web\/tests\/ui\/e2e-helpers\.js$/,
+  /^web\/scripts\/access-url-diagnostics\.js$/,
+  /^web\/scripts\/app-store-access-url-gate\.js$/,
+  /^web\/scripts\/app-store-access-url-summary\.js$/,
+  /^web\/scripts\/select-ui-tests\.js$/,
+  /^web\/scripts\/select-ui-tests-check\.js$/,
 ];
 
 const DOCS_ONLY_PATTERNS = [
@@ -82,23 +120,41 @@ function normalizeChangedFiles(changedFiles) {
 
 function selectRegressionTestsFromNormalized(normalizedFiles) {
   if (normalizedFiles.length === 0) {
-    return [...ALL_REGRESSION_TESTS];
+    return ALL_TESTS;
   }
 
   const selectedTests = new Set();
   let runAllRegression = false;
+  let runAllHeavyRegression = false;
 
-  // Ordering matters: skip docs, honor all-regression triggers, then apply targeted and smoke-covered matches.
+  // Ordering matters: skip docs, honor heavy all-regression triggers (CI/test infra),
+  // then standard all-regression triggers (config/routing), then targeted and smoke-covered matches.
+  // If a file matching a standard all-regression trigger appears later in the iteration than
+  // a file matching a targeted heavy pattern, the heavy test is retained via selectedTests.has().
   for (const filePath of normalizedFiles) {
     if (matchesAny(filePath, DOCS_ONLY_PATTERNS)) {
+      continue;
+    }
+    if (matchesAny(filePath, FULL_HEAVY_REGRESSION_PATTERNS)) {
+      runAllRegression = true;
+      runAllHeavyRegression = true;
       continue;
     }
     if (matchesAny(filePath, FULL_REGRESSION_PATTERNS)) {
       runAllRegression = true;
       continue;
     }
-    if (matchesAny(filePath, WORKER_NODE_PATTERNS)) {
+    if (matchesAny(filePath, WORKER_NODE_DEPLOY_PATTERNS)) {
       selectedTests.add("tests/ui/worker-node.spec.js");
+      selectedTests.add(APP_STORE_ACCESS_TEST);
+      continue;
+    }
+    if (matchesAny(filePath, WORKER_NODE_UI_PATTERNS)) {
+      selectedTests.add("tests/ui/worker-node.spec.js");
+      continue;
+    }
+    if (matchesAny(filePath, APP_STORE_ACCESS_PATTERNS)) {
+      selectedTests.add(APP_STORE_ACCESS_TEST);
       continue;
     }
     if (matchesAny(filePath, SITE_PATTERNS)) {
@@ -114,10 +170,14 @@ function selectRegressionTestsFromNormalized(normalizedFiles) {
   }
 
   if (runAllRegression) {
-    return [...ALL_REGRESSION_TESTS];
+    // Include the heavy test when a full-heavy trigger was hit, or when a targeted
+    // worker/app-store match already selected it before a later full-regression trigger.
+    return (runAllHeavyRegression || selectedTests.has(APP_STORE_ACCESS_TEST))
+      ? ALL_TESTS
+      : ALL_REGRESSION_TESTS;
   }
 
-  return ALL_REGRESSION_TESTS.filter(testFile => selectedTests.has(testFile));
+  return ALL_TESTS.filter(testFile => selectedTests.has(testFile));
 }
 
 // Selects non-smoke UI regression specs for repository-relative changed paths.
@@ -125,13 +185,47 @@ function selectRegressionTests(changedFiles) {
   return selectRegressionTestsFromNormalized(normalizeChangedFiles(changedFiles));
 }
 
+function splitHeavyRegressionTests(testFiles) {
+  const standard = [];
+  const heavy = [];
+  for (const testFile of testFiles) {
+    if (HEAVY_TESTS.includes(testFile)) {
+      heavy.push(testFile);
+    } else {
+      standard.push(testFile);
+    }
+  }
+  return {standard, heavy};
+}
+
+function writeTestFiles(outputPath, testFiles) {
+  try {
+    // Empty output files are intentional: the workflow uses Bash `-s` to test whether any spec was selected.
+    fs.writeFileSync(outputPath, testFiles.length > 0 ? `${testFiles.join("\n")}\n` : "");
+  } catch (error) {
+    process.stderr.write(`Error writing selected UI test file: ${outputPath}: ${error.message}\n`);
+    process.exitCode = 1;
+    return false;
+  }
+  return true;
+}
+
 function main(argv) {
-  const changedFilesPath = argv[2];
-  if (!changedFilesPath) {
-    process.stderr.write("Usage: node scripts/select-ui-tests.js <changed-files.txt>\n");
+  const args = argv.slice(2);
+  const splitMode = args[0] === "--split";
+  const usage = splitMode
+    ? "Usage: node scripts/select-ui-tests.js --split <changed-files.txt> <combined-output.txt> <standard-output.txt> <heavy-output.txt>\n"
+    : "Usage: node scripts/select-ui-tests.js <changed-files.txt>\n";
+  if (args.length === 0 || (splitMode && args.length !== 5) || (!splitMode && args.length !== 1)) {
+    process.stderr.write(usage);
     process.exitCode = 1;
     return;
   }
+
+  const changedFilesPath = splitMode ? args[1] : args[0];
+  const combinedOutputPath = splitMode ? args[2] : null;
+  const standardOutputPath = splitMode ? args[3] : null;
+  const heavyOutputPath = splitMode ? args[4] : null;
 
   const repoRoot = path.resolve(__dirname, "..", "..");
   let resolvedChangedFilesPath;
@@ -165,6 +259,15 @@ function main(argv) {
     process.stderr.write("Warning: no changed files detected; falling back to all regression tests.\n");
   }
   const tests = selectRegressionTestsFromNormalized(normalizedFiles);
+  if (splitMode) {
+    const {standard, heavy} = splitHeavyRegressionTests(tests);
+    if (!writeTestFiles(combinedOutputPath, tests) ||
+        !writeTestFiles(standardOutputPath, standard) ||
+        !writeTestFiles(heavyOutputPath, heavy)) {
+      return;
+    }
+    return;
+  }
   process.stdout.write(tests.length > 0 ? `${tests.join("\n")}\n` : "");
 }
 
@@ -174,5 +277,8 @@ if (require.main === module) {
 
 module.exports = {
   ALL_REGRESSION_TESTS,
+  APP_STORE_ACCESS_TEST,
+  HEAVY_TESTS,
   selectRegressionTests,
+  splitHeavyRegressionTests,
 };

--- a/web/tests/ui/access-url-diagnostics-check.js
+++ b/web/tests/ui/access-url-diagnostics-check.js
@@ -1,0 +1,554 @@
+const assert = require("assert");
+const {
+  ACCESS_URL_FAILURE_CATEGORIES,
+  ACCESS_URL_FAILURE_SCOPES,
+  ACCESS_URL_TYPES,
+  classifyAccessUrlFailure,
+  formatAccessUrlFailure,
+  isReportableAccessUrlCategory,
+  shouldFailAccessUrlOutcome,
+  summarizeAccessUrlOutcomes,
+} = require("./access-url-diagnostics");
+
+function expectCategory(name, input, expectedCategory) {
+  const actualCategory = classifyAccessUrlFailure(input).category;
+  assert.strictEqual(
+    actualCategory,
+    expectedCategory,
+    `${name}: expected ${expectedCategory}, got ${actualCategory}`
+  );
+}
+
+assert.ok(
+  !Object.values(ACCESS_URL_FAILURE_CATEGORIES).includes("legacy-category"),
+  "ACCESS_URL_FAILURE_CATEGORIES must not contain a catch-all fallback category"
+);
+assert.deepStrictEqual(
+  Object.values(ACCESS_URL_FAILURE_CATEGORIES).sort(),
+  [
+    ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC,
+    ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC,
+    ACCESS_URL_FAILURE_CATEGORIES.DOMAIN_ACCESS_URL_UNREACHABLE,
+    ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE,
+    ACCESS_URL_FAILURE_CATEGORIES.SERVICE_ACCESS_URL_NOT_RENDERED,
+    ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC,
+  ].sort(),
+  "the bottom-level classifier should stay focused on six broad, actionable buckets"
+);
+
+expectCategory(
+  "connection refused is a node port listener/routing problem",
+  {error: new Error("net::ERR_CONNECTION_REFUSED at http://192.168.250.2:31080")},
+  ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE
+);
+
+expectCategory(
+  "connection refused wins when a message also mentions timeout",
+  {error: new Error("request timeout after connection refused at http://192.168.250.2:31080")},
+  ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE
+);
+
+expectCategory(
+  "connection refused wins when a message also mentions DNS",
+  {error: new Error("connection refused while resolving via DNS server at http://192.168.250.2:31080")},
+  ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE
+);
+
+expectCategory(
+  "timeout is a network path problem",
+  {error: new Error("page.goto: Timeout 10000ms exceeded")},
+  ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC
+);
+
+expectCategory(
+  "browser DNS failure is grouped with CI/network diagnostics",
+  {error: new Error("net::ERR_NAME_NOT_RESOLVED")},
+  ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC
+);
+
+expectCategory(
+  "domain Access URL DNS failure is grouped with domain/ingress reachability",
+  {accessUrlType: ACCESS_URL_TYPES.DOMAIN, error: new Error("net::ERR_NAME_NOT_RESOLVED")},
+  ACCESS_URL_FAILURE_CATEGORIES.DOMAIN_ACCESS_URL_UNREACHABLE
+);
+
+expectCategory(
+  "domain Access URL connection refused is grouped with domain/ingress reachability",
+  {accessUrlType: ACCESS_URL_TYPES.DOMAIN, error: new Error("net::ERR_CONNECTION_REFUSED")},
+  ACCESS_URL_FAILURE_CATEGORIES.DOMAIN_ACCESS_URL_UNREACHABLE
+);
+
+expectCategory(
+  "domain Access URL missing from Deployments is a rendered URL candidate",
+  {
+    serviceUrlMissing: true,
+    accessUrlType: ACCESS_URL_TYPES.DOMAIN,
+    serviceType: "ClusterIP",
+    detail: "Deployment page row did not render Ingress domain Access URL",
+  },
+  ACCESS_URL_FAILURE_CATEGORIES.SERVICE_ACCESS_URL_NOT_RENDERED
+);
+
+expectCategory(
+  "DNS wins when a message also mentions timeout",
+  {error: new Error("timeout while resolving via DNS server")},
+  ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC
+);
+
+expectCategory(
+  "empty successful response is an application workload problem",
+  {responseStatus: 200, body: "   "},
+  ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC
+);
+
+expectCategory(
+  "http 503 is an application workload problem",
+  {responseStatus: 503, body: "service unavailable"},
+  ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC
+);
+
+expectCategory(
+  "missing response is grouped with CI/network diagnostics",
+  {responseStatus: null, body: ""},
+  ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC
+);
+
+expectCategory(
+  "null input is treated as no HTTP response instead of throwing",
+  null,
+  ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC
+);
+
+expectCategory(
+  "status zero is treated as no HTTP response",
+  {responseStatus: 0, body: ""},
+  ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC
+);
+
+expectCategory(
+  "empty string status is treated as no HTTP response",
+  {responseStatus: "", body: ""},
+  ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC
+);
+
+expectCategory(
+  "string status zero is treated as no HTTP response",
+  {responseStatus: "0", body: ""},
+  ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC
+);
+
+expectCategory(
+  "NodePort service URL not rendered is categorized separately",
+  {serviceUrlMissing: true, serviceType: "NodePort", detail: "service row did not expose a matching Access URL"},
+  ACCESS_URL_FAILURE_CATEGORIES.SERVICE_ACCESS_URL_NOT_RENDERED
+);
+
+expectCategory(
+  "ClusterIP service without an Access URL is an app workload diagnostic",
+  {serviceUrlMissing: true, serviceType: "ClusterIP", detail: "service type ClusterIP does not expose a NodePort Access URL"},
+  ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC
+);
+
+expectCategory(
+  "workload evidence can override a browser connection error",
+  {appWorkloadDiagnostic: true, detail: "NodePort service has no running pods matching its selector"},
+  ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC
+);
+
+expectCategory(
+  "test harness evidence stays out of app-store reportable categories",
+  {testHarnessDiagnostic: true, detail: "release context is missing service and release names"},
+  ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC
+);
+
+expectCategory(
+  "unmatched browser navigation errors stay in a defined diagnostic class",
+  {error: new Error("something unexpected")},
+  ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC
+);
+
+expectCategory(
+  "successful response that reaches failure handling is a validation mismatch",
+  {responseStatus: 200, body: "sample is ready"},
+  ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC
+);
+
+expectCategory(
+  "string status 200 follows the same validation path as numeric 200",
+  {responseStatus: "200", body: "sample is ready"},
+  ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC
+);
+
+expectCategory(
+  "non-numeric status with detail is a browser navigation error",
+  {responseStatus: "NetworkError", detail: "browser aborted before receiving a status"},
+  ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC
+);
+
+const objectErrorClassification = classifyAccessUrlFailure({error: {code: "ERR_FAILED", reason: "browser aborted"}});
+assert.strictEqual(objectErrorClassification.category, ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC);
+assert.match(objectErrorClassification.detail, /ERR_FAILED/);
+assert.doesNotMatch(objectErrorClassification.detail, /\[object Object\]/);
+
+const errorLikeClassification = classifyAccessUrlFailure({error: {message: "net::ERR_CONNECTION_REFUSED"}});
+assert.strictEqual(errorLikeClassification.category, ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE);
+assert.match(errorLikeClassification.detail, /ERR_CONNECTION_REFUSED/);
+
+const stackOnlyError = new Error("");
+stackOnlyError.stack = "stack-only browser failure";
+const stackOnlyClassification = classifyAccessUrlFailure({error: stackOnlyError});
+assert.strictEqual(stackOnlyClassification.category, ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC);
+assert.match(stackOnlyClassification.detail, /stack-only browser failure/);
+
+const emptyError = new Error("");
+emptyError.stack = "";
+const emptyErrorClassification = classifyAccessUrlFailure({error: emptyError});
+assert.strictEqual(emptyErrorClassification.category, ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC);
+assert.match(emptyErrorClassification.detail, /Error/);
+
+const circularError = {code: "ERR_CIRCULAR"};
+circularError.self = circularError;
+const circularClassification = classifyAccessUrlFailure({error: circularError});
+assert.strictEqual(circularClassification.category, ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC);
+assert.match(circularClassification.detail, /ERR_CIRCULAR/);
+assert.match(circularClassification.detail, /\[Circular\]/);
+
+const sharedCause = {code: "ERR_SHARED_CAUSE"};
+const sharedReferenceClassification = classifyAccessUrlFailure({error: {left: sharedCause, right: sharedCause}});
+assert.strictEqual(sharedReferenceClassification.category, ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC);
+assert.match(sharedReferenceClassification.detail, /ERR_SHARED_CAUSE/);
+assert.doesNotMatch(sharedReferenceClassification.detail, /\[Circular\]/);
+
+const unstringifiableError = {
+  toJSON() {
+    throw new Error("json failed");
+  },
+  toString() {
+    throw new Error("string failed");
+  },
+};
+const unstringifiableClassification = classifyAccessUrlFailure({error: unstringifiableError});
+assert.strictEqual(unstringifiableClassification.category, ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC);
+assert.match(unstringifiableClassification.detail, /\[Unstringifiable value\]/);
+
+const emptyObjectErrorClassification = classifyAccessUrlFailure({error: {}});
+assert.strictEqual(emptyObjectErrorClassification.category, ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC);
+assert.doesNotMatch(emptyObjectErrorClassification.detail, /\[object Object\]/);
+
+const formatted = formatAccessUrlFailure({
+  accessUrl: "http://192.168.250.2:31080",
+  source: "app-store",
+  repoName: "podinfo",
+  chartName: "podinfo",
+  chartVersion: "6.14.0",
+  releaseName: "podinfo-ok-demo",
+  deploymentName: "podinfo",
+  serviceName: "podinfo",
+  serviceType: "NodePort",
+  attemptCount: 7,
+  classification: classifyAccessUrlFailure({error: new Error("net::ERR_CONNECTION_REFUSED")}),
+});
+
+assert.match(formatted, /category=node-port-unreachable/);
+assert.match(formatted, /source=app-store/);
+assert.match(formatted, /repo=podinfo/);
+assert.match(formatted, /chart=podinfo@6\.14\.0/);
+assert.match(formatted, /release=default\/podinfo-ok-demo/);
+assert.match(formatted, /deployment=default\/podinfo/);
+assert.match(formatted, /service=default\/podinfo:NodePort/);
+assert.match(formatted, /url=http:\/\/192\.168\.250\.2:31080/);
+assert.match(formatted, /attempts=7/);
+assert.match(formatted, /detail=net::ERR_CONNECTION_REFUSED/);
+assert.match(formatted, /hint=.+/);
+
+const formattedEscapedDetail = formatAccessUrlFailure({
+  classification: {
+    category: ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC,
+    detail: "connection refused; phase=browser path=C:\\temp\nnext",
+    hint: "check trace; retry=false",
+  },
+});
+assert.match(formattedEscapedDetail, /detail=connection refused\\x3b phase\\x3dbrowser path\\x3dC:\\x5ctemp next/);
+assert.match(formattedEscapedDetail, /hint=check trace\\x3b retry\\x3dfalse/);
+
+const formattedEscapedFields = formatAccessUrlFailure({
+  accessUrl: "http://host/?a=1;b=2",
+  source: "app=store",
+  repoName: "repo;one",
+  chartName: "chart=name",
+  chartVersion: "0;1",
+  releaseName: "rel=1",
+  namespace: "ns;1",
+  classification: classifyAccessUrlFailure({responseStatus: 503, body: "nope"}),
+});
+assert.match(formattedEscapedFields, /source=app\\x3dstore/);
+assert.match(formattedEscapedFields, /repo=repo\\x3bone/);
+assert.match(formattedEscapedFields, /chart=chart\\x3dname@0\\x3b1/);
+assert.match(formattedEscapedFields, /release=ns\\x3b1\/rel\\x3d1/);
+assert.match(formattedEscapedFields, /url=http:\/\/host\/\?a\\x3d1\\x3bb\\x3d2/);
+
+const formattedWithoutClassification = formatAccessUrlFailure({detail: "browser crashed before classification"});
+assert.match(formattedWithoutClassification, /category=test-harness-diagnostic/);
+assert.match(formattedWithoutClassification, /detail=browser crashed before classification/);
+assert.doesNotMatch(formattedWithoutClassification, /category=legacy-category/);
+
+const formattedKnownCategoryWithoutDetail = formatAccessUrlFailure({
+  detail: "fallback detail stays visible",
+  classification: {
+    category: ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC,
+  },
+});
+assert.match(formattedKnownCategoryWithoutDetail, /category=ci-or-network-diagnostic/);
+assert.match(formattedKnownCategoryWithoutDetail, /detail=fallback detail stays visible/);
+
+const formattedLegacyClassification = formatAccessUrlFailure({
+  classification: {
+    category: "legacy-category",
+    detail: "legacy caller returned a removed category",
+  },
+});
+assert.match(formattedLegacyClassification, /category=test-harness-diagnostic/);
+assert.doesNotMatch(formattedLegacyClassification, /category=legacy-category/);
+
+const formattedZeroAttempts = formatAccessUrlFailure({
+  classification: classifyAccessUrlFailure({responseStatus: null}),
+  attemptCount: 0,
+});
+assert.match(formattedZeroAttempts, /attempts=0/);
+
+const emptySummary = {
+  totalCount: 0,
+  reachableCount: 0,
+  failureCount: 0,
+  reportableFailureCount: 0,
+  diagnosticFailureCount: 0,
+  categories: [],
+  diagnosticCategories: [],
+};
+assert.deepStrictEqual(summarizeAccessUrlOutcomes(), emptySummary);
+assert.deepStrictEqual(summarizeAccessUrlOutcomes(null), emptySummary);
+assert.deepStrictEqual(summarizeAccessUrlOutcomes([]), emptySummary);
+
+const reportableCategories = Object.values(ACCESS_URL_FAILURE_CATEGORIES)
+  .filter(category => isReportableAccessUrlCategory(category))
+  .sort();
+assert.deepStrictEqual(
+  reportableCategories,
+  [
+    ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE,
+    ACCESS_URL_FAILURE_CATEGORIES.SERVICE_ACCESS_URL_NOT_RENDERED,
+  ].sort(),
+  "only stable app-store/CasOS candidates should be reportable categories"
+);
+
+assert.strictEqual(
+  shouldFailAccessUrlOutcome({
+    reachable: false,
+    accessUrl: "http://demo-release.casos.invalid",
+    classification: classifyAccessUrlFailure({
+      accessUrlType: ACCESS_URL_TYPES.DOMAIN,
+      error: new Error("net::ERR_NAME_NOT_RESOLVED"),
+    }),
+  }),
+  true,
+  "a rendered Access URL that cannot be opened must fail the UI gate even when its category is diagnostic"
+);
+assert.strictEqual(
+  shouldFailAccessUrlOutcome({
+    reachable: false,
+    classification: classifyAccessUrlFailure({
+      appWorkloadDiagnostic: true,
+      detail: "release did not create a Service that can be associated with its Deployments",
+    }),
+  }),
+  false,
+  "diagnostics without a rendered Access URL should not pretend to be a failed click/open result"
+);
+
+assert.strictEqual(
+  classifyAccessUrlFailure({error: new Error("page.goto: Timeout 10000ms exceeded")}).scope,
+  ACCESS_URL_FAILURE_SCOPES.CI_OR_ENVIRONMENT
+);
+assert.strictEqual(
+  classifyAccessUrlFailure({responseStatus: 503, body: "service unavailable"}).scope,
+  ACCESS_URL_FAILURE_SCOPES.APP_WORKLOAD
+);
+assert.strictEqual(
+  classifyAccessUrlFailure({responseStatus: 200, body: "sample is ready"}).scope,
+  ACCESS_URL_FAILURE_SCOPES.TEST_HARNESS
+);
+
+const allReachableSummary = summarizeAccessUrlOutcomes([
+  {reachable: true, chartName: "podinfo", releaseName: "podinfo-ok-one"},
+  {reachable: true, chartName: "podinfo", releaseName: "podinfo-ok-two"},
+]);
+assert.strictEqual(allReachableSummary.totalCount, 2);
+assert.strictEqual(allReachableSummary.reachableCount, 2);
+assert.strictEqual(allReachableSummary.failureCount, 0);
+assert.deepStrictEqual(allReachableSummary.categories, []);
+assert.deepStrictEqual(allReachableSummary.diagnosticCategories, []);
+
+const observedOnlySummary = summarizeAccessUrlOutcomes([
+  {
+    reachable: true,
+    chartName: "podinfo",
+    chartVersion: "6.14.0",
+    releaseName: "podinfo-ok-demo",
+    namespace: "default",
+    accessUrl: "http://192.168.250.2:31080",
+  },
+  {
+    reachable: false,
+    chartName: "casos-access-url-clusterip",
+    chartVersion: "0.1.0",
+    releaseName: "as-ci-demo",
+    namespace: "default",
+    classification: classifyAccessUrlFailure({
+      serviceUrlMissing: true,
+      serviceType: "ClusterIP",
+      detail: "service row did not expose a matching Access URL",
+    }),
+  },
+  {
+    reachable: false,
+    chartName: "casos-access-url-nodeport-missing",
+    chartVersion: "0.1.0",
+    releaseName: "as-missing-demo",
+    namespace: "default",
+    deploymentName: "as-missing-demo",
+    serviceName: "as-missing-demo",
+    serviceType: "NodePort",
+    classification: classifyAccessUrlFailure({
+      serviceUrlMissing: true,
+      serviceType: "NodePort",
+      detail: "NodePort service row did not expose a matching Access URL",
+    }),
+  },
+  {
+    reachable: false,
+    chartName: "casos-access-url-no-endpoints",
+    chartVersion: "0.1.0",
+    releaseName: "as-ne-demo",
+    namespace: "default",
+    deploymentName: "as-ne-demo",
+    serviceName: "as-ne-demo",
+    serviceType: "NodePort",
+    accessUrl: "http://192.168.250.2:31081",
+    attemptCount: 2,
+    classification: classifyAccessUrlFailure({
+      error: new Error("net::ERR_CONNECTION_REFUSED at http://192.168.250.2:31081"),
+    }),
+  },
+]);
+
+assert.deepStrictEqual(
+  observedOnlySummary.categories.map(item => item.category).sort(),
+  [
+    ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE,
+    ACCESS_URL_FAILURE_CATEGORIES.SERVICE_ACCESS_URL_NOT_RENDERED,
+  ].sort()
+);
+assert.deepStrictEqual(
+  observedOnlySummary.diagnosticCategories.map(item => item.category),
+  [ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC]
+);
+assert.strictEqual(observedOnlySummary.failureCount, 3);
+assert.strictEqual(observedOnlySummary.reachableCount, 1);
+assert.strictEqual(observedOnlySummary.reportableFailureCount, 2);
+assert.strictEqual(observedOnlySummary.diagnosticFailureCount, 1);
+assert.ok(
+  observedOnlySummary.categories.every(item => item.examples.length > 0),
+  "every reported category must include at least one observed example"
+);
+assert.ok(
+  observedOnlySummary.diagnosticCategories.every(item => item.examples.length > 0),
+  "every diagnostic category must include at least one observed example"
+);
+assert.ok(
+  observedOnlySummary.categories.every(item => item.category !== ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC),
+  "unobserved categories must not be listed"
+);
+assert.ok(
+  observedOnlySummary.categories
+    .flatMap(item => item.examples)
+    .every(example => example.chartName && example.releaseName),
+  "summary examples should identify the app-store chart and release"
+);
+assert.ok(
+  observedOnlySummary.categories
+    .flatMap(item => item.examples)
+    .every(example => example.deploymentName && example.serviceName),
+  "reportable summary examples should identify the Deployment row and backing Service"
+);
+
+const repeatedFailureSummary = summarizeAccessUrlOutcomes(Array.from({length: 7}, (_, index) => ({
+  reachable: false,
+  chartName: `casos-access-url-no-endpoints-${index}`,
+  releaseName: `as-ne-${index}`,
+  classification: classifyAccessUrlFailure({error: new Error("net::ERR_CONNECTION_REFUSED")}),
+})));
+assert.strictEqual(repeatedFailureSummary.failureCount, 7);
+assert.strictEqual(repeatedFailureSummary.categories.length, 1);
+assert.strictEqual(repeatedFailureSummary.categories[0].category, ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE);
+assert.strictEqual(repeatedFailureSummary.categories[0].count, 7);
+assert.strictEqual(repeatedFailureSummary.categories[0].examples.length, 5);
+
+const diagnosticOnlySummary = summarizeAccessUrlOutcomes([
+  {
+    reachable: false,
+    chartName: "casos-probe-budget-demo",
+    releaseName: "as-probe-demo",
+    classification: classifyAccessUrlFailure({error: new Error("page.goto: Timeout 10000ms exceeded")}),
+  },
+  {
+    reachable: false,
+    chartName: "casos-access-url-http-503",
+    releaseName: "as-http-demo",
+    classification: classifyAccessUrlFailure({responseStatus: 503, body: "service unavailable"}),
+  },
+  {
+    reachable: false,
+    chartName: "casos-access-url-empty",
+    releaseName: "as-empty-demo",
+    classification: classifyAccessUrlFailure({responseStatus: 200, body: "   "}),
+  },
+]);
+assert.strictEqual(diagnosticOnlySummary.failureCount, 3);
+assert.strictEqual(diagnosticOnlySummary.reportableFailureCount, 0);
+assert.deepStrictEqual(diagnosticOnlySummary.categories, []);
+assert.deepStrictEqual(
+  diagnosticOnlySummary.diagnosticCategories.map(item => item.category).sort(),
+  [
+    ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC,
+    ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC,
+  ].sort()
+);
+assert.ok(
+  diagnosticOnlySummary.diagnosticCategories.every(item => item.examples.length > 0 && item.scope),
+  "diagnostic-only categories should retain examples and scope for debugging without reporting them as CasOS issues"
+);
+
+const legacyCategorySummary = summarizeAccessUrlOutcomes([
+  {
+    reachable: false,
+    chartName: "legacy-chart",
+    releaseName: "legacy-release",
+    classification: {
+      category: "legacy-category",
+      detail: "legacy caller returned a removed category",
+    },
+  },
+]);
+assert.deepStrictEqual(legacyCategorySummary.categories, []);
+assert.deepStrictEqual(
+  legacyCategorySummary.diagnosticCategories.map(item => item.category),
+  [ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC]
+);
+assert.ok(
+  legacyCategorySummary.diagnosticCategories
+    .flatMap(item => item.examples)
+    .every(example => example.detail.includes("legacy caller")),
+  "legacy classifications should keep their detail while being mapped to a defined category"
+);
+
+console.log("access URL diagnostics checks passed");

--- a/web/tests/ui/access-url-diagnostics.js
+++ b/web/tests/ui/access-url-diagnostics.js
@@ -1,0 +1,1 @@
+module.exports = require("../../scripts/access-url-diagnostics");

--- a/web/tests/ui/access-url-gate-check.js
+++ b/web/tests/ui/access-url-gate-check.js
@@ -1,0 +1,278 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const {spawnSync} = require("child_process");
+const {
+  ACCESS_URL_FAILURE_CATEGORIES,
+  ACCESS_URL_TYPES,
+  classifyAccessUrlFailure,
+} = require("./access-url-diagnostics");
+const {
+  buildAccessUrlSummaryPayload,
+} = require("../../scripts/app-store-access-url-summary");
+
+const gateScriptPath = path.join(__dirname, "../../scripts/app-store-access-url-gate.js");
+const gateTempDir = fs.mkdtempSync(path.join(__dirname, ".access-url-gate-"));
+
+function writeGatePayload(name, payload) {
+  const outputPath = path.join(gateTempDir, name);
+  fs.writeFileSync(outputPath, JSON.stringify(payload, null, 2), "utf8");
+  return outputPath;
+}
+
+function runGate(summaryPath, args = [], env = {}) {
+  const result = spawnSync(process.execPath, [gateScriptPath, summaryPath, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      APP_STORE_ACCESS_EXIT_CODE_PATH: path.join(gateTempDir, "missing-exit-code.txt"),
+      ...env,
+    },
+  });
+  return {
+    ...result,
+    outputText: `${result.stdout || ""}${result.stderr || ""}`,
+  };
+}
+
+try {
+  const normalizedPayload = buildAccessUrlSummaryPayload([
+    {
+      reachable: false,
+      chartName: "legacy-chart",
+      releaseName: "legacy-release",
+      classification: {
+        category: "legacy-category",
+      },
+    },
+  ]);
+  assert.strictEqual(
+    normalizedPayload.outcomes[0].classification.category,
+    ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC,
+    "summary payloads should normalize unrecognized categories before writing JSON"
+  );
+  assert.match(normalizedPayload.outcomes[0].classification.detail, /not recorded/);
+  assert.doesNotMatch(JSON.stringify(normalizedPayload), /unknown/i);
+
+  const reportableGate = runGate(writeGatePayload("reportable.json", {
+    version: 1,
+    outcomes: [
+      {
+        reachable: false,
+        chartName: "podinfo",
+        releaseName: "podinfo-reportable",
+        namespace: "default",
+        deploymentName: "podinfo",
+        serviceName: "podinfo",
+        serviceType: "NodePort",
+        accessUrl: "http://192.168.250.2:31080",
+        classification: classifyAccessUrlFailure({error: new Error("net::ERR_CONNECTION_REFUSED")}),
+      },
+    ],
+  }));
+  assert.strictEqual(reportableGate.status, 1, "reportable Access URL categories should fail the product gate");
+  assert.match(reportableGate.outputText, /::error::/);
+  assert.match(reportableGate.outputText, new RegExp(ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE));
+  assert.match(reportableGate.outputText, /deployment=default\/podinfo/);
+  assert.match(reportableGate.outputText, /service=default\/podinfo:NodePort/);
+  assert.doesNotMatch(reportableGate.outputText, /unknown/i);
+
+  const diagnosticGate = runGate(writeGatePayload("diagnostic.json", {
+    version: 1,
+    outcomes: [
+      {
+        reachable: false,
+        chartName: "podinfo",
+        releaseName: "podinfo-diagnostic",
+        classification: classifyAccessUrlFailure({responseStatus: 503, body: "service unavailable"}),
+      },
+    ],
+  }));
+  assert.strictEqual(diagnosticGate.status, 0, "diagnostic-only Access URL categories should not fail the product gate");
+  assert.match(diagnosticGate.outputText, /::warning::/);
+  assert.match(diagnosticGate.outputText, new RegExp(ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC));
+  assert.doesNotMatch(diagnosticGate.outputText, /::error::/);
+  assert.doesNotMatch(diagnosticGate.outputText, /unknown/i);
+
+  const unreachableDiagnosticGate = runGate(writeGatePayload("unreachable-diagnostic.json", {
+    version: 1,
+    outcomes: [
+      {
+        reachable: false,
+        chartName: "podinfo",
+        releaseName: "podinfo-domain",
+        namespace: "default",
+        deploymentName: "podinfo-domain",
+        serviceName: "podinfo-domain",
+        serviceType: "ClusterIP",
+        accessUrlType: ACCESS_URL_TYPES.DOMAIN,
+        accessUrl: "http://podinfo-domain.casos.invalid",
+        classification: classifyAccessUrlFailure({
+          accessUrlType: ACCESS_URL_TYPES.DOMAIN,
+          error: new Error("net::ERR_NAME_NOT_RESOLVED"),
+        }),
+      },
+    ],
+  }));
+  assert.strictEqual(
+    unreachableDiagnosticGate.status,
+    1,
+    "a rendered Access URL that cannot be opened should fail the UI gate even when the category is diagnostic"
+  );
+  assert.match(unreachableDiagnosticGate.outputText, /::error::/);
+  assert.match(unreachableDiagnosticGate.outputText, new RegExp(ACCESS_URL_FAILURE_CATEGORIES.DOMAIN_ACCESS_URL_UNREACHABLE));
+  assert.match(unreachableDiagnosticGate.outputText, /target=domain/);
+  assert.doesNotMatch(unreachableDiagnosticGate.outputText, /unknown/i);
+
+  const mixedDiagnosticGate = runGate(writeGatePayload("mixed-diagnostic.json", {
+    version: 1,
+    outcomes: [
+      {
+        reachable: false,
+        chartName: "podinfo",
+        releaseName: "podinfo-ci",
+        namespace: "default",
+        classification: classifyAccessUrlFailure({
+          appWorkloadDiagnostic: true,
+          detail: "release did not create a NodePort Service",
+        }),
+      },
+      {
+        reachable: false,
+        chartName: "podinfo",
+        releaseName: "podinfo-np0",
+        namespace: "default",
+        deploymentName: "podinfo-np0",
+        serviceName: "podinfo-np0",
+        serviceType: "NodePort",
+        accessUrlType: ACCESS_URL_TYPES.NODEPORT,
+        accessUrl: "http://192.168.223.2:31081",
+        classification: classifyAccessUrlFailure({
+          appWorkloadDiagnostic: true,
+          detail: "NodePort service has no running pods",
+        }),
+      },
+    ],
+  }));
+  assert.strictEqual(mixedDiagnosticGate.status, 1, "mixed diagnostics should fail only for the rendered URL outcome");
+  const mixedErrorLines = mixedDiagnosticGate.outputText
+    .split(/\r?\n/)
+    .filter(line => line.includes("::error::"));
+  assert.ok(mixedErrorLines.some(line => line.includes("podinfo-np0")));
+  assert.ok(
+    mixedErrorLines.every(line => !line.includes("podinfo-ci")),
+    "UI failure errors should not include no-URL diagnostic examples from the same category"
+  );
+
+  const missingArgValueGate = runGate(writeGatePayload("arg.json", {version: 1, outcomes: []}), [
+    "--fallback-category",
+    "--fallback-detail", "detail should not be consumed as a category",
+  ]);
+  assert.strictEqual(missingArgValueGate.status, 0, "invalid gate arguments should stay diagnostic");
+  assert.match(missingArgValueGate.outputText, /::warning::/);
+  assert.match(missingArgValueGate.outputText, /requires a value/);
+  assert.doesNotMatch(missingArgValueGate.outputText, /unknown/i);
+
+  const missingGate = runGate(path.join(gateTempDir, "missing.json"), [
+    "--fallback-category", ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC,
+    "--fallback-detail", "selector did not produce an App Store Access URL target",
+  ]);
+  assert.strictEqual(missingGate.status, 0, "missing summary should be a diagnostic warning, not a product failure");
+  assert.match(missingGate.outputText, /::warning::/);
+  assert.match(missingGate.outputText, new RegExp(ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC));
+  assert.doesNotMatch(missingGate.outputText, /unknown/i);
+
+  const invalidSummaryPath = path.join(gateTempDir, "invalid.json");
+  fs.writeFileSync(invalidSummaryPath, "{not json", "utf8");
+  const invalidGate = runGate(invalidSummaryPath, [
+    "--fallback-category", ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC,
+    "--fallback-detail", "QEMU worker preparation failed before the experiment",
+  ]);
+  assert.strictEqual(invalidGate.status, 0, "invalid summary should stay diagnostic");
+  assert.match(invalidGate.outputText, new RegExp(ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC));
+  assert.doesNotMatch(invalidGate.outputText, /unknown/i);
+  assert.strictEqual(fs.readFileSync(`${invalidSummaryPath}.original`, "utf8"), "{not json");
+
+  const qemuMissingSummaryPath = path.join(gateTempDir, "qemu-missing.json");
+  const qemuGate = runGate(qemuMissingSummaryPath, [], {
+    HAS_APP_STORE_ACCESS_TESTS: "true",
+    PREPARE_APP_STORE_WORKER_OUTCOME: "failure",
+  });
+  assert.strictEqual(qemuGate.status, 0, "QEMU setup failures should remain CI diagnostics");
+  assert.match(qemuGate.outputText, new RegExp(ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC));
+  assert.match(qemuGate.outputText, /QEMU worker VM preparation/);
+  assert.doesNotMatch(qemuGate.outputText, /unknown/i);
+
+  const unselectedGate = runGate(path.join(gateTempDir, "unselected.json"), [], {
+    HAS_APP_STORE_ACCESS_TESTS: "false",
+    PREPARE_APP_STORE_WORKER_OUTCOME: "skipped",
+  });
+  assert.strictEqual(unselectedGate.status, 0, "selector-empty access tests should stay diagnostic");
+  assert.match(unselectedGate.outputText, new RegExp(ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC));
+  assert.match(unselectedGate.outputText, /changed-path selector/);
+  assert.doesNotMatch(unselectedGate.outputText, /unknown/i);
+
+  const exitCodePath = path.join(gateTempDir, "experiment-exit-code.txt");
+  fs.writeFileSync(exitCodePath, "124\n", "utf8");
+  const playwrightExitGate = runGate(path.join(gateTempDir, "playwright-missing.json"), [], {
+    APP_STORE_ACCESS_EXIT_CODE_PATH: exitCodePath,
+    HAS_APP_STORE_ACCESS_TESTS: "true",
+    PREPARE_APP_STORE_WORKER_OUTCOME: "success",
+  });
+  assert.strictEqual(playwrightExitGate.status, 0, "Playwright harness exits should stay diagnostic without reportable summary evidence");
+  assert.match(playwrightExitGate.outputText, /exited with code 124/);
+  assert.match(playwrightExitGate.outputText, new RegExp(ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC));
+  assert.doesNotMatch(playwrightExitGate.outputText, /unknown/i);
+
+  const emptyExitCodePath = path.join(gateTempDir, "empty-exit-code.txt");
+  fs.writeFileSync(emptyExitCodePath, "", "utf8");
+  const emptyExitCodeGate = runGate(path.join(gateTempDir, "empty-exit-missing-summary.json"), [], {
+    APP_STORE_ACCESS_EXIT_CODE_PATH: emptyExitCodePath,
+    HAS_APP_STORE_ACCESS_TESTS: "true",
+    PREPARE_APP_STORE_WORKER_OUTCOME: "success",
+  });
+  assert.strictEqual(emptyExitCodeGate.status, 0, "empty exit-code files should stay generic diagnostics");
+  assert.match(emptyExitCodeGate.outputText, /did not produce a product-gate summary/);
+  assert.doesNotMatch(emptyExitCodeGate.outputText, /exited with code not-recorded/);
+  assert.doesNotMatch(emptyExitCodeGate.outputText, /unknown/i);
+
+  const malformedSummaryGate = runGate(writeGatePayload("malformed-summary.json", {
+    version: 1,
+    summary: {
+      totalCount: 1,
+      diagnosticCategories: [
+        {
+          count: 1,
+          examples: [{detail: "legacy summary bucket omitted category"}],
+        },
+      ],
+    },
+  }));
+  assert.strictEqual(malformedSummaryGate.status, 0, "malformed legacy summary buckets should stay diagnostic");
+  assert.match(malformedSummaryGate.outputText, new RegExp(ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC));
+  assert.doesNotMatch(malformedSummaryGate.outputText, /undefined/);
+  assert.doesNotMatch(malformedSummaryGate.outputText, /unknown/i);
+
+  const legacyGate = runGate(writeGatePayload("legacy.json", {
+    version: 1,
+    outcomes: [
+      {
+        reachable: false,
+        chartName: "legacy-chart",
+        releaseName: "legacy-release",
+        classification: {
+          category: "legacy-category",
+          detail: "legacy caller returned a removed category",
+        },
+      },
+    ],
+  }));
+  assert.strictEqual(legacyGate.status, 0, "legacy categories should normalize to a diagnostic gate result");
+  assert.match(legacyGate.outputText, new RegExp(ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC));
+  assert.doesNotMatch(legacyGate.outputText, /legacy-category/);
+  assert.doesNotMatch(legacyGate.outputText, /unknown/i);
+} finally {
+  fs.rmSync(gateTempDir, {force: true, recursive: true});
+}
+
+console.log("access URL gate checks passed");

--- a/web/tests/ui/app-store-access-url-click-evidence.js
+++ b/web/tests/ui/app-store-access-url-click-evidence.js
@@ -1,0 +1,80 @@
+async function markDeploymentAccessUrlClick(page, target) {
+  await page.evaluate(({rowKey, accessUrl, accessUrlType}) => {
+    const previousStyle = document.getElementById("casos-access-url-click-style");
+    if (previousStyle) {
+      previousStyle.remove();
+    }
+    const previousBanner = document.getElementById("casos-access-url-click-banner");
+    if (previousBanner) {
+      previousBanner.remove();
+    }
+    document
+      .querySelectorAll(".casos-access-url-click-row,.casos-access-url-click-link")
+      .forEach(element => element.classList.remove("casos-access-url-click-row", "casos-access-url-click-link"));
+
+    const style = document.createElement("style");
+    style.id = "casos-access-url-click-style";
+    style.textContent = `
+      .casos-access-url-click-row {
+        box-shadow: inset 0 0 0 3px #faad14 !important;
+        background: rgba(250, 173, 20, 0.10) !important;
+      }
+      .casos-access-url-click-link {
+        outline: 3px solid #faad14 !important;
+        outline-offset: 3px !important;
+        border-radius: 4px !important;
+        background: #fffbe6 !important;
+        color: #ad6800 !important;
+      }
+      #casos-access-url-click-banner {
+        position: fixed;
+        right: 24px;
+        bottom: 24px;
+        z-index: 2147483646;
+        max-width: min(520px, calc(100vw - 48px));
+        box-sizing: border-box;
+        padding: 10px 12px;
+        border: 2px solid #faad14;
+        border-radius: 8px;
+        background: #fffbe6;
+        color: #613400;
+        box-shadow: 0 10px 24px rgba(97, 52, 0, 0.20);
+        font-family: Arial, sans-serif;
+        font-size: 13px;
+        line-height: 1.4;
+        overflow-wrap: anywhere;
+      }
+      #casos-access-url-click-banner strong {
+        display: block;
+        margin-bottom: 2px;
+      }
+    `;
+    document.head.appendChild(style);
+
+    const row = Array.from(document.querySelectorAll("tr[data-row-key]"))
+      .find(element => element.getAttribute("data-row-key") === rowKey);
+    const link = row
+      ? Array.from(row.querySelectorAll("a[href]")).find(element => element.getAttribute("href") === accessUrl)
+      : null;
+    if (row) {
+      row.classList.add("casos-access-url-click-row");
+    }
+    if (link) {
+      link.classList.add("casos-access-url-click-link");
+    }
+
+    const banner = document.createElement("div");
+    banner.id = "casos-access-url-click-banner";
+    const title = document.createElement("strong");
+    title.textContent = `Clicking ${accessUrlType || "Access"} URL from Deployments`;
+    const url = document.createElement("div");
+    url.textContent = accessUrl || "url-not-recorded";
+    banner.appendChild(title);
+    banner.appendChild(url);
+    document.body.appendChild(banner);
+  }, target);
+}
+
+module.exports = {
+  markDeploymentAccessUrlClick,
+};

--- a/web/tests/ui/app-store-access-url-config.js
+++ b/web/tests/ui/app-store-access-url-config.js
@@ -1,0 +1,139 @@
+const fs = require("fs");
+const path = require("path");
+
+const API_ADD_HELM_REPO = "/api/add-helm-repo";
+const API_ADD_MACHINE = "/api/add-machine";
+const API_DELETE_HELM_REPO = "/api/delete-helm-repo";
+const API_DEPLOY_MACHINE_NODE = "/api/deploy-machine-node";
+const API_DELETE_MACHINE = "/api/delete-machine";
+const API_GET_DEPLOYMENTS = "/api/get-deployments";
+const API_GET_REPO_CHARTS = "/api/get-repo-charts";
+const API_GET_HELM_REPOS = "/api/get-helm-repos";
+const API_GET_HELM_RELEASES = "/api/get-helm-releases";
+const API_GET_INGRESSES = "/api/get-ingresses";
+const API_GET_MACHINE_NODE_LOGS = "/api/get-machine-node-logs";
+const API_GET_MACHINE_NODE_TASKS = "/api/get-machine-node-tasks";
+const API_GET_NODES = "/api/get-nodes";
+const API_GET_PODS = "/api/get-pods";
+const API_INSTALL_HELM_CHART_STREAM = "/api/install-helm-chart-stream";
+const API_GET_SERVICES = "/api/get-services";
+const API_UNINSTALL_HELM_RELEASE = "/api/uninstall-helm-release";
+
+const APP_STORE_SOURCE = "app-store";
+const APP_STORE_ROUTE = "/app-store";
+const DEPLOYMENTS_ROUTE = process.env.E2E_APP_STORE_DEPLOYMENTS_ROUTE || "/deployments";
+const MACHINES_ROUTE = "/machines";
+const NAMESPACE = process.env.E2E_APP_STORE_NAMESPACE || "default";
+const SERVICES_ROUTE = process.env.E2E_APP_STORE_SERVICES_ROUTE || "/services";
+const WORKER_READY_TIMEOUT_MS = readPositiveIntegerEnv("E2E_APP_STORE_WORKER_TIMEOUT_MS", 20 * 60 * 1000);
+const MACHINE_CREATE_TIMEOUT_MS = readPositiveIntegerEnv("E2E_APP_STORE_MACHINE_CREATE_TIMEOUT_MS", 2 * 60 * 1000);
+const UI_NAVIGATION_TIMEOUT_MS = readPositiveIntegerEnv("E2E_APP_STORE_UI_NAVIGATION_TIMEOUT_MS", 30 * 1000);
+const WORKER_TASK_POLL_INTERVAL_MS = readPositiveIntegerEnv("E2E_APP_STORE_WORKER_TASK_POLL_INTERVAL_MS", 5000);
+const WORKER_NODE_POLL_INTERVAL_MS = readPositiveIntegerEnv("E2E_APP_STORE_WORKER_NODE_POLL_INTERVAL_MS", 3000);
+const HELM_READY_TIMEOUT_MS = readPositiveIntegerEnv("E2E_APP_STORE_HELM_TIMEOUT_MS", 3 * 60 * 1000);
+const ACCESS_READY_TIMEOUT_MS = readPositiveIntegerEnv("E2E_APP_STORE_ACCESS_TIMEOUT_MS", 2 * 60 * 1000);
+const ACCESS_EXPERIMENT_TIMEOUT_MS = readPositiveIntegerEnv("E2E_APP_STORE_EXPERIMENT_ACCESS_TIMEOUT_MS", 30 * 1000);
+const NODE_PORT_MIN = 30000;
+const NODE_PORT_MAX = 32767;
+const APP_STORE_NODE_PORT = readNodePortEnv("E2E_APP_STORE_NODE_PORT", 31080);
+const APP_STORE_NO_PODS_NODE_PORT = readNodePortEnv(
+  "E2E_APP_STORE_UNROUTED_NODE_PORT",
+  APP_STORE_NODE_PORT === NODE_PORT_MAX ? NODE_PORT_MAX - 1 : APP_STORE_NODE_PORT + 1
+);
+if (APP_STORE_NO_PODS_NODE_PORT === APP_STORE_NODE_PORT) {
+  throw new Error("E2E_APP_STORE_UNROUTED_NODE_PORT must differ from E2E_APP_STORE_NODE_PORT");
+}
+const E2E_APISERVER_URL = process.env.E2E_APISERVER_URL || "https://127.0.0.1:16443";
+const E2E_MACHINE_OWNER = process.env.E2E_MACHINE_OWNER || "admin";
+const SSH_HOST = process.env.E2E_APP_STORE_SSH_HOST || "127.0.0.1";
+const SSH_PORT = readPositiveIntegerEnv("E2E_APP_STORE_SSH_PORT", 22);
+const SSH_USER = process.env.E2E_APP_STORE_SSH_USER || "";
+const SSH_PRIVATE_KEY = process.env.E2E_APP_STORE_SSH_PRIVATE_KEY || readSshPrivateKeyFromPath();
+const hasWorkerSshConfig = Boolean(SSH_USER && SSH_PRIVATE_KEY);
+const WORKER_DIAGNOSTICS_LOG = path.join(process.cwd(), "ui-app-store-worker-diagnostics.log");
+const RETRYABLE_INFRASTRUCTURE_PATTERNS = Object.freeze([
+  /connection refused/i,
+  /invalid connection/i,
+  /dial tcp .*3306/i,
+  /cluster not ready/i,
+  /temporarily unavailable/i,
+]);
+const RETRYABLE_HTTP_STATUS_CODES = Object.freeze([408, 429]);
+const LOG_PROGRESS_INTERVAL_MS = 30 * 1000;
+
+function readPositiveIntegerEnv(name, fallback) {
+  const raw = process.env[name];
+  const value = raw === undefined || raw === "" ? fallback : Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer when set`);
+  }
+  return value;
+}
+
+function readNodePortEnv(name, fallback) {
+  const raw = process.env[name];
+  const value = raw === undefined || raw === "" ? fallback : Number(raw);
+  if (!Number.isInteger(value) || value < NODE_PORT_MIN || value > NODE_PORT_MAX) {
+    throw new Error(`${name} must be an integer between ${NODE_PORT_MIN} and ${NODE_PORT_MAX} when set`);
+  }
+  return value;
+}
+
+function readSshPrivateKeyFromPath() {
+  const keyPath = process.env.E2E_APP_STORE_SSH_KEY_PATH;
+  if (!keyPath) {
+    return "";
+  }
+  try {
+    return fs.readFileSync(keyPath, "utf8");
+  } catch (error) {
+    throw new Error(`failed to read E2E_APP_STORE_SSH_KEY_PATH ${keyPath}: ${error.message}`, {cause: error});
+  }
+}
+
+module.exports = {
+  ACCESS_EXPERIMENT_TIMEOUT_MS,
+  ACCESS_READY_TIMEOUT_MS,
+  API_ADD_HELM_REPO,
+  API_ADD_MACHINE,
+  API_DELETE_HELM_REPO,
+  API_DEPLOY_MACHINE_NODE,
+  API_DELETE_MACHINE,
+  API_GET_DEPLOYMENTS,
+  API_GET_REPO_CHARTS,
+  API_GET_HELM_REPOS,
+  API_GET_HELM_RELEASES,
+  API_GET_INGRESSES,
+  API_GET_MACHINE_NODE_LOGS,
+  API_GET_MACHINE_NODE_TASKS,
+  API_GET_NODES,
+  API_GET_PODS,
+  API_INSTALL_HELM_CHART_STREAM,
+  API_GET_SERVICES,
+  API_UNINSTALL_HELM_RELEASE,
+  APP_STORE_NODE_PORT,
+  APP_STORE_NO_PODS_NODE_PORT,
+  APP_STORE_ROUTE,
+  APP_STORE_SOURCE,
+  DEPLOYMENTS_ROUTE,
+  E2E_APISERVER_URL,
+  E2E_MACHINE_OWNER,
+  HELM_READY_TIMEOUT_MS,
+  LOG_PROGRESS_INTERVAL_MS,
+  MACHINE_CREATE_TIMEOUT_MS,
+  MACHINES_ROUTE,
+  NAMESPACE,
+  RETRYABLE_INFRASTRUCTURE_PATTERNS,
+  RETRYABLE_HTTP_STATUS_CODES,
+  SSH_HOST,
+  SSH_PORT,
+  SSH_PRIVATE_KEY,
+  SSH_USER,
+  SERVICES_ROUTE,
+  UI_NAVIGATION_TIMEOUT_MS,
+  WORKER_DIAGNOSTICS_LOG,
+  WORKER_NODE_POLL_INTERVAL_MS,
+  WORKER_READY_TIMEOUT_MS,
+  WORKER_TASK_POLL_INTERVAL_MS,
+  hasWorkerSshConfig,
+};

--- a/web/tests/ui/app-store-access-url-deployment-probe.js
+++ b/web/tests/ui/app-store-access-url-deployment-probe.js
@@ -1,0 +1,388 @@
+const {expect} = require("@playwright/test");
+const {
+  ACCESS_URL_TYPES,
+  classifyAccessUrlFailure,
+} = require("./access-url-diagnostics");
+const {
+  API_GET_DEPLOYMENTS,
+  API_GET_INGRESSES,
+  API_GET_NODES,
+  API_GET_SERVICES,
+  DEPLOYMENTS_ROUTE,
+  NAMESPACE,
+} = require("./app-store-access-url-config");
+const {readOkJson} = require("./app-store-access-url-http");
+const {
+  cssAttributeValue,
+  readNamespacedList,
+} = require("./app-store-access-url-probe-utils");
+const {
+  markDeploymentAccessUrlClick,
+} = require("./app-store-access-url-click-evidence");
+
+const RESOURCE_ROW_VISIBLE_TIMEOUT_MS = 60 * 1000;
+
+async function findDeploymentAccessUrl(page, releaseContext) {
+  let evidence;
+  try {
+    evidence = await readDeploymentAccessEvidence(page, releaseContext);
+  } catch (error) {
+    return {
+      ...emptyDeploymentAccessTarget(),
+      classification: classifyAccessUrlFailure({
+        detail: `failed to read Deployment Access URL evidence: ${error.message}`,
+      }),
+    };
+  }
+
+  const expectedTargets = findExpectedDeploymentAccessTargets({...evidence, releaseContext});
+  if (expectedTargets.length === 0) {
+    return {
+      ...emptyDeploymentAccessTarget(),
+      classification: classifyMissingDeploymentAccessTarget(evidence, releaseContext),
+    };
+  }
+  let selectedTarget = null;
+  if (releaseContext.expectedAccessUrlType) {
+    selectedTarget = expectedTargets.find(target => target.accessUrlType === releaseContext.expectedAccessUrlType) || null;
+    if (!selectedTarget) {
+      return {
+        ...emptyDeploymentAccessTarget(),
+        accessUrlType: releaseContext.expectedAccessUrlType,
+        classification: classifyAccessUrlFailure({
+          serviceUrlMissing: true,
+          accessUrlType: releaseContext.expectedAccessUrlType,
+          detail: `release ${releaseContext.namespace || NAMESPACE}/${releaseContext.releaseName} expected a ${releaseContext.expectedAccessUrlType} Deployment Access URL, but only discovered target types: ${formatDiscoveredAccessUrlTypes(expectedTargets)}`,
+        }),
+      };
+    }
+  }
+  selectedTarget = selectedTarget || expectedTargets.find(target => target.nodePort === releaseContext.nodePort) || expectedTargets[0];
+
+  try {
+    await page.goto(DEPLOYMENTS_ROUTE);
+    await page.waitForLoadState("networkidle");
+  } catch (error) {
+    return {
+      ...selectedTarget,
+      classification: classifyAccessUrlFailure({
+        detail: `navigation to deployments route failed: ${error.message}`,
+      }),
+    };
+  }
+
+  for (const target of expectedTargets) {
+    const rowKey = `${target.namespace}/${target.deploymentName}`;
+    const row = page.locator(`tr[data-row-key="${cssAttributeValue(rowKey)}"]`);
+    try {
+      await expect(row).toBeVisible({timeout: RESOURCE_ROW_VISIBLE_TIMEOUT_MS});
+      const accessLink = row.locator(`a[href="${cssAttributeValue(target.accessUrl)}"]`);
+      await expect(accessLink, `Deployment row ${rowKey} should render Access URL ${target.accessUrl}`).toBeVisible();
+    } catch (error) {
+      return {
+        ...target,
+        classification: classifyAccessUrlFailure({
+          serviceUrlMissing: true,
+          accessUrlType: target.accessUrlType,
+          serviceType: target.serviceType,
+          detail: `Deployment page row ${rowKey} did not render ${target.accessUrlType} Access URL ${target.accessUrl} for service ${target.namespace}/${target.serviceName}: ${error.message}`,
+        }),
+      };
+    }
+  }
+
+  return selectedTarget;
+}
+
+async function openDeploymentAccessUrlPage(page, target, {timeoutMs = 5000} = {}) {
+  if (!target?.deploymentName || !target?.namespace || !target?.accessUrl) {
+    throw new Error("Deployment Access URL click needs deploymentName, namespace, and accessUrl");
+  }
+  await page.goto(DEPLOYMENTS_ROUTE);
+  await page.waitForLoadState("networkidle");
+  const rowKey = `${target.namespace}/${target.deploymentName}`;
+  const row = page.locator(`tr[data-row-key="${cssAttributeValue(rowKey)}"]`);
+  const accessLink = row.locator(`a[href="${cssAttributeValue(target.accessUrl)}"]`);
+  await expect(row).toBeVisible({timeout: RESOURCE_ROW_VISIBLE_TIMEOUT_MS});
+  await expect(accessLink, `Deployment row ${rowKey} should expose clickable Access URL ${target.accessUrl}`).toBeVisible();
+  await accessLink.scrollIntoViewIfNeeded({timeout: Math.min(timeoutMs, RESOURCE_ROW_VISIBLE_TIMEOUT_MS)})
+    .catch(error => {
+      console.warn(`Failed to scroll Deployment Access URL ${rowKey} into view: ${error.message}`);
+    });
+  await markDeploymentAccessUrlClick(page, {
+    rowKey,
+    accessUrl: target.accessUrl,
+    accessUrlType: target.accessUrlType,
+  }).catch(error => {
+    console.warn(`Failed to mark Deployment Access URL click ${rowKey}: ${error.message}`);
+  });
+  await page.waitForTimeout(250);
+  const popupPromise = page.waitForEvent("popup", {timeout: timeoutMs}).catch(() => null);
+  await accessLink.click({timeout: timeoutMs});
+  const accessPage = await popupPromise;
+  if (accessPage) {
+    await accessPage.bringToFront().catch(() => {});
+  }
+  return accessPage;
+}
+
+function emptyDeploymentAccessTarget() {
+  return {
+    deploymentName: "",
+    serviceName: "",
+    serviceType: "",
+    accessUrlType: "",
+    ingressName: "",
+    ingressHost: "",
+  };
+}
+
+function formatDiscoveredAccessUrlTypes(targets) {
+  const types = [...new Set((targets || []).map(target => target.accessUrlType || "type-not-recorded"))];
+  return types.length > 0 ? types.join(",") : "none";
+}
+
+async function readDeploymentAccessEvidence(page, releaseContext) {
+  const namespace = releaseContext.namespace || NAMESPACE;
+  const [deployments, services, ingresses, nodeIP] = await Promise.all([
+    readNamespacedList(page, API_GET_DEPLOYMENTS, namespace, "get-deployments"),
+    readNamespacedList(page, API_GET_SERVICES, namespace, "get-services"),
+    readNamespacedList(page, API_GET_INGRESSES, namespace, "get-ingresses"),
+    readNodeIP(page),
+  ]);
+  return {deployments, services, ingresses, nodeIP};
+}
+
+function findExpectedDeploymentAccessTargets({deployments = [], services = [], ingresses = [], nodeIP, releaseContext = {}}) {
+  const namespace = releaseContext.namespace || NAMESPACE;
+  const targets = [];
+  const seen = new Set();
+  collectNodePortDeploymentAccessTargets({deployments, services, nodeIP, namespace, releaseContext, targets, seen});
+  collectDomainDeploymentAccessTargets({deployments, services, ingresses, namespace, releaseContext, targets, seen});
+  return targets.sort(compareDeploymentAccessTargets);
+}
+
+function collectNodePortDeploymentAccessTargets({deployments, services, nodeIP, namespace, releaseContext, targets, seen}) {
+  if (!nodeIP) {
+    return;
+  }
+  for (const service of services) {
+    if (!isNodePortServiceForRelease(service, namespace, releaseContext)) {
+      continue;
+    }
+    const matchingDeployments = deployments.filter(deployment =>
+      deployment.namespace === namespace &&
+      serviceSelectorMatchesDeployment(service.selector, deployment.selector)
+    );
+    for (const deployment of matchingDeployments) {
+      for (const port of service.ports || []) {
+        if (!port.nodePort) {
+          continue;
+        }
+        const accessUrl = `http://${nodeIP}:${port.nodePort}`;
+        const key = `${namespace}/${deployment.name}/${service.name}/${port.nodePort}`;
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+        targets.push({
+          deploymentName: deployment.name,
+          namespace,
+          serviceName: service.name,
+          serviceType: service.type,
+          accessUrlType: ACCESS_URL_TYPES.NODEPORT,
+          accessUrl,
+          nodePort: port.nodePort,
+        });
+      }
+    }
+  }
+}
+
+function collectDomainDeploymentAccessTargets({deployments, services, ingresses, namespace, releaseContext, targets, seen}) {
+  const serviceByName = new Map((services || [])
+    .filter(service => service.namespace === namespace)
+    .map(service => [service.name, service]));
+
+  for (const deployment of deployments || []) {
+    if (deployment.namespace !== namespace || !isReleaseRelatedDeployment(deployment, releaseContext)) {
+      continue;
+    }
+    // Mirror DeploymentListPage.getAccessUrls: domain links are rendered from rule.serviceName.
+    const deployServiceNames = new Set((services || [])
+      .filter(service => service.namespace === namespace && service.selector?.app === deployment.name)
+      .map(service => service.name));
+    deployServiceNames.add(deployment.name);
+
+    for (const ingress of ingresses || []) {
+      if (ingress.namespace !== namespace || !isReleaseRelatedIngress(ingress, releaseContext)) {
+        continue;
+      }
+      for (const rule of ingress.rules || []) {
+        if (!rule.host || !rule.serviceName || !deployServiceNames.has(rule.serviceName)) {
+          continue;
+        }
+        const service = serviceByName.get(rule.serviceName);
+        const path = rule.path && rule.path !== "/" ? rule.path : "";
+        const accessUrl = `http://${rule.host}${path}`;
+        const key = `${namespace}/${deployment.name}/${ingress.name}/${rule.serviceName}/${accessUrl}`;
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+        targets.push({
+          deploymentName: deployment.name,
+          namespace,
+          serviceName: rule.serviceName,
+          serviceType: service?.type || "",
+          accessUrlType: ACCESS_URL_TYPES.DOMAIN,
+          accessUrl,
+          ingressName: ingress.name,
+          ingressHost: rule.host,
+        });
+      }
+    }
+  }
+}
+
+function compareDeploymentAccessTargets(left, right) {
+  return compareString(left.deploymentName, right.deploymentName) ||
+    compareString(left.serviceName, right.serviceName) ||
+    accessUrlTypeRank(left.accessUrlType) - accessUrlTypeRank(right.accessUrlType) ||
+    compareString(left.accessUrl, right.accessUrl) ||
+    (left.nodePort || 0) - (right.nodePort || 0);
+}
+
+function accessUrlTypeRank(accessUrlType) {
+  if (accessUrlType === ACCESS_URL_TYPES.NODEPORT) {
+    return 0;
+  }
+  if (accessUrlType === ACCESS_URL_TYPES.DOMAIN) {
+    return 1;
+  }
+  return 2;
+}
+
+function compareString(left, right) {
+  const leftText = String(left || "");
+  const rightText = String(right || "");
+  if (leftText === rightText) {
+    return 0;
+  }
+  return leftText < rightText ? -1 : 1;
+}
+
+function isNodePortServiceForRelease(service, namespace, releaseContext) {
+  return service?.namespace === namespace &&
+    service.type === "NodePort" &&
+    Array.isArray(service.ports) &&
+    service.ports.some(port => port.nodePort) &&
+    isReleaseRelatedService(service, releaseContext);
+}
+
+function isReleaseRelatedService(service, releaseContext = {}) {
+  const releaseName = releaseContext.releaseName || "";
+  if (!releaseName) {
+    return true;
+  }
+  if (service.name === releaseName || service.name.startsWith(`${releaseName}-`)) {
+    return true;
+  }
+  if (releaseContext.serviceName && service.name === releaseContext.serviceName) {
+    return true;
+  }
+  return Object.values(service.selector || {}).some(value => value === releaseName);
+}
+
+function isReleaseRelatedDeployment(deployment, releaseContext = {}) {
+  const releaseName = releaseContext.releaseName || "";
+  if (!releaseName) {
+    return true;
+  }
+  if (deployment.name === releaseName || deployment.name.startsWith(`${releaseName}-`)) {
+    return true;
+  }
+  return Object.values(deployment.selector || {}).some(value => value === releaseName);
+}
+
+function isReleaseRelatedIngress(ingress, releaseContext = {}) {
+  const releaseName = releaseContext.releaseName || "";
+  if (!releaseName) {
+    return true;
+  }
+  if (ingress.name === releaseName || ingress.name.startsWith(`${releaseName}-`)) {
+    return true;
+  }
+  return (ingress.rules || []).some(rule =>
+    rule.serviceName === releaseName ||
+    String(rule.serviceName || "").startsWith(`${releaseName}-`)
+  );
+}
+
+function serviceSelectorMatchesDeployment(serviceSelector = {}, deploymentSelector = {}) {
+  const entries = Object.entries(serviceSelector || {});
+  if (entries.length === 0) {
+    return false;
+  }
+  return entries.every(([key, value]) => deploymentSelector?.[key] === value);
+}
+
+function classifyMissingDeploymentAccessTarget(evidence, releaseContext) {
+  const namespace = releaseContext.namespace || NAMESPACE;
+  if (!evidence.nodeIP) {
+    return classifyAccessUrlFailure({
+      detail: "Deployment Access URL could not be evaluated because CasOS did not report a worker node IP",
+    });
+  }
+
+  const relatedServices = (evidence.services || []).filter(service =>
+    service.namespace === namespace && isReleaseRelatedService(service, releaseContext)
+  );
+  if (relatedServices.length === 0) {
+    return classifyAccessUrlFailure({
+      appWorkloadDiagnostic: true,
+      detail: `release ${namespace}/${releaseContext.releaseName} did not create a Service that can be associated with its Deployments`,
+    });
+  }
+
+  const nodePortServices = relatedServices.filter(service => service.type === "NodePort");
+  if (nodePortServices.length === 0) {
+    const domainIngresses = (evidence.ingresses || []).filter(ingress =>
+      ingress.namespace === namespace &&
+      (ingress.rules || []).some(rule => rule.host && relatedServices.some(service => service.name === rule.serviceName))
+    );
+    if (domainIngresses.length > 0) {
+      return classifyAccessUrlFailure({
+        appWorkloadDiagnostic: true,
+        detail: `release ${namespace}/${releaseContext.releaseName} created Ingress domain rules, but none matched a listed Deployment Access URL row by rule serviceName`,
+      });
+    }
+    return classifyAccessUrlFailure({
+      appWorkloadDiagnostic: true,
+      detail: `release ${namespace}/${releaseContext.releaseName} did not create a NodePort Service for Deployment Access URL rendering; service types: ${relatedServices.map(service => `${service.name}:${service.type}`).join(",")}`,
+    });
+  }
+
+  return classifyAccessUrlFailure({
+    appWorkloadDiagnostic: true,
+    detail: `release ${namespace}/${releaseContext.releaseName} created NodePort Services, but none selected a listed Deployment by selector`,
+  });
+}
+
+async function readNodeIP(page) {
+  const response = await page.context().request.get(API_GET_NODES);
+  const body = await readOkJson(response, "get-nodes");
+  const nodes = Array.isArray(body.data) ? body.data : [];
+  const nodeWithExternalIP = nodes.find(node => node.externalIP);
+  if (nodeWithExternalIP) {
+    return nodeWithExternalIP.externalIP;
+  }
+  const nodeWithInternalIP = nodes.find(node => node.internalIP);
+  return nodeWithInternalIP?.internalIP || "";
+}
+
+module.exports = {
+  findDeploymentAccessUrl,
+  findExpectedDeploymentAccessTargets,
+  openDeploymentAccessUrlPage,
+};

--- a/web/tests/ui/app-store-access-url-helm.js
+++ b/web/tests/ui/app-store-access-url-helm.js
@@ -1,0 +1,239 @@
+const {expect} = require("@playwright/test");
+const {expectOkJson} = require("./e2e-helpers");
+const {
+  API_ADD_HELM_REPO,
+  API_DELETE_HELM_REPO,
+  API_GET_HELM_REPOS,
+  API_GET_HELM_RELEASES,
+  API_GET_REPO_CHARTS,
+  API_INSTALL_HELM_CHART_STREAM,
+  API_UNINSTALL_HELM_RELEASE,
+  APP_STORE_ROUTE,
+  APP_STORE_SOURCE,
+  HELM_READY_TIMEOUT_MS,
+  LOG_PROGRESS_INTERVAL_MS,
+  NAMESPACE,
+} = require("./app-store-access-url-config");
+const {
+  compactRelease,
+  logAppStoreProgress,
+} = require("./app-store-access-url-log");
+const {
+  RetryableInfrastructureError,
+  isIgnorableCleanupMessage,
+  isRetryableHttpStatus,
+  isRetryableInfrastructureError,
+  readOkJson,
+  responseErrorMessage,
+} = require("./app-store-access-url-http");
+const {
+  escapeRegExp,
+  routeUrlPattern,
+} = require("./app-store-access-url-routes");
+
+const HELM_RELEASE_POLL_INTERVAL_MS = 3000;
+const HELM_CLEANUP_TIMEOUT_MS = 15 * 1000;
+const HELM_CLEANUP_POLL_INTERVAL_MS = 2000;
+
+async function getHelmReleases(page) {
+  const response = await page.context().request.get(`${API_GET_HELM_RELEASES}?namespace=${NAMESPACE}`);
+  const body = await readOkJson(response, "get-helm-releases");
+  return body.data || [];
+}
+
+async function addRepoFromAppStore(page, repoName, repoURL, expectedCharts = []) {
+  await page.goto(APP_STORE_ROUTE);
+  await page.waitForLoadState("networkidle");
+  await expect(page).toHaveURL(routeUrlPattern(APP_STORE_ROUTE));
+  await page.getByRole("button", {name: "Add Repo"}).click();
+  const dialog = page.getByRole("dialog", {name: "Add Helm Repo"});
+  await expect(dialog).toBeVisible();
+  await dialog.getByLabel(/Repo name/).fill(repoName);
+  await dialog.getByLabel(/Repo URL/).fill(repoURL);
+
+  const addRepo = page.waitForResponse(response =>
+    response.url().includes(API_ADD_HELM_REPO) && response.request().method() === "POST"
+  );
+  await dialog.getByRole("button", {name: "OK"}).click();
+  const body = await expectOkJson(await addRepo);
+  await expect(dialog).toBeHidden();
+
+  const repos = await page.context().request.get(API_GET_HELM_REPOS);
+  const reposBody = await expectOkJson(repos);
+  const repo = (reposBody.data || []).find(item => item.name === repoName);
+  expect(repo, `repo ${repoName} should be persisted`).toBeTruthy();
+  await expect(page.getByText(repoName, {exact: true})).toBeVisible();
+  const charts = page.waitForResponse(
+    response => response.url().includes(API_GET_REPO_CHARTS) && response.request().method() === "GET",
+    {timeout: HELM_READY_TIMEOUT_MS}
+  );
+  await page.getByText(repoName, {exact: true}).click();
+  const chartsBody = await expectOkJson(await charts);
+  const listedCharts = expectedCharts.map(expectedChart => {
+    const chart = (chartsBody.data || []).find(item =>
+      item.name === expectedChart.chartName &&
+      (!expectedChart.chartVersion || item.version === expectedChart.chartVersion)
+    );
+    const chartLabel = expectedChart.chartVersion
+      ? `${expectedChart.chartName}@${expectedChart.chartVersion}`
+      : expectedChart.chartName;
+    expect(
+      chart,
+      `${chartLabel} must be listed in the app store repo before installation`
+    ).toBeTruthy();
+    return {
+      ...expectedChart,
+      source: APP_STORE_SOURCE,
+      repoId: repo.id || body.data?.id || null,
+      repoName,
+      repoURL,
+      chartName: chart.name,
+      chartVersion: chart.version,
+      namespace: NAMESPACE,
+    };
+  });
+  return {
+    repoId: repo.id || body.data?.id || null,
+    repoName,
+    repoURL,
+    charts: listedCharts,
+  };
+}
+
+async function installChartFromAppStore(page, releaseName, appStoreChart) {
+  expect(appStoreChart.source).toBe(APP_STORE_SOURCE);
+  expect(appStoreChart.chartName).toBeTruthy();
+  expect(appStoreChart.chartVersion).toBeTruthy();
+  const chartCard = page.locator(".ant-card-hoverable")
+    .filter({hasText: appStoreChart.chartName})
+    .filter({hasText: appStoreChart.chartVersion})
+    .filter({has: page.getByRole("button", {name: "Install"})});
+  await expect(chartCard, "the chart must be uniquely selected from the App Store chart list").toHaveCount(1);
+  await expect(chartCard, "the chart must be selected from the App Store chart list").toBeVisible();
+  await chartCard.getByRole("button", {name: "Install"}).click();
+
+  const dialog = page.getByRole("dialog", {name: new RegExp(`Install chart\\s+${escapeRegExp(appStoreChart.chartName)}`)});
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText(appStoreChart.repoURL, {exact: true})).toBeVisible();
+  await dialog.getByLabel("Release name").fill(releaseName);
+  const valuesTextarea = dialog.locator("textarea");
+  await expect(valuesTextarea).toBeVisible({timeout: HELM_READY_TIMEOUT_MS});
+  const valuesYAML = resolveChartValuesYAML(appStoreChart, releaseName);
+  if (valuesYAML) {
+    await valuesTextarea.fill(valuesYAML);
+  }
+
+  const installResponsePromise = page.waitForResponse(response =>
+    response.url().includes(API_INSTALL_HELM_CHART_STREAM) && response.request().method() === "POST"
+  );
+  await dialog.getByRole("button", {name: "Install"}).click();
+  const installResponse = await installResponsePromise;
+  expect(installResponse.ok()).toBeTruthy();
+  await expect(dialog).toBeHidden({timeout: HELM_READY_TIMEOUT_MS});
+  return {...appStoreChart, releaseName};
+}
+
+function resolveChartValuesYAML(appStoreChart, releaseName) {
+  if (typeof appStoreChart.valuesYAML === "function") {
+    return appStoreChart.valuesYAML({releaseName, appStoreChart});
+  }
+  return appStoreChart.valuesYAML;
+}
+
+async function waitForHelmRelease(page, releaseContext) {
+  const started = Date.now();
+  let lastReleases = [];
+  let lastRetryableError = "";
+  let lastProgressLogAt = 0;
+  while (Date.now() - started < HELM_READY_TIMEOUT_MS) {
+    try {
+      lastReleases = await getHelmReleases(page);
+      const release = lastReleases.find(item => item.name === releaseContext.releaseName);
+      if (release?.status === "deployed") {
+        expect(release).toMatchObject({
+          namespace: releaseContext.namespace,
+          chart: `${releaseContext.chartName}-${releaseContext.chartVersion}`,
+        });
+        return release;
+      }
+      lastRetryableError = "";
+    } catch (error) {
+      if (!isRetryableInfrastructureError(error)) {
+        throw error;
+      }
+      lastRetryableError = error.message;
+    }
+    const now = Date.now();
+    if (now - lastProgressLogAt >= LOG_PROGRESS_INTERVAL_MS) {
+      lastProgressLogAt = now;
+      logAppStoreProgress("wait-helm-release", started, {
+        release: compactRelease(lastReleases.find(item => item.name === releaseContext.releaseName)),
+        lastRetryableError,
+      });
+    }
+    await page.waitForTimeout(HELM_RELEASE_POLL_INTERVAL_MS);
+  }
+  throw new Error(`release ${releaseContext.namespace}/${releaseContext.releaseName} from ${releaseContext.source} chart ${releaseContext.chartName}@${releaseContext.chartVersion} was not deployed; releases: ${JSON.stringify(lastReleases)}${lastRetryableError ? `; last retryable error: ${lastRetryableError}` : ""}`);
+}
+
+async function cleanupHelmRelease(page, releaseName) {
+  const started = Date.now();
+  let lastError = "";
+  while (Date.now() - started < HELM_CLEANUP_TIMEOUT_MS) {
+    try {
+      const response = await page.context().request.post(API_UNINSTALL_HELM_RELEASE, {
+        data: {releaseName, namespace: NAMESPACE},
+      });
+      if (!response.ok()) {
+        const message = responseErrorMessage(`uninstall release ${releaseName}`, response);
+        if (response.status() === 404) {
+          return;
+        }
+        if (isRetryableHttpStatus(response.status())) {
+          throw new RetryableInfrastructureError(message);
+        }
+        throw new Error(message);
+      }
+      try {
+        await readOkJson(response, `uninstall release ${releaseName}`);
+        return;
+      } catch (error) {
+        if (isIgnorableCleanupMessage(error.message)) {
+          return;
+        }
+        if (isRetryableInfrastructureError(error)) {
+          throw error;
+        }
+        throw error;
+      }
+    } catch (error) {
+      if (!isRetryableInfrastructureError(error)) {
+        if (isIgnorableCleanupMessage(error.message)) {
+          return;
+        }
+        throw error;
+      }
+      lastError = error.message;
+      await page.waitForTimeout(HELM_CLEANUP_POLL_INTERVAL_MS);
+    }
+  }
+  if (lastError) {
+    console.warn(`Skipping Helm release cleanup for ${releaseName}: ${lastError}`);
+  }
+}
+
+async function deleteHelmRepo(page, repoId) {
+  if (!repoId) {
+    return;
+  }
+  const response = await page.context().request.post(`${API_DELETE_HELM_REPO}?id=${repoId}`);
+  await expectOkJson(response);
+}
+
+module.exports = {
+  addRepoFromAppStore,
+  cleanupHelmRelease,
+  deleteHelmRepo,
+  installChartFromAppStore,
+  waitForHelmRelease,
+};

--- a/web/tests/ui/app-store-access-url-http.js
+++ b/web/tests/ui/app-store-access-url-http.js
@@ -1,0 +1,81 @@
+const {
+  RETRYABLE_INFRASTRUCTURE_PATTERNS,
+  RETRYABLE_HTTP_STATUS_CODES,
+} = require("./app-store-access-url-config");
+
+const IGNORABLE_CLEANUP_MESSAGES = Object.freeze([
+  "not found",
+  "not loaded",
+  "cluster not ready",
+]);
+
+class RetryableInfrastructureError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "RetryableInfrastructureError";
+  }
+}
+
+function isRetryableInfrastructureMessage(message) {
+  const text = String(message || "");
+  return RETRYABLE_INFRASTRUCTURE_PATTERNS.some(pattern => pattern.test(text));
+}
+
+function isRetryableInfrastructureError(error) {
+  return error instanceof RetryableInfrastructureError || isRetryableInfrastructureMessage(error?.message || error);
+}
+
+function isRetryableHttpStatus(status) {
+  return status >= 500 || RETRYABLE_HTTP_STATUS_CODES.includes(status);
+}
+
+function isIgnorableCleanupMessage(message) {
+  const text = String(message || "").toLowerCase();
+  return IGNORABLE_CLEANUP_MESSAGES.some(pattern => text.includes(pattern));
+}
+
+function responseErrorMessage(context, response) {
+  return `${context}: HTTP ${response.status()}`;
+}
+
+async function readOkJson(response, context) {
+  if (!response.ok()) {
+    const message = responseErrorMessage(context, response);
+    if (isRetryableHttpStatus(response.status())) {
+      throw new RetryableInfrastructureError(message);
+    }
+    throw new Error(message);
+  }
+
+  let body;
+  try {
+    body = await response.json();
+  } catch (error) {
+    const parseError = String(error?.message || error || "error message unavailable");
+    const message = `${context}: failed to parse JSON response: ${parseError}`;
+    throw new Error(message);
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error(`${context}: unexpected JSON response shape`);
+  }
+
+  if (body.status !== "ok") {
+    const msg = String(body.msg || "");
+    const message = msg ? `${context}: ${msg}` : `${context}: unexpected response`;
+    if (isRetryableInfrastructureError(message)) {
+      throw new RetryableInfrastructureError(message);
+    }
+    throw new Error(message);
+  }
+  return body;
+}
+
+module.exports = {
+  RetryableInfrastructureError,
+  isIgnorableCleanupMessage,
+  isRetryableInfrastructureError,
+  isRetryableHttpStatus,
+  readOkJson,
+  responseErrorMessage,
+};

--- a/web/tests/ui/app-store-access-url-log.js
+++ b/web/tests/ui/app-store-access-url-log.js
@@ -1,0 +1,211 @@
+const {randomUUID} = require("crypto");
+
+const LOG_PREFIX = "[app-store-access]";
+
+function emitAppStoreLog(payload) {
+  console.log(`${LOG_PREFIX} ${JSON.stringify(payload)}`);
+}
+
+function createAppStoreStageTracker(baseDetails = {}) {
+  const startedAt = Date.now();
+  const durations = [];
+
+  function log(event, details = {}) {
+    emitAppStoreLog({
+      event,
+      elapsedMs: Date.now() - startedAt,
+      ...baseDetails,
+      ...details,
+    });
+  }
+
+  async function run(stage, action, details = {}, options = {}) {
+    const stageStartedAt = Date.now();
+    log("stage-start", {stage, timeoutMs: options.timeoutMs, ...details});
+    try {
+      const result = await runWithOptionalTimeout(stage, action, options.timeoutMs);
+      const durationMs = Date.now() - stageStartedAt;
+      durations.push({stage, durationMs});
+      log("stage-finish", {stage, durationMs});
+      return result;
+    } catch (error) {
+      log("stage-fail", {stage, durationMs: Date.now() - stageStartedAt, error: compactError(error)});
+      throw error;
+    }
+  }
+
+  function finish() {
+    const totalDurationMs = Date.now() - startedAt;
+    const slowestDurations = [...durations]
+      .sort((left, right) => right.durationMs - left.durationMs)
+      .slice(0, 8);
+    log("stage-summary", {totalDurationMs, durations, slowestDurations});
+  }
+
+  return {log, run, finish};
+}
+
+async function runWithOptionalTimeout(stage, action, timeoutMs) {
+  if (!timeoutMs) {
+    return action();
+  }
+  let timeout;
+  try {
+    return await Promise.race([
+      action(),
+      new Promise((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`stage ${stage} timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function compactError(error) {
+  return {
+    name: error?.name || "Error",
+    message: compactErrorMessage(error).slice(0, 2000),
+  };
+}
+
+function compactErrorMessage(error) {
+  if (error?.message) {
+    return String(error.message);
+  }
+  if (error === null || error === undefined || error === "") {
+    return "error message unavailable";
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (typeof error === "object") {
+    return stringifyLogObject(error);
+  }
+  return String(error);
+}
+
+function stringifyLogObject(value) {
+  try {
+    const json = JSON.stringify(value);
+    return json && json !== "{}" ? json : "error object without message";
+  } catch (error) {
+    return "error object could not be stringified";
+  }
+}
+
+function logAppStoreProgress(stage, startedAt, details = {}) {
+  emitAppStoreLog({
+    event: "stage-progress",
+    stage,
+    elapsedMs: Date.now() - startedAt,
+    ...details,
+  });
+}
+
+function logAppStoreDiagnostic(event, details = {}) {
+  emitAppStoreLog({
+    event,
+    ...details,
+  });
+}
+
+function compactTask(task) {
+  if (!task) {
+    return null;
+  }
+  return {
+    id: task.id,
+    status: task.status,
+    phase: task.phase,
+    errorMsg: task.errorMsg || "",
+    updatedAt: task.updatedAt || task.updateTime || task.updatedTime || "",
+  };
+}
+
+function compactRelease(release) {
+  if (!release) {
+    return null;
+  }
+  return {
+    name: release.name,
+    namespace: release.namespace,
+    status: release.status,
+    chart: release.chart,
+  };
+}
+
+function compactAppStoreChart(chart) {
+  if (!chart) {
+    return null;
+  }
+  return {
+    key: chart.key,
+    chartName: chart.chartName,
+    chartVersion: chart.chartVersion,
+    releasePrefix: chart.releasePrefix,
+    nodePort: chart.nodePort,
+    expectReachable: chart.expectReachable,
+    expectedAccessUrlType: chart.expectedAccessUrlType,
+    expectedCategory: chart.expectedCategory,
+    expectedFailureLocation: chart.expectedFailureLocation,
+    sampleReason: chart.sampleReason,
+  };
+}
+
+function compactAccessOutcome(outcome) {
+  if (!outcome) {
+    return null;
+  }
+  return {
+    chartName: outcome.chartName,
+    chartVersion: outcome.chartVersion,
+    releaseName: outcome.releaseName,
+    namespace: outcome.namespace,
+    deploymentName: outcome.deploymentName,
+    serviceName: outcome.serviceName,
+    serviceType: outcome.serviceType,
+    accessUrlType: outcome.accessUrlType,
+    ingressName: outcome.ingressName,
+    ingressHost: outcome.ingressHost,
+    accessUrl: outcome.accessUrl,
+    reachable: outcome.reachable,
+    attemptCount: outcome.attemptCount,
+    expectedAccessUrlType: outcome.expectedAccessUrlType,
+    expectedCategory: outcome.expectedCategory,
+    expectedFailureLocation: outcome.expectedFailureLocation,
+    category: outcome.classification?.category,
+    scope: outcome.classification?.scope,
+    reportable: outcome.classification?.reportable,
+    reportReason: outcome.classification?.reportReason,
+    detail: outcome.classification?.detail,
+  };
+}
+
+function compactDeployLogs(logs, limit = 8) {
+  return (logs || []).slice(-limit).filter(Boolean).map(log => ({
+    level: log.level,
+    message: log.message,
+    createdAt: log.createdAt,
+  }));
+}
+
+function makeResourceSuffix() {
+  const raw = process.env.GITHUB_RUN_ID || process.env.E2E_TEST_TOKEN || String(process.pid);
+  const runPart = String(raw).replace(/[^a-z0-9-]/gi, "").toLowerCase().slice(-8) || "local";
+  return `${runPart}-${randomUUID().slice(0, 8)}`;
+}
+
+module.exports = {
+  compactAccessOutcome,
+  compactAppStoreChart,
+  compactDeployLogs,
+  compactRelease,
+  compactTask,
+  createAppStoreStageTracker,
+  logAppStoreDiagnostic,
+  logAppStoreProgress,
+  makeResourceSuffix,
+};

--- a/web/tests/ui/app-store-access-url-probe-check.js
+++ b/web/tests/ui/app-store-access-url-probe-check.js
@@ -1,0 +1,226 @@
+const assert = require("assert");
+const {ACCESS_URL_TYPES} = require("./access-url-diagnostics");
+const {
+  findExpectedDeploymentAccessTargets,
+} = require("./app-store-access-url-deployment-probe");
+
+const releaseContext = {
+  releaseName: "demo-release",
+  namespace: "default",
+};
+
+const selectorMatchedTargets = findExpectedDeploymentAccessTargets({
+  deployments: [
+    {
+      namespace: "default",
+      name: "demo-worker",
+      selector: {
+        "app.kubernetes.io/instance": "demo-release",
+        "app.kubernetes.io/name": "demo",
+      },
+    },
+  ],
+  services: [
+    {
+      namespace: "default",
+      name: "demo-http",
+      type: "NodePort",
+      selector: {
+        "app.kubernetes.io/instance": "demo-release",
+        "app.kubernetes.io/name": "demo",
+      },
+      ports: [{nodePort: 31080}],
+    },
+  ],
+  nodeIP: "192.168.250.2",
+  releaseContext,
+});
+
+assert.deepStrictEqual(
+  selectorMatchedTargets,
+  [
+    {
+      deploymentName: "demo-worker",
+      namespace: "default",
+      serviceName: "demo-http",
+      serviceType: "NodePort",
+      accessUrlType: ACCESS_URL_TYPES.NODEPORT,
+      accessUrl: "http://192.168.250.2:31080",
+      nodePort: 31080,
+    },
+  ],
+  "Deployment Access URL expectations should follow service selectors, not only same-name services"
+);
+
+const unrelatedTargets = findExpectedDeploymentAccessTargets({
+  deployments: [
+    {
+      namespace: "default",
+      name: "demo-worker",
+      selector: {"app.kubernetes.io/instance": "demo-release"},
+    },
+  ],
+  services: [
+    {
+      namespace: "default",
+      name: "other-http",
+      type: "NodePort",
+      selector: {"app.kubernetes.io/instance": "other-release"},
+      ports: [{nodePort: 31081}],
+    },
+  ],
+  nodeIP: "192.168.250.2",
+  releaseContext,
+});
+
+assert.deepStrictEqual(
+  unrelatedTargets,
+  [],
+  "NodePort services for other releases should not create Deployment Access URL expectations"
+);
+
+const domainTargets = findExpectedDeploymentAccessTargets({
+  deployments: [
+    {
+      namespace: "default",
+      name: "demo-worker",
+      selector: {
+        app: "demo-worker",
+        "app.kubernetes.io/instance": "demo-release",
+      },
+    },
+  ],
+  services: [
+    {
+      namespace: "default",
+      name: "demo-web",
+      type: "ClusterIP",
+      selector: {
+        app: "demo-worker",
+      },
+      ports: [{port: 9898}],
+    },
+  ],
+  ingresses: [
+    {
+      namespace: "default",
+      name: "demo-release-ingress",
+      rules: [
+        {
+          host: "demo-release.casos.invalid",
+          path: "/",
+          serviceName: "demo-web",
+          servicePort: 9898,
+        },
+        {
+          host: "demo-release.casos.invalid",
+          path: "/api",
+          serviceName: "demo-web",
+          servicePort: 9898,
+        },
+      ],
+    },
+  ],
+  nodeIP: "",
+  releaseContext,
+});
+
+assert.deepStrictEqual(
+  domainTargets,
+  [
+    {
+      deploymentName: "demo-worker",
+      namespace: "default",
+      serviceName: "demo-web",
+      serviceType: "ClusterIP",
+      accessUrlType: ACCESS_URL_TYPES.DOMAIN,
+      accessUrl: "http://demo-release.casos.invalid",
+      ingressName: "demo-release-ingress",
+      ingressHost: "demo-release.casos.invalid",
+    },
+    {
+      deploymentName: "demo-worker",
+      namespace: "default",
+      serviceName: "demo-web",
+      serviceType: "ClusterIP",
+      accessUrlType: ACCESS_URL_TYPES.DOMAIN,
+      accessUrl: "http://demo-release.casos.invalid/api",
+      ingressName: "demo-release-ingress",
+      ingressHost: "demo-release.casos.invalid",
+    },
+  ],
+  "Deployment Access URL expectations should follow Ingress rule serviceName lookups for domain links"
+);
+
+const unrelatedDomainTargets = findExpectedDeploymentAccessTargets({
+  deployments: [
+    {
+      namespace: "default",
+      name: "demo-worker",
+      selector: {
+        app: "demo-worker",
+        "app.kubernetes.io/instance": "demo-release",
+      },
+    },
+  ],
+  services: [
+    {
+      namespace: "default",
+      name: "other-web",
+      type: "ClusterIP",
+      selector: {app: "other-worker"},
+      ports: [{port: 9898}],
+    },
+  ],
+  ingresses: [
+    {
+      namespace: "default",
+      name: "other-ingress",
+      rules: [
+        {
+          host: "other-release.casos.invalid",
+          path: "/",
+          serviceName: "other-web",
+          servicePort: 9898,
+        },
+      ],
+    },
+  ],
+  nodeIP: "",
+  releaseContext,
+});
+
+assert.deepStrictEqual(
+  unrelatedDomainTargets,
+  [],
+  "Ingress rules for unrelated services should not create Deployment Access URL expectations"
+);
+
+const noNodeIpTargets = findExpectedDeploymentAccessTargets({
+  deployments: [
+    {
+      namespace: "default",
+      name: "demo-worker",
+      selector: {"app.kubernetes.io/instance": "demo-release"},
+    },
+  ],
+  services: [
+    {
+      namespace: "default",
+      name: "demo-http",
+      type: "NodePort",
+      selector: {"app.kubernetes.io/instance": "demo-release"},
+      ports: [{nodePort: 31080}],
+    },
+  ],
+  nodeIP: "",
+  releaseContext,
+});
+
+assert.deepStrictEqual(
+  noNodeIpTargets,
+  [],
+  "Deployment Access URL expectations need the same node IP evidence used by the UI"
+);
+
+console.log("app store access URL probe checks passed");

--- a/web/tests/ui/app-store-access-url-probe-utils.js
+++ b/web/tests/ui/app-store-access-url-probe-utils.js
@@ -1,0 +1,23 @@
+const {NAMESPACE} = require("./app-store-access-url-config");
+const {readOkJson} = require("./app-store-access-url-http");
+
+async function readNamespacedList(page, apiPath, namespace = NAMESPACE, context) {
+  const response = await page.context().request.get(`${apiPath}?namespace=${encodeURIComponent(namespace)}`);
+  const body = await readOkJson(response, context);
+  return Array.isArray(body.data) ? body.data : [];
+}
+
+// Keep the data-row-key and href selectors valid if future sample names contain CSS-sensitive characters.
+function cssAttributeValue(value) {
+  return String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, "\\\"")
+    .replace(/\r/g, "\\D ")
+    .replace(/\n/g, "\\A ")
+    .replace(/\f/g, "\\C ");
+}
+
+module.exports = {
+  cssAttributeValue,
+  readNamespacedList,
+};

--- a/web/tests/ui/app-store-access-url-probe.js
+++ b/web/tests/ui/app-store-access-url-probe.js
@@ -1,0 +1,312 @@
+const {expect} = require("@playwright/test");
+const {
+  ACCESS_URL_TYPES,
+  classifyAccessUrlFailure,
+  formatAccessUrlFailure,
+} = require("./access-url-diagnostics");
+const {
+  ACCESS_READY_TIMEOUT_MS,
+  API_GET_PODS,
+  API_GET_SERVICES,
+  NAMESPACE,
+  SERVICES_ROUTE,
+} = require("./app-store-access-url-config");
+const {
+  findDeploymentAccessUrl,
+  openDeploymentAccessUrlPage,
+} = require("./app-store-access-url-deployment-probe");
+const {
+  logAppStoreProgress,
+} = require("./app-store-access-url-log");
+const {
+  cssAttributeValue,
+  readNamespacedList,
+} = require("./app-store-access-url-probe-utils");
+
+const MAX_NAVIGATION_TIMEOUT_MS = 10000;
+const MIN_NAVIGATION_TIMEOUT_MS = 1000;
+const BACKOFF_CAP_MS = 3000;
+const BACKOFF_BASE_MS = 500;
+const BACKOFF_EXPONENT_LIMIT = 3;
+const RESOURCE_ROW_VISIBLE_TIMEOUT_MS = 60 * 1000;
+const ACCESS_URL_CLICK_TIMEOUT_MS = 5000;
+
+async function readServiceAccessUrl(page, releaseContext) {
+  const result = await findServiceAccessUrl(page, releaseContext);
+  if (result.classification) {
+    throw new Error(formatAccessUrlFailure({...releaseContext, classification: result.classification}));
+  }
+  return result.accessUrl;
+}
+
+async function findServiceAccessUrl(page, releaseContext) {
+  try {
+    await page.goto(SERVICES_ROUTE);
+    await page.waitForLoadState("networkidle");
+  } catch (error) {
+    const classification = classifyAccessUrlFailure({
+      detail: `navigation to services route failed: ${error.message}`,
+    });
+    return {classification};
+  }
+  const serviceEvidence = await readServiceEvidence(page, releaseContext).catch(error => ({
+    service: null,
+    error: error.message,
+  }));
+  const namespace = releaseContext.namespace || NAMESPACE;
+  const serviceName = serviceEvidence.service?.name || releaseContext.serviceName || releaseContext.releaseName;
+  if (!serviceName) {
+    return {
+      classification: classifyAccessUrlFailure({
+        testHarnessDiagnostic: true,
+        detail: `service name is missing from service evidence and release context for namespace ${namespace}`,
+      }),
+    };
+  }
+  const rowKey = `${namespace}/${serviceName}`;
+  const row = page.locator(`tr[data-row-key="${cssAttributeValue(rowKey)}"]`);
+  const expectedNodePort = releaseContext.nodePort || serviceEvidence.nodePort;
+  try {
+    await expect(row).toBeVisible({timeout: RESOURCE_ROW_VISIBLE_TIMEOUT_MS});
+    const rowText = await row.textContent().catch(() => "");
+    const serviceType = serviceEvidence.service?.type || detectServiceType(rowText);
+    const accessLink = expectedNodePort
+      ? row.getByRole("link", {name: new RegExp(`:${expectedNodePort}$`)})
+      : row.getByRole("link").first();
+    await expect(accessLink).toBeVisible();
+    const accessUrl = await accessLink.getAttribute("href");
+    expect(accessUrl, "the Services page Access URL should have an href").toBeTruthy();
+    if (expectedNodePort) {
+      expect(accessUrl).toContain(`:${expectedNodePort}`);
+    }
+    if (serviceType && serviceType !== "NodePort") {
+      const classification = classifyAccessUrlFailure({
+        serviceUrlMissing: true,
+        serviceType,
+        detail: `service ${namespace}/${serviceName} has type ${serviceType} but exposed ${accessUrl}`,
+      });
+      return {classification, serviceName, serviceType};
+    }
+    return {accessUrl, serviceName, serviceType};
+  } catch (error) {
+    const serviceType = serviceEvidence.service?.type || "";
+    const serviceDetail = serviceType
+      ? `service ${namespace}/${serviceName} has type ${serviceType} and did not expose a matching NodePort Access URL`
+      : `service ${namespace}/${serviceName} did not expose a matching Access URL: ${error.message}`;
+    const classification = classifyAccessUrlFailure({
+      serviceUrlMissing: true,
+      serviceType,
+      detail: serviceDetail,
+    });
+    return {classification, serviceName, serviceType, serviceEvidenceError: serviceEvidence.error};
+  }
+}
+
+async function waitForAccessUrl(page, accessUrl, releaseContext) {
+  const result = await probeAccessUrl(page, accessUrl, releaseContext, {timeoutMs: ACCESS_READY_TIMEOUT_MS});
+  if (result.reachable) {
+    return;
+  }
+  throw new Error(formatAccessUrlFailure(result));
+}
+
+async function probeReleaseAccessUrl(page, releaseContext, {timeoutMs}) {
+  const deploymentResult = await findDeploymentAccessUrl(page, releaseContext);
+  if (deploymentResult.classification) {
+    return {
+      ...releaseContext,
+      deploymentName: deploymentResult.deploymentName,
+      serviceName: deploymentResult.serviceName,
+      serviceType: deploymentResult.serviceType,
+      accessUrlType: deploymentResult.accessUrlType,
+      ingressName: deploymentResult.ingressName,
+      ingressHost: deploymentResult.ingressHost,
+      reachable: false,
+      attemptCount: 0,
+      classification: deploymentResult.classification,
+    };
+  }
+  let accessPage = null;
+  let accessClickError = null;
+  const accessClickStartedAt = Date.now();
+  try {
+    accessPage = await openDeploymentAccessUrlPage(page, deploymentResult, {
+      timeoutMs: Math.min(ACCESS_URL_CLICK_TIMEOUT_MS, Math.max(MIN_NAVIGATION_TIMEOUT_MS, timeoutMs)),
+    });
+  } catch (error) {
+    accessClickError = error;
+    logAppStoreProgress("click-deployment-access-url", accessClickStartedAt, {
+      releaseName: releaseContext.releaseName,
+      deploymentName: deploymentResult.deploymentName,
+      accessUrl: deploymentResult.accessUrl,
+      error: error.message,
+    });
+  }
+  return probeAccessUrl(page, deploymentResult.accessUrl, {
+    ...releaseContext,
+    deploymentName: deploymentResult.deploymentName,
+    serviceName: deploymentResult.serviceName,
+    serviceType: deploymentResult.serviceType,
+    accessUrlType: deploymentResult.accessUrlType,
+    ingressName: deploymentResult.ingressName,
+    ingressHost: deploymentResult.ingressHost,
+    accessClickError: accessClickError?.message || "",
+  }, {timeoutMs, accessPage});
+}
+
+async function probeAccessUrl(page, accessUrl, releaseContext, {timeoutMs, accessPage: clickedAccessPage = null}) {
+  const started = Date.now();
+  let lastFailure = null;
+  let attemptCount = 0;
+  const maxNavigationTimeoutMs = Math.min(MAX_NAVIGATION_TIMEOUT_MS, Math.max(MIN_NAVIGATION_TIMEOUT_MS, timeoutMs));
+  let accessPage = clickedAccessPage;
+  try {
+    if (!accessPage) {
+      accessPage = await page.context().newPage();
+    }
+    while (Date.now() - started < timeoutMs) {
+      attemptCount += 1;
+      const remainingMs = timeoutMs - (Date.now() - started);
+      const navigationTimeoutMs = Math.min(maxNavigationTimeoutMs, Math.max(MIN_NAVIGATION_TIMEOUT_MS, remainingMs));
+      try {
+        const response = await accessPage.goto(accessUrl, {timeout: navigationTimeoutMs, waitUntil: "domcontentloaded"});
+        const body = (await accessPage.locator("body").textContent()) || "";
+        const successStatus = Boolean(response) && response.status() >= 200 && response.status() < 300;
+        if (successStatus && body.trim().length > 0) {
+          return {
+            ...releaseContext,
+            accessUrl,
+            reachable: true,
+            attemptCount,
+          };
+        }
+        lastFailure = {responseStatus: response?.status() ?? null, body};
+      } catch (error) {
+        lastFailure = {error};
+      }
+      const classification = classifyAccessUrlFailure({
+        ...(lastFailure || {detail: "access attempt failed"}),
+        accessUrlType: releaseContext.accessUrlType,
+      });
+      logAppStoreProgress("wait-access-url", started, {
+        attemptCount,
+        category: classification.category,
+        scope: classification.scope,
+        reportable: classification.reportable,
+        detail: classification.detail,
+      });
+      const backoffMs = Math.min(
+        BACKOFF_CAP_MS,
+        BACKOFF_BASE_MS * (2 ** Math.min(attemptCount - 1, BACKOFF_EXPONENT_LIMIT))
+      );
+      if (Date.now() - started + backoffMs < timeoutMs) {
+        await delay(backoffMs);
+      }
+    }
+  } finally {
+    if (accessPage) {
+      await accessPage.close().catch(() => {});
+    }
+  }
+  const classification = await classifyAccessProbeFailure(page, {
+    ...releaseContext,
+    accessUrl,
+  }, lastFailure || {
+    detail: "access probe did not start; check timeoutMs configuration",
+  });
+  return {
+    ...releaseContext,
+    accessUrl,
+    reachable: false,
+    attemptCount,
+    classification,
+  };
+}
+
+async function classifyAccessProbeFailure(page, releaseContext, failureInput) {
+  const baseClassification = classifyAccessUrlFailure({
+    ...failureInput,
+    accessUrlType: releaseContext.accessUrlType,
+  });
+  const workloadEvidence = await readWorkloadEvidence(page, releaseContext).catch(error => ({
+    error: error.message,
+  }));
+  if (workloadEvidence.error || !workloadEvidence.service) {
+    if (releaseContext.accessUrlType === ACCESS_URL_TYPES.DOMAIN) {
+      return classifyAccessUrlFailure({
+        domainAccessUrlDiagnostic: true,
+        detail: `domain Access URL ${releaseContext.accessUrl || ""} could not be opened and service evidence was unavailable: ${workloadEvidence.error || baseClassification.detail}`,
+      });
+    }
+    return baseClassification;
+  }
+
+  const service = workloadEvidence.service;
+  if (service.type && service.type !== "NodePort" && releaseContext.accessUrlType !== ACCESS_URL_TYPES.DOMAIN) {
+    return classifyAccessUrlFailure({
+      appWorkloadDiagnostic: true,
+      detail: `service ${service.namespace}/${service.name} has type ${service.type}, so the chart is not exposing a NodePort workload`,
+    });
+  }
+  if (workloadEvidence.runningPods.length === 0) {
+    return classifyAccessUrlFailure({
+      appWorkloadDiagnostic: true,
+      detail: `${service.type || "Service"} service ${service.namespace}/${service.name} has no running pods matching selector ${formatSelector(service.selector)}`,
+    });
+  }
+  if (releaseContext.accessUrlType === ACCESS_URL_TYPES.DOMAIN) {
+    return classifyAccessUrlFailure({
+      domainAccessUrlDiagnostic: true,
+      detail: `domain Access URL ${releaseContext.accessUrl} for Ingress ${releaseContext.namespace || NAMESPACE}/${releaseContext.ingressName || "ingress-not-recorded"} could not be opened: ${baseClassification.detail}`,
+    });
+  }
+  return baseClassification;
+}
+
+async function readWorkloadEvidence(page, releaseContext) {
+  const serviceEvidence = await readServiceEvidence(page, releaseContext);
+  const pods = await readNamespacedList(page, API_GET_PODS, releaseContext.namespace || NAMESPACE, "get-pods");
+  const matchingPods = serviceEvidence.service?.selector
+    ? pods.filter(pod => labelsMatchSelector(pod.labels, serviceEvidence.service.selector))
+    : [];
+  return {
+    ...serviceEvidence,
+    matchingPods,
+    runningPods: matchingPods.filter(pod => pod.phase === "Running"),
+  };
+}
+
+async function readServiceEvidence(page, releaseContext) {
+  const namespace = releaseContext.namespace || NAMESPACE;
+  const serviceName = releaseContext.serviceName || releaseContext.releaseName;
+  const services = await readNamespacedList(page, API_GET_SERVICES, namespace, "get-services");
+  const service = services.find(item => item.namespace === namespace && item.name === serviceName) || null;
+  const nodePort = service?.ports?.find(port => port.nodePort)?.nodePort;
+  return {service, nodePort};
+}
+
+function labelsMatchSelector(labels = {}, selector = {}) {
+  return Object.entries(selector).every(([key, value]) => labels[key] === value);
+}
+
+function formatSelector(selector = {}) {
+  const entries = Object.entries(selector);
+  return entries.length > 0
+    ? entries.map(([key, value]) => `${key}=${value}`).join(",")
+    : "empty selector";
+}
+
+function detectServiceType(text) {
+  const match = String(text || "").match(/\b(ClusterIP|NodePort|LoadBalancer|ExternalName)\b/);
+  return match ? match[1] : "";
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+module.exports = {
+  probeReleaseAccessUrl,
+  readServiceAccessUrl,
+  waitForAccessUrl,
+};

--- a/web/tests/ui/app-store-access-url-routes.js
+++ b/web/tests/ui/app-store-access-url-routes.js
@@ -1,0 +1,12 @@
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function routeUrlPattern(route) {
+  return new RegExp(`${escapeRegExp(route)}\\/?$`);
+}
+
+module.exports = {
+  escapeRegExp,
+  routeUrlPattern,
+};

--- a/web/tests/ui/app-store-access-url-samples.js
+++ b/web/tests/ui/app-store-access-url-samples.js
@@ -1,0 +1,146 @@
+const {
+  ACCESS_URL_FAILURE_CATEGORIES,
+  ACCESS_URL_TYPES,
+} = require("./access-url-diagnostics");
+const {
+  APP_STORE_NODE_PORT,
+  APP_STORE_NO_PODS_NODE_PORT,
+} = require("./app-store-access-url-config");
+
+const REPRESENTATIVE_APP_STORE_REPOS = deepFreeze([
+  {
+    key: "podinfo",
+    repoNamePrefix: "podinfo",
+    repoURL: "https://stefanprodan.github.io/podinfo",
+    charts: [
+      {
+        key: "podinfo-nodeport",
+        chartName: "podinfo",
+        releasePrefix: "podinfo-ok",
+        valuesYAML: podinfoNodePortValues({replicaCount: 1, nodePort: APP_STORE_NODE_PORT}),
+        nodePort: APP_STORE_NODE_PORT,
+        expectReachable: true,
+        sampleReason: "reachable NodePort control from a real app-store chart",
+      },
+      {
+        key: "podinfo-clusterip",
+        chartName: "podinfo",
+        releasePrefix: "podinfo-ci",
+        expectReachable: false,
+        expectedCategory: ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC,
+        expectedFailureLocation: "service-not-nodeport",
+        sampleReason: "default podinfo service is ClusterIP, so CasOS should not report a missing NodePort URL as a bug",
+      },
+      {
+        key: "podinfo-nodeport-no-pods",
+        chartName: "podinfo",
+        releasePrefix: "podinfo-np0",
+        valuesYAML: podinfoNodePortValues({replicaCount: 0, nodePort: APP_STORE_NO_PODS_NODE_PORT}),
+        nodePort: APP_STORE_NO_PODS_NODE_PORT,
+        expectReachable: false,
+        expectedCategory: ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC,
+        expectedFailureLocation: "nodeport-no-running-pods",
+        sampleReason: "NodePort is rendered but the chart has no running pods behind the service",
+      },
+      {
+        key: "podinfo-domain",
+        chartName: "podinfo",
+        releasePrefix: "podinfo-domain",
+        valuesYAML: ({releaseName}) => podinfoDomainValues({host: `${releaseName}.casos.invalid`}),
+        expectReachable: false,
+        expectedAccessUrlType: ACCESS_URL_TYPES.DOMAIN,
+        expectedCategory: ACCESS_URL_FAILURE_CATEGORIES.DOMAIN_ACCESS_URL_UNREACHABLE,
+        expectedFailureLocation: "domain-dns-or-ingress-route",
+        sampleReason: "Ingress-backed domain Access URL should be rendered from the Deployments page and classified when the URL cannot open",
+      },
+    ],
+  },
+  {
+    key: "echo-server",
+    repoNamePrefix: "echo-server",
+    repoURL: "https://ealenn.github.io/charts",
+    charts: [
+      {
+        key: "echo-server-clusterip",
+        chartName: "echo-server",
+        releasePrefix: "echo-server-ci",
+        expectReachable: false,
+        expectedCategory: ACCESS_URL_FAILURE_CATEGORIES.APP_WORKLOAD_DIAGNOSTIC,
+        expectedFailureLocation: "service-not-nodeport",
+        sampleReason: "second real app-store chart with a default ClusterIP service",
+      },
+    ],
+  },
+]);
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+  for (const propertyName of Object.getOwnPropertyNames(value)) {
+    deepFreeze(value[propertyName]);
+  }
+  return Object.freeze(value);
+}
+
+function podinfoNodePortValues({replicaCount, nodePort}) {
+  return [
+    `replicaCount: ${replicaCount}`,
+    "service:",
+    "  enabled: true",
+    "  type: NodePort",
+    "  httpPort: 9898",
+    "  externalPort: 9898",
+    `  nodePort: ${nodePort}`,
+    "redis:",
+    "  enabled: false",
+    "ingress:",
+    "  enabled: false",
+    "",
+  ].join("\n");
+}
+
+function podinfoDomainValues({host}) {
+  return [
+    "replicaCount: 1",
+    "service:",
+    "  enabled: true",
+    "  type: ClusterIP",
+    "  httpPort: 9898",
+    "  externalPort: 9898",
+    "redis:",
+    "  enabled: false",
+    "ingress:",
+    "  enabled: true",
+    "  className: \"\"",
+    "  hosts:",
+    `    - host: ${host}`,
+    "      paths:",
+    "        - path: /",
+    "          pathType: ImplementationSpecific",
+    "",
+  ].join("\n");
+}
+
+function flattenRepresentativeCharts(repos) {
+  const sourceRepos = repos ?? REPRESENTATIVE_APP_STORE_REPOS;
+  return sourceRepos.flatMap(repo => repo.charts.map(chart => ({
+    ...chart,
+    repoKey: repo.key,
+    repoNamePrefix: repo.repoNamePrefix,
+    repoURL: repo.repoURL,
+  })));
+}
+
+function expectedObservedFailureCategories(charts) {
+  return [...new Set((charts || [])
+    .filter(chart => !chart.expectReachable && chart.expectedCategory)
+    .map(chart => chart.expectedCategory))]
+    .sort();
+}
+
+module.exports = {
+  REPRESENTATIVE_APP_STORE_REPOS,
+  expectedObservedFailureCategories,
+  flattenRepresentativeCharts,
+};

--- a/web/tests/ui/app-store-access-url-visual-evidence-check.js
+++ b/web/tests/ui/app-store-access-url-visual-evidence-check.js
@@ -1,0 +1,82 @@
+const assert = require("assert");
+const {
+  ACCESS_URL_FAILURE_CATEGORIES,
+  ACCESS_URL_TYPES,
+  classifyAccessUrlFailure,
+} = require("./access-url-diagnostics");
+const {
+  buildAccessUrlFailureAnnotations,
+  VISUAL_SUMMARY_MAX_LENGTH,
+} = require("./app-store-access-url-visual-evidence");
+
+const annotations = buildAccessUrlFailureAnnotations([
+  {
+    reachable: false,
+    namespace: "default",
+    chartName: "podinfo",
+    releaseName: "podinfo-domain-demo",
+    deploymentName: "podinfo-domain-demo",
+    serviceName: "podinfo-domain-demo",
+    serviceType: "ClusterIP",
+    accessUrlType: ACCESS_URL_TYPES.DOMAIN,
+    accessUrl: "http://podinfo-domain-demo.casos.invalid",
+    attemptCount: 2,
+    classification: classifyAccessUrlFailure({
+      accessUrlType: ACCESS_URL_TYPES.DOMAIN,
+      error: new Error("net::ERR_NAME_NOT_RESOLVED"),
+    }),
+  },
+  {
+    reachable: false,
+    namespace: "default",
+    chartName: "echo-server",
+    releaseName: "echo-ci-demo",
+    deploymentName: "echo-ci-demo",
+    serviceName: "echo-ci-demo",
+    serviceType: "NodePort",
+    accessUrlType: ACCESS_URL_TYPES.NODEPORT,
+    accessUrl: "http://192.168.250.2:31080",
+    attemptCount: 4,
+    classification: classifyAccessUrlFailure({
+      error: new Error("net::ERR_CONNECTION_REFUSED"),
+    }),
+  },
+]);
+
+assert.strictEqual(annotations.length, 2);
+assert.strictEqual(annotations[0].title, "Domain Access URL failed");
+assert.strictEqual(annotations[0].category, ACCESS_URL_FAILURE_CATEGORIES.DOMAIN_ACCESS_URL_UNREACHABLE);
+assert.strictEqual(annotations[0].rowKey, "default/podinfo-domain-demo");
+assert.match(annotations[0].detail, /ERR_NAME_NOT_RESOLVED/);
+assert.match(annotations[0].summary, /deployment=default\/podinfo-domain-demo/);
+assert.match(annotations[0].summary, /url=http:\/\/podinfo-domain-demo\.casos\.invalid/);
+assert.ok(
+  annotations[0].summary.length <= VISUAL_SUMMARY_MAX_LENGTH,
+  "visual summaries should fit inside the screenshot label"
+);
+
+assert.strictEqual(annotations[1].title, "NodePort Access URL failed");
+assert.strictEqual(annotations[1].category, ACCESS_URL_FAILURE_CATEGORIES.NODE_PORT_UNREACHABLE);
+assert.strictEqual(annotations[1].rowKey, "default/echo-ci-demo");
+assert.match(annotations[1].detail, /ERR_CONNECTION_REFUSED/);
+assert.match(annotations[1].summary, /attempts=4/);
+
+const legacyAnnotations = buildAccessUrlFailureAnnotations([
+  {
+    reachable: false,
+    namespace: "default",
+    deploymentName: "legacy-demo",
+    accessUrl: "http://legacy-demo.casos.invalid",
+    classification: {
+      category: "legacy-category",
+      detail: "legacy caller returned a removed category",
+    },
+  },
+]);
+
+assert.strictEqual(legacyAnnotations.length, 1);
+assert.strictEqual(legacyAnnotations[0].category, ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC);
+assert.doesNotMatch(legacyAnnotations[0].summary, /category=legacy-category/);
+assert.match(legacyAnnotations[0].summary, /legacy caller returned a removed category/);
+
+console.log("app store access URL visual evidence checks passed");

--- a/web/tests/ui/app-store-access-url-visual-evidence.js
+++ b/web/tests/ui/app-store-access-url-visual-evidence.js
@@ -1,0 +1,287 @@
+const {
+  ACCESS_URL_FAILURE_CATEGORIES,
+  ACCESS_URL_TYPES,
+  formatAccessUrlFailure,
+  summarizeAccessUrlOutcomes,
+} = require("./access-url-diagnostics");
+const {
+  DEPLOYMENTS_ROUTE,
+  NAMESPACE,
+} = require("./app-store-access-url-config");
+const {
+  cssAttributeValue,
+} = require("./app-store-access-url-probe-utils");
+
+const VISUAL_SUMMARY_MAX_LENGTH = 320;
+const VISUAL_DETAIL_MAX_LENGTH = 180;
+const VISUAL_EVIDENCE_TIMEOUT_MS = 5000;
+const MAX_OVERLAY_ITEMS = 4;
+const ACCESS_SUMMARY_ARTIFACT_NAME = "ui-app-store-access-summary.json";
+const VISUAL_EVIDENCE_FALLBACK_DETAIL = "Access URL visual evidence could not summarize the failed outcome";
+
+function buildAccessUrlFailureAnnotations(outcomes) {
+  return (outcomes || [])
+    .map((outcome, index) => buildAccessUrlFailureAnnotation(outcome, index))
+    .filter(Boolean);
+}
+
+async function attachAnnotatedAccessUrlFailureScreenshot(page, outcomes, testInfo) {
+  const annotations = buildAccessUrlFailureAnnotations(outcomes);
+  if (annotations.length === 0) {
+    return;
+  }
+  await renderAccessUrlFailureOverlay(page, annotations, {navigateToDeployments: true, highlightRows: true});
+  if (!testInfo || typeof testInfo.outputPath !== "function") {
+    return;
+  }
+  const screenshotPath = testInfo.outputPath("access-url-failures-annotated.png");
+  await page.screenshot({path: screenshotPath, fullPage: true});
+  await testInfo.attach("access-url-failures-annotated", {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+}
+
+async function showAccessUrlFailureOverlay(page, outcomes) {
+  const annotations = buildAccessUrlFailureAnnotations(outcomes);
+  if (annotations.length === 0) {
+    return;
+  }
+  await renderAccessUrlFailureOverlay(page, annotations, {navigateToDeployments: false, highlightRows: false});
+  await page.waitForSelector("#casos-access-url-failure-overlay", {
+    state: "visible",
+    timeout: VISUAL_EVIDENCE_TIMEOUT_MS,
+  })
+    .catch(error => {
+      console.warn(`Access URL failure overlay did not become visible: ${error.message}`);
+    });
+}
+
+async function renderAccessUrlFailureOverlay(page, annotations, options = {}) {
+  if (options.navigateToDeployments) {
+    await page.goto(DEPLOYMENTS_ROUTE).catch(error => {
+      console.warn(`Failed to navigate to Deployments for Access URL annotation: ${error.message}`);
+    });
+    await page.waitForLoadState("networkidle").catch(error => {
+      console.warn(`Failed to wait for Deployments network idle before Access URL annotation: ${error.message}`);
+    });
+    await scrollFirstFailureIntoView(page, annotations).catch(error => {
+      console.warn(`Failed to scroll Access URL failure into view: ${error.message}`);
+    });
+  }
+  await page.evaluate(({annotations: visualAnnotations, highlightRows, maxOverlayItems, artifactName}) => {
+    const previousOverlay = document.getElementById("casos-access-url-failure-overlay");
+    if (previousOverlay) {
+      previousOverlay.remove();
+    }
+    const previousStyle = document.getElementById("casos-access-url-failure-style");
+    if (previousStyle) {
+      previousStyle.remove();
+    }
+    document
+      .querySelectorAll(".casos-access-url-failure-row,.casos-access-url-failure-link")
+      .forEach(element => {
+        element.classList.remove("casos-access-url-failure-row", "casos-access-url-failure-link");
+      });
+
+    const style = document.createElement("style");
+    style.id = "casos-access-url-failure-style";
+    style.textContent = `
+      .casos-access-url-failure-row {
+        box-shadow: inset 0 0 0 3px #ff4d4f !important;
+        background: rgba(255, 77, 79, 0.08) !important;
+      }
+      .casos-access-url-failure-link {
+        outline: 3px solid #ff4d4f !important;
+        outline-offset: 3px !important;
+        border-radius: 4px !important;
+        background: #fff1f0 !important;
+        color: #a8071a !important;
+      }
+      #casos-access-url-failure-overlay {
+        position: fixed;
+        right: 24px;
+        top: 72px;
+        z-index: 2147483647;
+        width: min(520px, calc(100vw - 48px));
+        max-height: calc(100vh - 96px);
+        overflow: auto;
+        box-sizing: border-box;
+        padding: 14px 16px;
+        border: 2px solid #ff4d4f;
+        border-radius: 8px;
+        background: #fff1f0;
+        color: #5c0011;
+        box-shadow: 0 12px 32px rgba(92, 0, 17, 0.22);
+        font-family: Arial, sans-serif;
+        font-size: 13px;
+        line-height: 1.45;
+      }
+      #casos-access-url-failure-overlay .casos-access-url-overlay-title {
+        font-size: 16px;
+        font-weight: 700;
+        margin-bottom: 8px;
+      }
+      #casos-access-url-failure-overlay .casos-access-url-overlay-item {
+        padding-top: 8px;
+        margin-top: 8px;
+        border-top: 1px solid rgba(255, 77, 79, 0.35);
+        overflow-wrap: anywhere;
+      }
+      #casos-access-url-failure-overlay .casos-access-url-overlay-label {
+        font-weight: 700;
+      }
+      #casos-access-url-failure-overlay .casos-access-url-overlay-code {
+        font-family: Consolas, Monaco, monospace;
+      }
+    `;
+    document.head.appendChild(style);
+
+    if (highlightRows) {
+      const rows = Array.from(document.querySelectorAll("tr[data-row-key]"));
+      for (const annotation of visualAnnotations) {
+        const row = rows.find(element => element.getAttribute("data-row-key") === annotation.rowKey);
+        if (!row) {
+          continue;
+        }
+        row.classList.add("casos-access-url-failure-row");
+        const link = Array.from(row.querySelectorAll("a[href]"))
+          .find(element => element.getAttribute("href") === annotation.accessUrl);
+        if (link) {
+          link.classList.add("casos-access-url-failure-link");
+          link.setAttribute("data-access-url-failure-reason", annotation.summary);
+          link.setAttribute("title", annotation.summary);
+        }
+      }
+    }
+
+    const overlay = document.createElement("div");
+    overlay.id = "casos-access-url-failure-overlay";
+    overlay.setAttribute("role", "note");
+    const title = document.createElement("div");
+    title.className = "casos-access-url-overlay-title";
+    title.textContent = `${visualAnnotations.length} Access URL failure(s)`;
+    overlay.appendChild(title);
+
+    for (const annotation of visualAnnotations.slice(0, maxOverlayItems)) {
+      const item = document.createElement("div");
+      item.className = "casos-access-url-overlay-item";
+      appendLine(item, `#${annotation.index} ${annotation.title}`, annotation.category, "casos-access-url-overlay-label");
+      appendLine(item, "URL", annotation.accessUrl || "url-not-recorded", "casos-access-url-overlay-code");
+      appendLine(item, "Row", annotation.rowKey || "deployment-row-not-recorded", "casos-access-url-overlay-code");
+      appendLine(item, "Reason", annotation.detail || annotation.summary, "");
+      overlay.appendChild(item);
+    }
+
+    if (visualAnnotations.length > maxOverlayItems) {
+      const more = document.createElement("div");
+      more.className = "casos-access-url-overlay-item";
+      more.textContent = `${visualAnnotations.length - maxOverlayItems} more failure(s) are in ${artifactName}`;
+      overlay.appendChild(more);
+    }
+    document.body.appendChild(overlay);
+
+    function appendLine(parent, label, value, valueClassName) {
+      const line = document.createElement("div");
+      const labelElement = document.createElement("span");
+      labelElement.className = "casos-access-url-overlay-label";
+      labelElement.textContent = `${label}: `;
+      const valueElement = document.createElement("span");
+      if (valueClassName) {
+        valueElement.className = valueClassName;
+      }
+      valueElement.textContent = value;
+      line.appendChild(labelElement);
+      line.appendChild(valueElement);
+      parent.appendChild(line);
+    }
+  }, {
+    annotations,
+    artifactName: ACCESS_SUMMARY_ARTIFACT_NAME,
+    highlightRows: Boolean(options.highlightRows),
+    maxOverlayItems: MAX_OVERLAY_ITEMS,
+  });
+}
+
+async function scrollFirstFailureIntoView(page, annotations) {
+  const first = annotations.find(annotation => annotation.rowKey && annotation.accessUrl);
+  if (!first) {
+    return;
+  }
+  const row = page.locator(`tr[data-row-key="${cssAttributeValue(first.rowKey)}"]`);
+  const link = row.locator(`a[href="${cssAttributeValue(first.accessUrl)}"]`);
+  await link.scrollIntoViewIfNeeded({timeout: VISUAL_EVIDENCE_TIMEOUT_MS})
+    .catch(() => row.scrollIntoViewIfNeeded({timeout: VISUAL_EVIDENCE_TIMEOUT_MS}));
+}
+
+function buildAccessUrlFailureAnnotation(outcome, index) {
+  if (!outcome) {
+    return null;
+  }
+  const classification = readVisualClassification(outcome);
+  const namespace = outcome.namespace || NAMESPACE;
+  const deploymentName = outcome.deploymentName || "";
+  return {
+    index: index + 1,
+    title: accessUrlFailureTitle(outcome.accessUrlType),
+    category: classification.category,
+    rowKey: deploymentName ? `${namespace}/${deploymentName}` : "",
+    accessUrl: outcome.accessUrl || "",
+    releaseName: outcome.releaseName || "",
+    deploymentName,
+    serviceName: outcome.serviceName || "",
+    detail: trimVisualText(classification.detail, VISUAL_DETAIL_MAX_LENGTH),
+    summary: trimVisualText(formatAccessUrlFailure({
+      ...outcome,
+      classification: {
+        category: classification.category,
+        detail: classification.detail,
+      },
+    }), VISUAL_SUMMARY_MAX_LENGTH),
+  };
+}
+
+function readVisualClassification(outcome) {
+  const summary = summarizeAccessUrlOutcomes([outcome]);
+  const bucket = [...summary.categories, ...summary.diagnosticCategories][0];
+  const example = bucket?.examples?.[0] || {};
+  if (bucket) {
+    return {
+      category: bucket.category,
+      scope: bucket.scope,
+      reportable: bucket.reportable,
+      detail: example.detail || bucket.reportReason || "Access URL failed without a detailed reason",
+    };
+  }
+  return {
+    category: ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC,
+    scope: "test-harness",
+    reportable: false,
+    detail: VISUAL_EVIDENCE_FALLBACK_DETAIL,
+  };
+}
+
+function accessUrlFailureTitle(accessUrlType) {
+  if (accessUrlType === ACCESS_URL_TYPES.DOMAIN) {
+    return "Domain Access URL failed";
+  }
+  if (accessUrlType === ACCESS_URL_TYPES.NODEPORT) {
+    return "NodePort Access URL failed";
+  }
+  return "Access URL failed";
+}
+
+function trimVisualText(value, maxLength) {
+  const text = String(value || "").replace(/\s+/g, " ").trim();
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+module.exports = {
+  attachAnnotatedAccessUrlFailureScreenshot,
+  buildAccessUrlFailureAnnotations,
+  showAccessUrlFailureOverlay,
+  VISUAL_SUMMARY_MAX_LENGTH,
+};

--- a/web/tests/ui/app-store-access-url-worker-diagnostics.js
+++ b/web/tests/ui/app-store-access-url-worker-diagnostics.js
@@ -1,0 +1,118 @@
+const childProcess = require("child_process");
+const fs = require("fs");
+const {
+  E2E_APISERVER_URL,
+  SSH_HOST,
+  SSH_PORT,
+  SSH_USER,
+  WORKER_DIAGNOSTICS_LOG,
+} = require("./app-store-access-url-config");
+const {logAppStoreDiagnostic} = require("./app-store-access-url-log");
+
+async function resetWorkerDiagnosticsLog() {
+  try {
+    await fs.promises.rm(WORKER_DIAGNOSTICS_LOG, {force: true});
+  } catch (error) {
+    console.warn(`Failed to reset worker diagnostics log: ${error.message}`);
+  }
+}
+
+function collectWorkerNodeDiagnostics(reason) {
+  const keyPath = process.env.E2E_APP_STORE_SSH_KEY_PATH;
+  if (!keyPath || !SSH_USER || !SSH_HOST) {
+    logAppStoreDiagnostic("worker-diagnostics-skip", {
+      reason,
+      detail: "SSH key path, user, or host is not available",
+    });
+    return Promise.resolve("");
+  }
+  if (/[\0\r\n]/.test(E2E_APISERVER_URL)) {
+    logAppStoreDiagnostic("worker-diagnostics-skip", {
+      reason,
+      detail: "apiserver URL contains unsupported control characters",
+    });
+    return Promise.resolve("");
+  }
+
+  const remoteScript = [
+    "set +e",
+    "echo '== diagnostic context =='",
+    `echo ${shellSingleQuote(`reason: ${reason}`)}`,
+    "date -u || true",
+    "hostnamectl || true",
+    "echo '== network =='",
+    "ip -brief addr || true",
+    "ip route || true",
+    "echo '== worker kubeconfig endpoint =='",
+    "grep -E '^    server:' /etc/kubernetes/worker.kubeconfig || true",
+    "echo '== apiserver readyz with worker CA =='",
+    `apiserver_url=${shellSingleQuote(E2E_APISERVER_URL)}`,
+    "curl -v --cacert /etc/kubernetes/ca.crt --connect-timeout 5 --max-time 20 \"$apiserver_url/readyz\" 2>&1 || true",
+    "echo '== kubelet service unit =='",
+    "sed -n '1,160p' /etc/systemd/system/kubelet.service || true",
+    "echo '== kubelet config =='",
+    "sed -n '1,160p' /var/lib/kubelet/config.yaml || true",
+    "echo '== kubelet status =='",
+    "systemctl status kubelet --no-pager || true",
+    "echo '== kubelet journal =='",
+    "journalctl -u kubelet --no-pager -n 240 || true",
+    "echo '== containerd status =='",
+    "systemctl status containerd --no-pager || true",
+    "echo '== containerd journal =='",
+    "journalctl -u containerd --no-pager -n 120 || true",
+  ].join("\n");
+
+  const args = [
+    "-o", "StrictHostKeyChecking=no",
+    "-o", "UserKnownHostsFile=/dev/null",
+    "-o", "ConnectTimeout=10",
+    "-i", keyPath,
+    "-p", String(SSH_PORT),
+    `${SSH_USER}@${SSH_HOST}`,
+    `bash -c ${shellSingleQuote(remoteScript)}`,
+  ];
+
+  logAppStoreDiagnostic("worker-diagnostics-start", {reason, path: WORKER_DIAGNOSTICS_LOG});
+  return new Promise(resolve => {
+    childProcess.execFile("ssh", args, {timeout: 35 * 1000, maxBuffer: 2 * 1024 * 1024}, (error, stdout, stderr) => {
+      const output = [
+        `# worker diagnostics: ${reason}`,
+        `# collectedAt: ${new Date().toISOString()}`,
+        stdout,
+        stderr ? `# stderr\n${stderr}` : "",
+        error ? `# ssh error\n${error.message}` : "",
+        "",
+      ].filter(Boolean).join("\n");
+
+      fs.promises.appendFile(WORKER_DIAGNOSTICS_LOG, output)
+        .then(() => {
+          logAppStoreDiagnostic("worker-diagnostics-finish", {
+            reason,
+            path: WORKER_DIAGNOSTICS_LOG,
+            exitCode: error?.code ?? (error?.signal ? -1 : 0),
+            signal: error?.signal || "",
+          });
+          resolve(error ? "" : WORKER_DIAGNOSTICS_LOG);
+        })
+        .catch(writeError => {
+          logAppStoreDiagnostic("worker-diagnostics-write-fail", {error: writeError.message});
+          logAppStoreDiagnostic("worker-diagnostics-finish", {
+            reason,
+            path: "",
+            exitCode: error?.code ?? (error?.signal ? -1 : 0),
+            signal: error?.signal || "",
+          });
+          resolve("");
+        });
+    });
+  });
+}
+
+function shellSingleQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+module.exports = {
+  collectWorkerNodeDiagnostics,
+  resetWorkerDiagnosticsLog,
+};

--- a/web/tests/ui/app-store-access-url-worker.js
+++ b/web/tests/ui/app-store-access-url-worker.js
@@ -1,0 +1,262 @@
+const {expect} = require("@playwright/test");
+const {expectOkJson} = require("./e2e-helpers");
+const {
+  API_ADD_MACHINE,
+  API_DEPLOY_MACHINE_NODE,
+  API_DELETE_MACHINE,
+  API_GET_MACHINE_NODE_LOGS,
+  API_GET_MACHINE_NODE_TASKS,
+  API_GET_NODES,
+  E2E_APISERVER_URL,
+  E2E_MACHINE_OWNER,
+  LOG_PROGRESS_INTERVAL_MS,
+  MACHINES_ROUTE,
+  SSH_HOST,
+  SSH_PORT,
+  SSH_PRIVATE_KEY,
+  SSH_USER,
+  UI_NAVIGATION_TIMEOUT_MS,
+  WORKER_NODE_POLL_INTERVAL_MS,
+  WORKER_READY_TIMEOUT_MS,
+  WORKER_TASK_POLL_INTERVAL_MS,
+} = require("./app-store-access-url-config");
+const {
+  compactDeployLogs,
+  compactTask,
+  logAppStoreDiagnostic,
+  logAppStoreProgress,
+} = require("./app-store-access-url-log");
+const {
+  isRetryableInfrastructureError,
+  readOkJson,
+} = require("./app-store-access-url-http");
+const {routeUrlPattern} = require("./app-store-access-url-routes");
+const {
+  collectWorkerNodeDiagnostics,
+  resetWorkerDiagnosticsLog,
+} = require("./app-store-access-url-worker-diagnostics");
+
+const WORKER_DISPLAY_NAME = "App Store Access Worker";
+
+async function createMachineFromUi(page, machineName) {
+  await page.goto(MACHINES_ROUTE, {
+    waitUntil: "domcontentloaded",
+    timeout: UI_NAVIGATION_TIMEOUT_MS,
+  });
+  await expect(page).toHaveURL(routeUrlPattern(MACHINES_ROUTE));
+  await expect(machineTableTitle(page)).toBeVisible({timeout: UI_NAVIGATION_TIMEOUT_MS});
+  const addButton = machineTableTitle(page).getByRole("button", {name: "Add"});
+  await expect(addButton).toBeVisible({timeout: UI_NAVIGATION_TIMEOUT_MS});
+  logAppStoreDiagnostic("create-machine-route-ready", {machineName});
+
+  await addButton.click();
+  const addDialog = page.getByRole("dialog", {name: "Add Machine"});
+  await expect(addDialog).toBeVisible({timeout: UI_NAVIGATION_TIMEOUT_MS});
+  logAppStoreDiagnostic("create-machine-dialog-ready", {machineName});
+  await addDialog.getByPlaceholder("my-machine").fill(machineName);
+  await addDialog.getByPlaceholder("My Machine").fill(WORKER_DISPLAY_NAME);
+  await addDialog.getByPlaceholder("192.168.1.10").fill(SSH_HOST);
+  await addDialog.getByLabel(/SSH port/).fill(String(SSH_PORT));
+  await addDialog.getByPlaceholder("root").fill(SSH_USER);
+  logAppStoreDiagnostic("create-machine-fields-filled", {machineName});
+  await selectPrivateKeyAuthType(page, addDialog, machineName);
+  const privateKeyField = addDialog.getByLabel(/Private key/);
+  await privateKeyField.fill(SSH_PRIVATE_KEY);
+  logAppStoreDiagnostic("create-machine-private-key-filled", {machineName});
+
+  const addMachine = page.waitForResponse(response =>
+    response.url().includes(API_ADD_MACHINE) && response.request().method() === "POST"
+  );
+  logAppStoreDiagnostic("create-machine-submit-ready", {machineName});
+  await addDialog.getByRole("button", {name: "Add"}).click();
+  logAppStoreDiagnostic("create-machine-submit-clicked", {machineName});
+  await expectOkJson(await addMachine);
+  logAppStoreDiagnostic("create-machine-api-created", {machineName});
+  await expect(addDialog).toBeHidden();
+  await findMachineRow(page, machineName);
+  logAppStoreDiagnostic("create-machine-row-visible", {machineName});
+}
+
+async function selectPrivateKeyAuthType(page, addDialog, machineName) {
+  const authTypeSelect = addDialog.getByRole("combobox", {name: "Auth type"});
+  await authTypeSelect.click({timeout: UI_NAVIGATION_TIMEOUT_MS});
+  logAppStoreDiagnostic("create-machine-auth-dropdown-open", {machineName});
+  // Ant Design exposes the dropdown option as a hidden role=option node in CI, so use the focused combobox keyboard path.
+  await authTypeSelect.press("ArrowDown");
+  await authTypeSelect.press("Enter");
+  await expect(addDialog.getByLabel(/Private key/)).toBeVisible({timeout: UI_NAVIGATION_TIMEOUT_MS});
+  logAppStoreDiagnostic("create-machine-auth-private-key-selected", {machineName});
+}
+
+function machineTable(page) {
+  return page.locator(".ant-table-wrapper").filter({hasText: "Machines"});
+}
+
+function machineTableTitle(page) {
+  return machineTable(page).locator(".ant-table-title");
+}
+
+async function findMachineRow(page, machineName) {
+  const row = machineTable(page).locator(`tr[data-row-key="${machineName}"]`);
+  await expect(row).toBeVisible();
+  return row;
+}
+
+function workerNodeDialog(page, machineName) {
+  return page.getByRole("dialog", {name: `Worker Node - ${machineName}`});
+}
+
+async function startWorkerNodeDeployment(page, machineName) {
+  const machineRow = await findMachineRow(page, machineName);
+  await machineRow.getByRole("button", {name: "Deploy worker node"}).click();
+  const dialog = workerNodeDialog(page, machineName);
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByLabel("Node name")).toHaveValue(machineName);
+  await dialog.getByLabel("Apiserver URL").fill(E2E_APISERVER_URL);
+
+  const deployMachineNode = page.waitForResponse(response =>
+    response.url().includes(API_DEPLOY_MACHINE_NODE) && response.request().method() === "POST"
+  );
+  await dialog.getByRole("button", {name: "Deploy Node"}).click();
+  const body = await expectOkJson(await deployMachineNode);
+  expect(body.data).toMatchObject({
+    machineName,
+    nodeName: machineName,
+    apiserverUrl: E2E_APISERVER_URL,
+    status: "pending",
+    phase: "queued",
+  });
+  await expect(page.locator(".ant-message").getByText("Node deployment started", {exact: true})).toBeVisible();
+  return body.data;
+}
+
+async function waitForWorkerNodeReady(page, nodeName, taskId) {
+  const started = Date.now();
+  let lastTask;
+  let lastLogs = [];
+  let lastRetryableError = "";
+  let lastProgressLogAt = 0;
+  while (Date.now() - started < WORKER_READY_TIMEOUT_MS) {
+    try {
+      const tasks = await getMachineNodeTasks(page, nodeName);
+      const matchedTask = tasks.find(task => task.id === taskId);
+      if (!matchedTask) {
+        lastTask = {
+          id: taskId,
+          status: "pending",
+          phase: "waiting-for-task",
+          errorMsg: `expected task not found among ${tasks.length} tasks`,
+        };
+        lastRetryableError = "";
+      } else {
+        lastTask = matchedTask;
+      }
+      if (lastTask?.status === "failed") {
+        throw new Error(`worker node deployment failed during ${lastTask.phase}: ${lastTask.errorMsg || "worker task did not include errorMsg"}`);
+      }
+      if (lastTask?.status === "succeeded" && lastTask.phase === "ready") {
+        const remainingMs = Math.max(1000, WORKER_READY_TIMEOUT_MS - (Date.now() - started));
+        return waitForNodeSummary(page, nodeName, remainingMs);
+      }
+      lastRetryableError = "";
+    } catch (error) {
+      if (!isRetryableInfrastructureError(error)) {
+        throw error;
+      }
+      lastTask = {
+        id: taskId,
+        status: "pending",
+        phase: "task-poll-retry",
+        errorMsg: error.message,
+      };
+      lastRetryableError = error.message;
+    }
+    const now = Date.now();
+    if (now - lastProgressLogAt >= LOG_PROGRESS_INTERVAL_MS) {
+      lastProgressLogAt = now;
+      if (lastTask?.id) {
+        try {
+          lastLogs = await getMachineNodeLogs(page, lastTask.id);
+        } catch (error) {
+          if (!isRetryableInfrastructureError(error)) {
+            throw error;
+          }
+          lastRetryableError = error.message;
+        }
+      }
+      logAppStoreProgress("wait-worker-ready", started, {
+        task: compactTask(lastTask),
+        logs: compactDeployLogs(lastLogs, 5),
+        lastRetryableError,
+      });
+    }
+    await page.waitForTimeout(WORKER_TASK_POLL_INTERVAL_MS);
+  }
+  if (lastTask?.id) {
+    try {
+      lastLogs = await getMachineNodeLogs(page, lastTask.id);
+    } catch (error) {
+      lastRetryableError = error.message || String(error);
+    }
+  }
+  const diagnosticsPath = await collectWorkerNodeDiagnostics("worker-ready-timeout");
+  throw new Error(`timed out waiting for worker node deployment; last task: ${JSON.stringify(lastTask || null)}; last logs: ${JSON.stringify(compactDeployLogs(lastLogs, 12))}${lastRetryableError ? `; last retryable error: ${lastRetryableError}` : ""}${diagnosticsPath ? `; worker diagnostics: ${diagnosticsPath}` : ""}`);
+}
+
+async function getMachineNodeTasks(page, machineName) {
+  const response = await page.context().request.get(
+    `${API_GET_MACHINE_NODE_TASKS}?owner=${encodeURIComponent(E2E_MACHINE_OWNER)}&machineName=${encodeURIComponent(machineName)}`
+  );
+  const body = await readOkJson(response, "get-machine-node-tasks");
+  return body.data || [];
+}
+
+async function getMachineNodeLogs(page, taskId) {
+  const response = await page.context().request.get(`${API_GET_MACHINE_NODE_LOGS}?taskId=${encodeURIComponent(taskId)}`);
+  const body = await readOkJson(response, "get-machine-node-logs");
+  return body.data || [];
+}
+
+async function getNodeSummaries(page) {
+  const response = await page.context().request.get(API_GET_NODES);
+  const body = await readOkJson(response, "get-nodes");
+  return body.data || [];
+}
+
+async function waitForNodeSummary(page, nodeName, timeoutMs = 60 * 1000) {
+  const started = Date.now();
+  let lastNodes = [];
+  let lastRetryableError = "";
+  while (Date.now() - started < timeoutMs) {
+    try {
+      lastNodes = await getNodeSummaries(page);
+      const node = lastNodes.find(item => item.name === nodeName);
+      if (node?.status === "Ready" && (node.internalIP || node.externalIP)) {
+        return node;
+      }
+      lastRetryableError = "";
+    } catch (error) {
+      if (!isRetryableInfrastructureError(error)) {
+        throw error;
+      }
+      lastRetryableError = error.message;
+    }
+    await page.waitForTimeout(WORKER_NODE_POLL_INTERVAL_MS);
+  }
+  throw new Error(`worker node ${nodeName} did not become visible with an IP; nodes: ${JSON.stringify(lastNodes)}${lastRetryableError ? `; last retryable error: ${lastRetryableError}` : ""}`);
+}
+
+async function deleteMachine(page, machineName) {
+  const response = await page.context().request.post(API_DELETE_MACHINE, {
+    data: {owner: E2E_MACHINE_OWNER, name: machineName},
+  });
+  await expectOkJson(response);
+}
+
+module.exports = {
+  createMachineFromUi,
+  deleteMachine,
+  resetWorkerDiagnosticsLog,
+  startWorkerNodeDeployment,
+  waitForWorkerNodeReady,
+};

--- a/web/tests/ui/app-store-access-url.spec.js
+++ b/web/tests/ui/app-store-access-url.spec.js
@@ -1,0 +1,216 @@
+const {test} = require("@playwright/test");
+const {signInAsCiUser} = require("./e2e-helpers");
+const {
+  ACCESS_URL_FAILURE_CATEGORIES,
+  formatAccessUrlFailure,
+  shouldFailAccessUrlOutcome,
+} = require("./access-url-diagnostics");
+const {
+  ACCESS_EXPERIMENT_TIMEOUT_MS,
+  ACCESS_READY_TIMEOUT_MS,
+  E2E_APISERVER_URL,
+  HELM_READY_TIMEOUT_MS,
+  MACHINE_CREATE_TIMEOUT_MS,
+  SSH_HOST,
+  SSH_PRIVATE_KEY,
+  SSH_USER,
+  WORKER_READY_TIMEOUT_MS,
+  hasWorkerSshConfig,
+} = require("./app-store-access-url-config");
+const {
+  REPRESENTATIVE_APP_STORE_REPOS,
+  flattenRepresentativeCharts,
+} = require("./app-store-access-url-samples");
+const {
+  compactAccessOutcome,
+  compactAppStoreChart,
+  createAppStoreStageTracker,
+  makeResourceSuffix,
+} = require("./app-store-access-url-log");
+const {
+  addRepoFromAppStore,
+  cleanupHelmRelease,
+  deleteHelmRepo,
+  installChartFromAppStore,
+  waitForHelmRelease,
+} = require("./app-store-access-url-helm");
+const {probeReleaseAccessUrl} = require("./app-store-access-url-probe");
+const {
+  attachAnnotatedAccessUrlFailureScreenshot,
+  showAccessUrlFailureOverlay,
+} = require("./app-store-access-url-visual-evidence");
+const {
+  diagnosticOutcome,
+  writeAccessUrlSummary,
+} = require("../../scripts/app-store-access-url-summary");
+const {
+  createMachineFromUi,
+  deleteMachine,
+  resetWorkerDiagnosticsLog,
+  startWorkerNodeDeployment,
+  waitForWorkerNodeReady,
+} = require("./app-store-access-url-worker");
+
+test.skip(!hasWorkerSshConfig && !process.env.CI, "requires E2E_APP_STORE_SSH_USER and SSH private key for a real worker node target");
+
+test.beforeEach(async({page}) => {
+  await signInAsCiUser(page);
+});
+
+test("samples app-store charts and classifies Access URL reachability", async({page}) => {
+  const selectedCharts = flattenRepresentativeCharts();
+  const expectedFailureCases = selectedCharts.filter(chart => !chart.expectReachable).length;
+  const expectedReachableCases = selectedCharts.filter(chart => chart.expectReachable).length;
+  test.setTimeout(
+    WORKER_READY_TIMEOUT_MS +
+    MACHINE_CREATE_TIMEOUT_MS +
+    HELM_READY_TIMEOUT_MS * selectedCharts.length +
+    ACCESS_READY_TIMEOUT_MS * expectedReachableCases +
+    ACCESS_EXPERIMENT_TIMEOUT_MS * expectedFailureCases +
+    4 * 60 * 1000
+  );
+  const suffix = makeResourceSuffix();
+  const machineName = `astore-${suffix}`;
+  const repoSpecs = REPRESENTATIVE_APP_STORE_REPOS.map(repo => ({
+    ...repo,
+    repoName: `${repo.repoNamePrefix}-${suffix}`,
+  }));
+  const releaseNames = selectedCharts.map(chart => `${chart.releasePrefix}-${suffix}`);
+  const repoIds = [];
+  let createdMachine = false;
+  const stages = createAppStoreStageTracker({machineName});
+  const releaseContexts = [];
+  const outcomes = [];
+  let status = "completed";
+  let failedAccessUrlOutcomes = [];
+  await resetWorkerDiagnosticsLog();
+
+  try {
+    stages.log("test-start", {sshHost: SSH_HOST, apiserverUrl: E2E_APISERVER_URL});
+    if (!hasWorkerSshConfig || !SSH_USER || !SSH_PRIVATE_KEY) {
+      status = "diagnostic-precondition";
+      outcomes.push(diagnosticOutcome(
+        ACCESS_URL_FAILURE_CATEGORIES.CI_OR_NETWORK_DIAGNOSTIC,
+        "CI did not provide SSH credentials for the App Store Access worker precondition",
+        {source: "app-store-access-precondition"}
+      ));
+      return;
+    }
+    stages.log("app-store-representative-samples-selected", {
+      repos: repoSpecs.map(repo => ({
+        key: repo.key,
+        repoName: repo.repoName,
+        repoURL: repo.repoURL,
+        charts: repo.charts.map(compactAppStoreChart),
+      })),
+    });
+
+    await stages.run("pre-cleanup-helm-releases", async() => {
+      for (const releaseName of releaseNames) {
+        await cleanupHelmRelease(page, releaseName);
+      }
+    }, {releaseNames});
+    await stages.run("create-machine", async() => {
+      await createMachineFromUi(page, machineName);
+    }, {}, {timeoutMs: MACHINE_CREATE_TIMEOUT_MS});
+    createdMachine = true;
+
+    const task = await stages.run("start-worker-deployment", () => startWorkerNodeDeployment(page, machineName));
+    await stages.run("wait-worker-ready", () => waitForWorkerNodeReady(page, machineName, task.id));
+
+    for (const repoSpec of repoSpecs) {
+      const appStoreRepo = await stages.run(
+        "add-repo-from-app-store",
+        () => addRepoFromAppStore(page, repoSpec.repoName, repoSpec.repoURL, repoSpec.charts),
+        {repoName: repoSpec.repoName, repoURL: repoSpec.repoURL}
+      );
+      if (appStoreRepo.repoId) {
+        repoIds.push(appStoreRepo.repoId);
+      }
+      stages.log("app-store-charts-selected", {
+        repoName: repoSpec.repoName,
+        charts: appStoreRepo.charts.map(compactAppStoreChart),
+      });
+
+      for (const appStoreChart of appStoreRepo.charts) {
+        const releaseName = `${appStoreChart.releasePrefix}-${suffix}`;
+        const releaseContext = await stages.run(
+          "install-chart-from-app-store",
+          () => installChartFromAppStore(page, releaseName, appStoreChart),
+          {repoName: repoSpec.repoName, releaseName, chartName: appStoreChart.chartName}
+        );
+        releaseContexts.push(releaseContext);
+        await stages.run("wait-helm-release", () => waitForHelmRelease(page, releaseContext), {
+          releaseName,
+          chartName: appStoreChart.chartName,
+        });
+      }
+    }
+
+    for (const releaseContext of releaseContexts) {
+      const timeoutMs = releaseContext.expectReachable ? ACCESS_READY_TIMEOUT_MS : ACCESS_EXPERIMENT_TIMEOUT_MS;
+      const outcome = await stages.run(
+        "probe-access-url",
+        () => probeReleaseAccessUrl(page, releaseContext, {timeoutMs}),
+        {releaseName: releaseContext.releaseName, chartName: releaseContext.chartName, timeoutMs}
+      );
+      outcomes.push(outcome);
+      stages.log("access-url-case-result", compactAccessOutcome(outcome));
+    }
+
+  } catch (error) {
+    status = "diagnostic-error";
+    stages.log("access-url-experiment-diagnostic-error", {error: error.message || String(error)});
+    outcomes.push(diagnosticOutcome(
+      ACCESS_URL_FAILURE_CATEGORIES.TEST_HARNESS_DIAGNOSTIC,
+      `App Store Access URL experiment stopped before product gate: ${error.message || String(error)}`,
+      {source: "app-store-access-experiment"}
+    ));
+  } finally {
+    await writeAccessUrlSummary(outcomes, {status})
+      .then(payload => {
+        stages.log("access-url-classification-summary", payload.summary);
+      })
+      .catch(error => {
+        stages.log("access-url-summary-write-fail", {error: error.message});
+      });
+    failedAccessUrlOutcomes = outcomes.filter(shouldFailAccessUrlOutcome);
+    if (failedAccessUrlOutcomes.length > 0) {
+      await attachAnnotatedAccessUrlFailureScreenshot(page, failedAccessUrlOutcomes, test.info())
+        .catch(error => {
+          stages.log("access-url-failure-annotation-fail", {error: error.message});
+        });
+    }
+    await stages.run("cleanup-helm-releases", async() => {
+      for (const releaseName of [...releaseNames].reverse()) {
+        try {
+          await cleanupHelmRelease(page, releaseName);
+        } catch (error) {
+          stages.log("cleanup-helm-release-fail", {releaseName, error: error.message});
+        }
+      }
+    }).catch(() => {});
+    for (const repoId of [...repoIds].reverse()) {
+      await stages.run("delete-helm-repo", () => deleteHelmRepo(page, repoId), {repoId}).catch(() => {});
+    }
+    if (createdMachine) {
+      await stages.run("delete-machine", () => deleteMachine(page, machineName)).catch(() => {});
+    }
+    if (failedAccessUrlOutcomes.length > 0) {
+      await showAccessUrlFailureOverlay(page, failedAccessUrlOutcomes)
+        .catch(error => {
+          stages.log("access-url-final-overlay-fail", {error: error.message});
+        });
+    }
+    stages.finish();
+  }
+
+  if (failedAccessUrlOutcomes.length > 0) {
+    throw new Error(
+      [
+        `${failedAccessUrlOutcomes.length} rendered App Store Access URL sample(s) could not be opened`,
+        ...failedAccessUrlOutcomes.map(outcome => formatAccessUrlFailure(outcome)),
+      ].join("\n")
+    );
+  }
+});


### PR DESCRIPTION
﻿## Summary
- add a GitHub Actions App Store Access URL E2E flow that starts a temporary QEMU/KVM Ubuntu worker VM and lets CasOS deploy it as a worker
- install representative App Store charts through the UI, open rendered Deployment Access URLs from the Deployments page, and classify unreachable URLs by evidence ownership
- add a product gate, structured summary/log artifacts, worker diagnostics, Playwright video/trace, and annotated failure screenshots for Access URL failures

## Why
This adds CI automation for the App Store Access URL workflow. The test clicks the same Access URL links users see on the Deployments page, fails when rendered Access URLs cannot be opened, and separates product candidates from app workload, CI/network, and test harness diagnostics.

No corresponding issue was found for this CI automation feature.

## Validation
- yarn run ui:test:selector:check
- yarn run ui:test:access-url-diagnostics:check
- git diff --check origin/master...HEAD
- GitHub Actions run on fork verified the Access URL test fails with classified URL failures and uploads annotated screenshots/videos/trace
