### PR TITLE
fix: finish worker deployment after delayed node readiness

### DIFF
--- a/deploy/node_bootstrap.go
+++ b/deploy/node_bootstrap.go
@@ -13,6 +13,11 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+type nodeBootstrapState struct {
+	podCIDR string
+	ready   bool
+}
+
 type NodeDeployer struct {
 	config     Config
 	restConfig *rest.Config
@@ -93,26 +98,32 @@ func (d *NodeDeployer) Deploy(ctx context.Context, opts NodeDeployOptions) (*Nod
 	}
 
 	d.logStep(nodeDeployPhaseWaiting, "Waiting for node registration")
-	podCIDR, err := d.waitForNodePodCIDR(ctx, opts.NodeName)
+	bootstrapState, err := d.waitForNodeBootstrapState(ctx, opts.NodeName)
 	if err != nil {
 		return nil, err
 	}
 
-	d.logStep(nodeDeployPhaseConfiguring, "Writing node CNI config")
-	if err = runner.WriteFileContext(ctx, "/etc/cni/net.d/10-casos-bridge.conflist", bridgeCNIConfig(podCIDR), "0644"); err != nil {
-		return nil, fmt.Errorf("write /etc/cni/net.d/10-casos-bridge.conflist: %w", err)
-	}
-	if _, err = runner.RunRootContext(ctx, "systemctl restart kubelet"); err != nil {
-		return nil, fmt.Errorf("restart kubelet: %w", err)
+	if bootstrapState.podCIDR != "" {
+		d.logStep(nodeDeployPhaseConfiguring, "Writing node CNI config")
+		if err = runner.WriteFileContext(ctx, "/etc/cni/net.d/10-casos-bridge.conflist", bridgeCNIConfig(bootstrapState.podCIDR), "0644"); err != nil {
+			return nil, fmt.Errorf("write /etc/cni/net.d/10-casos-bridge.conflist: %w", err)
+		}
+		if _, err = runner.RunRootContext(ctx, "systemctl restart kubelet"); err != nil {
+			return nil, fmt.Errorf("restart kubelet: %w", err)
+		}
 	}
 
 	if err = d.startKubeProxy(ctx, runner); err != nil {
 		return nil, err
 	}
 
-	d.logStep(nodeDeployPhaseWaiting, "Waiting for Node Ready")
-	if err = d.waitForNodeReady(ctx, opts.NodeName); err != nil {
-		return nil, err
+	if !bootstrapState.ready {
+		d.logStep(nodeDeployPhaseWaiting, "Waiting for Node Ready")
+		if err = d.waitForNodeReady(ctx, opts.NodeName); err != nil {
+			return nil, err
+		}
+	} else {
+		d.logStep(nodeDeployPhaseWaiting, "Node is already Ready")
 	}
 
 	d.logStep(nodeDeployPhaseConfiguring, "Writing CasOS managed SSH key")
@@ -138,34 +149,46 @@ func newRunnerForMachine(machine NodeDeployMachine) (*NodeDeploySSHRunner, error
 	})
 }
 
-func (d *NodeDeployer) waitForNodePodCIDR(ctx context.Context, nodeName string) (string, error) {
+func (d *NodeDeployer) waitForNodeBootstrapState(ctx context.Context, nodeName string) (*nodeBootstrapState, error) {
 	if d.restConfig == nil {
-		return "", fmt.Errorf("apiserver rest config is required")
+		return nil, fmt.Errorf("apiserver rest config is required")
 	}
 	client, err := kubernetes.NewForConfig(d.restConfig)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	deadlineTimer, deadline := deploymentWaitDeadline(ctx)
 	ticker := time.NewTicker(3 * time.Second)
 	defer deadlineTimer.Stop()
 	defer ticker.Stop()
+	lastState := &nodeBootstrapState{}
 	for {
 		select {
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return nil, ctx.Err()
 		case <-deadline:
-			return "", fmt.Errorf("timed out waiting for node PodCIDR")
+			if lastState.ready {
+				return nil, fmt.Errorf("timed out waiting for PodCIDR assignment after node became Ready")
+			}
+			return nil, fmt.Errorf("timed out waiting for node registration")
 		case <-ticker.C:
 			node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
-					return "", err
+					return nil, err
 				}
 				continue
 			}
-			if node.Spec.PodCIDR != "" {
-				return node.Spec.PodCIDR, nil
+			state := &nodeBootstrapState{
+				podCIDR: node.Spec.PodCIDR,
+				ready:   isNodeReady(node),
+			}
+			lastState = state
+			if state.podCIDR != "" {
+				return state, nil
+			}
+			if state.ready {
+				d.logStep(nodeDeployPhaseWaiting, "Node is Ready; waiting for PodCIDR assignment")
 			}
 		}
 	}
@@ -197,13 +220,23 @@ func (d *NodeDeployer) waitForNodeReady(ctx context.Context, nodeName string) er
 				}
 				continue
 			}
-			for _, condition := range node.Status.Conditions {
-				if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-					return nil
-				}
+			if isNodeReady(node) {
+				return nil
 			}
 		}
 	}
+}
+
+func isNodeReady(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *NodeDeployer) apiserverVersion() (string, error) {


### PR DESCRIPTION
## Problem

Automatic worker deployment could fail when node readiness arrived later than resource creation. However, the first version of this fix also introduced a more subtle risk: if a worker node reported `Ready=True` before `PodCIDR` was assigned, the deploy flow could continue as if an existing CNI config were reusable.

That is unsafe for a new worker node because the CasOS bridge CNI config depends on `PodCIDR` to write `/etc/cni/net.d/10-casos-bridge.conflist`.

## Root Cause

The bootstrap wait loop returned when either of these became true:

- `node.Spec.PodCIDR != ""`
- node `Ready=True`

For this deploy path, `Ready=True` alone is not enough. Without `PodCIDR`, CasOS cannot generate the node bridge CNI config, so treating that state as successful can leave the node with broken pod networking.

## Fix

- keep the shared `isNodeReady()` helper
- continue waiting when the node is Ready but `PodCIDR` is still empty
- only return from bootstrap waiting once `PodCIDR` is assigned
- remove the optimistic "reuse existing node CNI config" branch
- return a clearer timeout error when a node becomes Ready but never receives `PodCIDR`

## Validation

- `go test ./deploy`
- Alibaba Open Code Review was run after the change and generated no comments
- verified this PR still contains exactly one commit on top of `master`

## Scope

This PR only adjusts worker-node bootstrap readiness handling. It does not change CNI file format, kubelet startup, kube-proxy startup, or App Store behavior.
