### PR TITLE
fix: run App Store UI regression tests with worker node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,32 +124,35 @@ jobs:
             echo "(none; fixed smoke already ran)"
             echo "has_tests=false" >> "$GITHUB_OUTPUT"
           fi
-          if grep -qxF "tests/ui/worker-node-ready.spec.js" web/ui-regression-tests.txt; then
-            echo "has_worker_vm_tests=true" >> "$GITHUB_OUTPUT"
+          grep -vxF "tests/ui/worker-node-ready.spec.js" web/ui-regression-tests.txt | grep -vxF "tests/ui/app-store.spec.js" > web/ui-standard-regression-tests.txt || true
+          grep -xF "tests/ui/app-store.spec.js" web/ui-regression-tests.txt > web/ui-app-store-tests.txt || true
+          echo "Standard UI regression tests:"
+          if [[ -s web/ui-standard-regression-tests.txt ]]; then
+            cat web/ui-standard-regression-tests.txt
+            echo "has_standard_tests=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_worker_vm_tests=false" >> "$GITHUB_OUTPUT"
+            echo "(none)"
+            echo "has_standard_tests=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Run UI regression tests
-        if: steps.ui-regression-tests.outputs.has_tests == 'true'
-        working-directory: ./web
-        shell: bash
-        run: |
-          set -o pipefail
-          mapfile -t ui_test_files < <(grep -vxF "tests/ui/worker-node-ready.spec.js" ui-regression-tests.txt || true)
-          if [[ ${#ui_test_files[@]} -gt 0 ]]; then
-            yarn run ui:test:regression -- "${ui_test_files[@]}" 2>&1 | tee ui-test.log
+          echo "App Store UI regression tests:"
+          if [[ -s web/ui-app-store-tests.txt ]]; then
+            cat web/ui-app-store-tests.txt
           else
-            echo "Only the worker-node-ready VM test was selected; it runs in its own step." | tee ui-test.log
+            echo "(none)"
           fi
-      - name: Skip UI regression tests
-        if: steps.ui-regression-tests.outputs.has_tests != 'true'
-        working-directory: ./web
-        shell: bash
-        run: |
-          echo "No changed-path UI regression tests selected; fixed smoke already ran." | tee ui-test.log
+          if [[ -s web/ui-app-store-tests.txt ]]; then
+            echo "has_app_store_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_app_store_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+          if grep -qxF "tests/ui/worker-node-ready.spec.js" web/ui-regression-tests.txt || grep -qxF "tests/ui/app-store.spec.js" web/ui-regression-tests.txt; then
+            echo "needs_worker_vm=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_worker_vm=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Prepare worker node VM
         id: prepare-worker-vm
-        if: steps.ui-regression-tests.outputs.has_worker_vm_tests == 'true'
+        if: steps.ui-regression-tests.outputs.needs_worker_vm == 'true'
         continue-on-error: true
         timeout-minutes: 15
         shell: bash
@@ -274,16 +277,51 @@ jobs:
           echo "E2E_WORKER_VM_IP=$worker_vm_ip" >> "$GITHUB_ENV"
           echo "apiserverBind=0.0.0.0" >> "$GITHUB_ENV"
           echo "E2E_APISERVER_URL=https://${host_bridge_ip}:${E2E_APISERVER_PORT}" >> "$GITHUB_ENV"
-      - name: Run worker node ready UI test
-        if: steps.ui-regression-tests.outputs.has_worker_vm_tests == 'true' && steps.prepare-worker-vm.outcome == 'success'
+      - name: Require worker node VM for selected UI tests
+        if: steps.ui-regression-tests.outputs.needs_worker_vm == 'true' && steps.prepare-worker-vm.outcome != 'success'
+        shell: bash
+        run: |
+          echo "Selected UI tests require a prepared worker node VM." >&2
+          exit 1
+      - name: Validate worker node is ready for worker VM UI tests
+        if: steps.ui-regression-tests.outputs.needs_worker_vm == 'true' && steps.prepare-worker-vm.outcome == 'success'
+        working-directory: ./web
+        timeout-minutes: 20
+        shell: bash
+        env:
+          E2E_DATA_DIR: ${{ runner.temp }}/casos-e2e-${{ github.run_id }}-${{ github.run_attempt }}-worker
+        run: |
+          set -o pipefail
+          yarn playwright test --workers=1 tests/ui/worker-node-ready.spec.js 2>&1 | tee ui-worker-node-ready-test.log
+      - name: Run App Store UI tests
+        if: steps.ui-regression-tests.outputs.has_app_store_tests == 'true' && steps.prepare-worker-vm.outcome == 'success'
+        working-directory: ./web
+        timeout-minutes: 20
+        shell: bash
+        env:
+          E2E_DATA_DIR: ${{ runner.temp }}/casos-e2e-${{ github.run_id }}-${{ github.run_attempt }}-worker
+        run: |
+          set -o pipefail
+          mapfile -t ui_test_files < ui-app-store-tests.txt
+          # App install tests share VM and cluster state, so run serially without retries to avoid retrying against partially installed releases.
+          yarn playwright test --grep-invert @smoke --workers=1 --retries=0 --reporter=list "${ui_test_files[@]}" 2>&1 | tee ui-app-store-test.log
+      - name: Run UI regression tests
+        if: steps.ui-regression-tests.outputs.has_standard_tests == 'true'
         working-directory: ./web
         timeout-minutes: 20
         shell: bash
         run: |
           set -o pipefail
-          yarn playwright test --workers=1 tests/ui/worker-node-ready.spec.js 2>&1 | tee ui-worker-node-ready-test.log
+          mapfile -t ui_test_files < ui-standard-regression-tests.txt
+          yarn run ui:test:regression -- "${ui_test_files[@]}" 2>&1 | tee ui-test.log
+      - name: Skip UI regression tests
+        if: steps.ui-regression-tests.outputs.has_standard_tests != 'true'
+        working-directory: ./web
+        shell: bash
+        run: |
+          echo "No standard changed-path UI regression tests selected; fixed smoke already ran." | tee ui-test.log
       - name: Cleanup worker node VM
-        if: always() && steps.ui-regression-tests.outputs.has_worker_vm_tests == 'true'
+        if: always() && steps.ui-regression-tests.outputs.needs_worker_vm == 'true'
         shell: bash
         run: |
           set +e
@@ -314,9 +352,12 @@ jobs:
             ./web/test-results
             ./web/ui-changed-files.txt
             ./web/ui-regression-tests.txt
+            ./web/ui-standard-regression-tests.txt
+            ./web/ui-app-store-tests.txt
             ./web/ui-smoke-test.log
             ./web/ui-test.log
             ./web/ui-worker-node-ready-test.log
+            ./web/ui-app-store-test.log
             ${{ runner.temp }}/casos-worker-vm/serial.log
           if-no-files-found: ignore
 

--- a/web/tests/ui/app-store-helpers.js
+++ b/web/tests/ui/app-store-helpers.js
@@ -6,6 +6,7 @@ const API_UNINSTALL_HELM_RELEASE = "/api/uninstall-helm-release";
 const API_ADD_HELM_REPO = "/api/add-helm-repo";
 const API_GET_HELM_REPOS = "/api/get-helm-repos";
 const API_DELETE_HELM_REPO = "/api/delete-helm-repo";
+const INSTALL_DONE_TIMEOUT_MS = Number(process.env.E2E_APP_INSTALL_DONE_TIMEOUT_MS) || 11 * 60 * 1000;
 const HTTP_CHECK_TIMEOUT_MS = Number(process.env.E2E_APP_HTTP_TIMEOUT_MS) || 180_000;
 const HTTP_CHECK_INTERVAL_MS = 3_000;
 
@@ -95,12 +96,40 @@ function installModal(page) {
   return page.getByRole("dialog").filter({hasText: "Install chart"});
 }
 
+function compactInstallDialogText(text) {
+  const trimmed = text.trim();
+  if (trimmed.length <= 4000) {
+    return trimmed || "No install dialog text was available.";
+  }
+  return `${trimmed.slice(0, 1800)}\n...\n${trimmed.slice(-1800)}`;
+}
+
+async function waitForInstallDone(dialog) {
+  const doneButton = dialog.getByRole("button", {name: "Done"});
+  const errorAlert = dialog.locator(".ant-alert-error").first();
+  const deadline = Date.now() + INSTALL_DONE_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    if (await doneButton.isVisible()) {
+      return;
+    }
+    if (await errorAlert.isVisible()) {
+      const dialogText = compactInstallDialogText(await dialog.innerText());
+      throw new Error(`Helm install failed before completion:\n${dialogText}`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+
+  const dialogText = compactInstallDialogText(await dialog.innerText());
+  throw new Error(`Timed out waiting for Helm install to complete:\n${dialogText}`);
+}
+
 async function openChartInstallModal(page, {repoName, chartName}) {
   await page.goto("/app-store");
   await expect(page).toHaveURL(/\/app-store$/);
 
   await page.getByText(repoName, {exact: true}).click();
-  const chartCard = page.locator(".ant-card").filter({has: page.getByText(chartName, {exact: true})});
+  const chartCard = page.locator(".ant-row .ant-col .ant-card").filter({has: page.getByText(chartName, {exact: true})});
   await expect(chartCard).toBeVisible({timeout: 30_000});
   await chartCard.getByRole("button", {name: "Install"}).click();
 
@@ -125,7 +154,7 @@ async function installAppFromAppStore(page, {repoName, chartName, releaseName, n
   await dialog.getByRole("button", {name: "Install"}).click();
   installedReleases.push({name: releaseName, namespace});
 
-  await expect(dialog.getByRole("button", {name: "Done"})).toBeVisible({timeout: 120_000});
+  await waitForInstallDone(dialog);
   await dialog.getByRole("button", {name: "Done"}).click();
   await expect(dialog).toBeHidden();
 }

--- a/web/tests/ui/app-store.spec.js
+++ b/web/tests/ui/app-store.spec.js
@@ -15,8 +15,10 @@ const appStoreTest = test.extend({
   installedReleases: installedReleasesFixture,
   addedHelmRepos: addedHelmReposFixture,
 });
+appStoreTest.describe.configure({mode: "serial", retries: 0});
 
 const E2E_NAMESPACE = "default";
+const APP_STORE_INSTALL_TIMEOUT_MS = Number(process.env.E2E_APP_INSTALL_TIMEOUT_MS) || 15 * 60 * 1000;
 // Official OCI-hosted chart for Casdoor, the identity/SSO provider this project itself
 // authenticates against (see controllers/e2e.go's casdoorsdk usage).
 const CASDOOR_OCI_REPO_URL = "oci://registry-1.docker.io/casbin/casdoor-helm-charts";
@@ -26,11 +28,37 @@ function nodePortValues(releaseName) {
   return `fullnameOverride: ${releaseName}\nservice:\n  type: NodePort\n`;
 }
 
+function casdoorValues(releaseName) {
+  return `${nodePortValues(releaseName)}config: |
+  appname = casdoor
+  httpport = {{ .Values.service.port }}
+  runmode = dev
+  SessionOn = true
+  copyrequestbody = true
+  driverName = sqlite
+  dataSourceName = /tmp/casdoor.db
+  dbName = {{ include "casdoor.dbName" . }}
+  redisEndpoint =
+  defaultStorageProvider =
+  isCloudIntranet = false
+  authState = "casdoor"
+  socks5Proxy = ""
+  verificationCodeTimeout = 10
+  initScore = 0
+  logPostOnly = true
+  origin =
+  enableGzip = true
+  ldapServerPort = 10389
+  initDataFile = ""
+`;
+}
+
 appStoreTest.beforeEach(async({page}) => {
   await signInAsCiUser(page);
 });
 
 appStoreTest("installs nginx from the App Store and serves its default page via the access URL", async({page, request, installedReleases}) => {
+  appStoreTest.setTimeout(APP_STORE_INSTALL_TIMEOUT_MS);
   const releaseName = makeReleaseName("e2e-nginx");
 
   await installAppFromAppStore(page, {
@@ -49,6 +77,7 @@ appStoreTest("installs nginx from the App Store and serves its default page via 
 });
 
 appStoreTest("installs Casdoor from the App Store and serves its login page via the access URL", async({page, request, installedReleases, addedHelmRepos}) => {
+  appStoreTest.setTimeout(APP_STORE_INSTALL_TIMEOUT_MS);
   const releaseName = makeReleaseName("e2e-casdoor");
   const repoName = makeRepoName("casdoor");
 
@@ -63,7 +92,7 @@ appStoreTest("installs Casdoor from the App Store and serves its login page via 
     chartName: CASDOOR_CHART_NAME,
     releaseName,
     namespace: E2E_NAMESPACE,
-    valuesYAML: nodePortValues(releaseName),
+    valuesYAML: casdoorValues(releaseName),
     installedReleases,
   });
 


### PR DESCRIPTION
﻿## Summary

This PR adds the App Store install/access-url regression path to the existing UI test workflow.

It keeps the CI/regression coverage separate from the product fix so the failing App Store behavior can be reviewed independently from the code that later fixes it.

## What changes

- Selects `tests/ui/app-store.spec.js` when App Store, Helm chart, ingress/access URL, or related install paths change.
- Runs App Store regression tests only after a worker VM has been prepared and validated.
- Treats the worker VM as a hard prerequisite for every selected UI test that needs it, so CI cannot go green by skipping worker-dependent tests after VM setup fails.
- Runs App Store install tests serially without retries because they share VM and cluster state.
- Extends artifact upload with App Store logs and selected-test files.
- Preserves the Casdoor install/access-url test intent and adds nginx from Bitnami coverage as the faster baseline install case.

## Why this is split out

This PR is the regression/CI layer. On the current product code, this path may fail because it exposes the App Store install/access-url problem instead of hiding it behind a lighter test case. A follow-up product fix should make this same path pass.

This split makes the review boundary clearer:

1. This PR: make CI run the meaningful App Store regression path with the worker-node prerequisite.
2. Follow-up product fix: repair the Helm/App Store behavior surfaced by the regression.

## Validation

- `node web/scripts/select-ui-tests-check.js`
- `git diff --check origin/master..HEAD`
- Text assertion: `needs_worker_vm` uses the generic worker VM failure gate and the old App Store-only gate is absent
- Fork validation:
  - bugkeep/casos#15 reaches the App Store regression and fails on the product install issue (`download chart: HTTP 403` on the current base)
  - bugkeep/casos#16 is stacked on the same CI path and shows the product-fix direction passing the App Store UI test path

No corresponding issue is known, so this uses the fallback `fix:` title/commit format.
