### PR TITLE
fix: bootstrap local app store platform dependencies

### DIFF
--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"encoding/json"
+	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +20,7 @@ type deploymentSummary struct {
 	ReadyReplicas     int32             `json:"readyReplicas"`
 	AvailableReplicas int32             `json:"availableReplicas"`
 	Image             string            `json:"image"`
+	Ports             []portSummary     `json:"ports"`
 	Selector          map[string]string `json:"selector"`
 	EnvVars           []envVarSummary   `json:"envVars"`
 	Volumes           []volumeSummary   `json:"volumes"`
@@ -39,6 +41,21 @@ func toDeploymentSummary(d appsv1.Deployment) deploymentSummary {
 	if d.Spec.Selector != nil {
 		selector = d.Spec.Selector.MatchLabels
 	}
+	ports := []portSummary{}
+	for _, container := range d.Spec.Template.Spec.Containers {
+		for _, p := range container.Ports {
+			protocol := string(p.Protocol)
+			if protocol == "" {
+				protocol = string(corev1.ProtocolTCP)
+			}
+			ports = append(ports, portSummary{
+				Name:       p.Name,
+				Protocol:   protocol,
+				Port:       p.ContainerPort,
+				TargetPort: strconv.FormatInt(int64(p.ContainerPort), 10),
+			})
+		}
+	}
 	return deploymentSummary{
 		Namespace:         d.Namespace,
 		Name:              d.Name,
@@ -46,6 +63,7 @@ func toDeploymentSummary(d appsv1.Deployment) deploymentSummary {
 		ReadyReplicas:     d.Status.ReadyReplicas,
 		AvailableReplicas: d.Status.AvailableReplicas,
 		Image:             image,
+		Ports:             ports,
 		Selector:          selector,
 		EnvVars:           extractEnvVars(d.Spec.Template.Spec.Containers),
 		Volumes:           extractVolumes(d),

--- a/server/bootstrap.go
+++ b/server/bootstrap.go
@@ -25,6 +25,14 @@ func Bootstrap(ctx context.Context, cfg *rest.Config, srvCfg Config) error {
 	if err := ensureNodeProxierBinding(ctx, client); err != nil {
 		return err
 	}
+	if err := ensureClusterDNS(ctx, client, srvCfg); err != nil {
+		return err
+	}
+	if srvCfg.StorageProvisionerEnabled {
+		if err := ensureDefaultStorageProvisioner(ctx, client, srvCfg); err != nil {
+			return err
+		}
+	}
 	return ensureCasbinWebhook(ctx, client, srvCfg)
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -7,18 +7,23 @@ import (
 	"strings"
 
 	"github.com/casosorg/casos/conf"
+	"github.com/sirupsen/logrus"
 )
 
 // Config holds control-plane settings populated from app.conf.
 type Config struct {
-	DataDir          string
-	ApiserverBind    string // actual bind / SAN IP (may be loopback in dev)
-	AdvertiseAddress string // non-loopback IP registered as kubernetes service endpoint
-	ApiserverPort    int
-	WebhookPort      int    // HTTPS port for the Casbin admission webhook server
-	DSN              string // MySQL DSN forwarded to kine
-	SandboxImage     string // containerd sandbox (pause) image, empty = upstream default
-	Socks5Proxy      string // outbound socks5 proxy, e.g. 127.0.0.1:10808
+	DataDir                   string
+	ApiserverBind             string // actual bind / SAN IP (may be loopback in dev)
+	AdvertiseAddress          string // non-loopback IP registered as kubernetes service endpoint
+	ApiserverPort             int
+	WebhookPort               int    // HTTPS port for the Casbin admission webhook server
+	DSN                       string // MySQL DSN forwarded to kine
+	SandboxImage              string // containerd sandbox (pause) image, empty = upstream default
+	Socks5Proxy               string // outbound socks5 proxy, e.g. 127.0.0.1:10808
+	CoreDNSImage              string // CoreDNS image used by the built-in DNS bootstrap
+	LocalPathProvisionerImage string // local-path-provisioner controller image
+	LocalPathHelperImage      string // helper pod image used by local-path-provisioner
+	StorageProvisionerEnabled bool   // install the built-in local-path provisioner for local clusters
 }
 
 // ConfigFromAppConf reads server config from the beego app.conf.
@@ -66,15 +71,24 @@ func ConfigFromAppConf() (Config, error) {
 		}
 	}
 
+	storageProvisionerEnabled := configBool("storageProvisionerEnabled", true)
+	coreDNSImage := configStringDefault("coreDNSImage", "docker.1ms.run/coredns/coredns:1.12.4")
+	localPathProvisionerImage := configStringDefault("localPathProvisionerImage", "docker.1ms.run/rancher/local-path-provisioner:v0.0.32")
+	localPathHelperImage := configStringDefault("localPathHelperImage", "docker.1ms.run/library/busybox:1.37.0")
+
 	return Config{
-		DataDir:          dataDir,
-		ApiserverBind:    bind,
-		AdvertiseAddress: advertise,
-		ApiserverPort:    port,
-		WebhookPort:      webhookPort,
-		DSN:              dsn,
-		SandboxImage:     sandboxImage,
-		Socks5Proxy:      socks5Proxy,
+		DataDir:                   dataDir,
+		ApiserverBind:             bind,
+		AdvertiseAddress:          advertise,
+		ApiserverPort:             port,
+		WebhookPort:               webhookPort,
+		DSN:                       dsn,
+		SandboxImage:              sandboxImage,
+		Socks5Proxy:               socks5Proxy,
+		CoreDNSImage:              coreDNSImage,
+		LocalPathProvisionerImage: localPathProvisionerImage,
+		LocalPathHelperImage:      localPathHelperImage,
+		StorageProvisionerEnabled: storageProvisionerEnabled,
 	}, nil
 }
 
@@ -88,6 +102,33 @@ func configInt(key string) int {
 		return 0
 	}
 	return res
+}
+
+func configBool(key string, defaultValue bool) bool {
+	value := strings.TrimSpace(conf.GetConfigString(key))
+	if value == "" {
+		return defaultValue
+	}
+	switch strings.ToLower(value) {
+	case "yes", "y", "on":
+		return true
+	case "no", "n", "off":
+		return false
+	}
+	res, err := strconv.ParseBool(value)
+	if err != nil {
+		logrus.Warnf("invalid boolean config %s=%q, using default %t", key, value, defaultValue)
+		return defaultValue
+	}
+	return res
+}
+
+func configStringDefault(key, defaultValue string) string {
+	value := strings.TrimSpace(conf.GetConfigString(key))
+	if value == "" {
+		return defaultValue
+	}
+	return value
 }
 
 // injectDBName inserts dbName into a MySQL DSN of the form

--- a/server/dns_bootstrap.go
+++ b/server/dns_bootstrap.go
@@ -1,0 +1,364 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	clusterDNSNamespace = "kube-system"
+	clusterDNSName      = "coredns"
+	// coreDNSRolloutRev forces a rollout when the managed CoreDNS pod template changes.
+	coreDNSRolloutRev = "4"
+)
+
+func ensureClusterDNS(ctx context.Context, client kubernetes.Interface, cfg Config) error {
+	if err := ensureNamespace(ctx, client, clusterDNSNamespace); err != nil {
+		return err
+	}
+	managed, err := isCoreDNSServiceManaged(ctx, client)
+	if err != nil {
+		return err
+	}
+	if !managed {
+		logrus.Warn("Skipping CoreDNS bootstrap because kube-system/kube-dns is not managed by casos")
+		return nil
+	}
+	if err := ensureCoreDNSServiceAccount(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureCoreDNSClusterRole(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureCoreDNSClusterRoleBinding(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureCoreDNSConfigMap(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureCoreDNSService(ctx, client); err != nil {
+		return err
+	}
+	return ensureCoreDNSDeployment(ctx, client, cfg)
+}
+
+func ensureCoreDNSServiceAccount(ctx context.Context, client kubernetes.Interface) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterDNSName,
+			Namespace: clusterDNSNamespace,
+			Labels:    coreDNSLabels(),
+		},
+	}
+	return createOrUpdateServiceAccount(ctx, client, sa)
+}
+
+func ensureCoreDNSClusterRole(ctx context.Context, client kubernetes.Interface) error {
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "system:coredns",
+			Labels: coreDNSLabels(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"endpoints", "services", "pods", "namespaces"},
+				Verbs:     []string{"list", "watch"},
+			},
+			{
+				APIGroups: []string{"discovery.k8s.io"},
+				Resources: []string{"endpointslices"},
+				Verbs:     []string{"list", "watch"},
+			},
+		},
+	}
+	return createOrUpdateClusterRole(ctx, client, role)
+}
+
+func ensureCoreDNSClusterRoleBinding(ctx context.Context, client kubernetes.Interface) error {
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "system:coredns",
+			Labels: coreDNSLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "system:coredns",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      clusterDNSName,
+				Namespace: clusterDNSNamespace,
+			},
+		},
+	}
+	return createOrUpdateClusterRoleBinding(ctx, client, binding)
+}
+
+func ensureCoreDNSConfigMap(ctx context.Context, client kubernetes.Interface) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterDNSName,
+			Namespace: clusterDNSNamespace,
+			Labels:    coreDNSLabels(),
+		},
+		Data: map[string]string{
+			"Corefile": `.:53 {
+    errors
+    health
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+        ttl 30
+    }
+    forward . /etc/resolv.conf
+    cache 30
+    loop
+    reload
+    loadbalance
+}
+`,
+		},
+	}
+	return createOrUpdateConfigMap(ctx, client, cm)
+}
+
+func ensureCoreDNSService(ctx context.Context, client kubernetes.Interface) error {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-dns",
+			Namespace: clusterDNSNamespace,
+			Labels:    coreDNSLabels(),
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: coreDNSSelectorLabels(),
+			Ports: []corev1.ServicePort{
+				{Name: "dns", Port: 53, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt(53)},
+				{Name: "dns-tcp", Port: 53, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(53)},
+				{Name: "metrics", Port: 9153, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(9153)},
+			},
+		},
+	}
+	return createOrUpdateService(ctx, client, svc)
+}
+
+func ensureCoreDNSDeployment(ctx context.Context, client kubernetes.Interface, cfg Config) error {
+	replicas := int32(1)
+	maxSurge := intstr.FromInt(1)
+	maxUnavailable := intstr.FromInt(0)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterDNSName,
+			Namespace: clusterDNSNamespace,
+			Labels:    coreDNSLabels(),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: coreDNSSelectorLabels()},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &maxSurge,
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: coreDNSLabels(),
+					Annotations: map[string]string{
+						"prometheus.io/port":   "9153",
+						"prometheus.io/scrape": "true",
+						"casos.io/rollout-rev": coreDNSRolloutRev,
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: clusterDNSName,
+					DNSPolicy:          corev1.DNSDefault,
+					Tolerations: []corev1.Toleration{
+						{Key: "CriticalAddonsOnly", Operator: corev1.TolerationOpExists},
+						{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            clusterDNSName,
+							Image:           cfg.CoreDNSImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Args:            []string{"-conf", "/etc/coredns/Corefile"},
+							Ports: []corev1.ContainerPort{
+								{Name: "dns", ContainerPort: 53, Protocol: corev1.ProtocolUDP},
+								{Name: "dns-tcp", ContainerPort: 53, Protocol: corev1.ProtocolTCP},
+								{Name: "metrics", ContainerPort: 9153, Protocol: corev1.ProtocolTCP},
+								{Name: "health", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+								{Name: "ready", ContainerPort: 8181, Protocol: corev1.ProtocolTCP},
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/health",
+										Port:   intstr.FromInt(8080),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 10,
+								TimeoutSeconds:      5,
+								SuccessThreshold:    1,
+								FailureThreshold:    5,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/ready",
+										Port:   intstr.FromInt(8181),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 10,
+								TimeoutSeconds:      5,
+								PeriodSeconds:       10,
+								FailureThreshold:    3,
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("70Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("170Mi"),
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr(false),
+								ReadOnlyRootFilesystem:   ptr(true),
+								RunAsNonRoot:             ptr(true),
+								RunAsUser:                ptr(int64(65534)),
+								RunAsGroup:               ptr(int64(65534)),
+								Capabilities: &corev1.Capabilities{
+									Add:  []corev1.Capability{"NET_BIND_SERVICE"},
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "config-volume", MountPath: "/etc/coredns", ReadOnly: true},
+								{Name: "tmp", MountPath: "/tmp"},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config-volume",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: clusterDNSName},
+									Items: []corev1.KeyToPath{
+										{Key: "Corefile", Path: "Corefile"},
+									},
+								},
+							},
+						},
+						{
+							Name: "tmp",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return createOrUpdateDeployment(ctx, client, deployment)
+}
+
+func coreDNSLabels() map[string]string {
+	labels := coreDNSSelectorLabels()
+	labels["k8s-app"] = "kube-dns"
+	return labels
+}
+
+func coreDNSSelectorLabels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       "coredns",
+		"app.kubernetes.io/managed-by": "casos",
+	}
+}
+
+func isCoreDNSServiceManaged(ctx context.Context, client kubernetes.Interface) (bool, error) {
+	current, err := client.CoreV1().Services(clusterDNSNamespace).Get(ctx, "kube-dns", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("get service %s/kube-dns: %w", clusterDNSNamespace, err)
+	}
+	return current.Labels["app.kubernetes.io/managed-by"] == "casos", nil
+}
+
+func createOrUpdateService(ctx context.Context, client kubernetes.Interface, svc *corev1.Service) error {
+	current, err := client.CoreV1().Services(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = client.CoreV1().Services(svc.Namespace).Create(ctx, svc, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create service %s/%s: %w", svc.Namespace, svc.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get service %s/%s: %w", svc.Namespace, svc.Name, err)
+	}
+	svc.Labels = mergeStringMap(current.Labels, svc.Labels)
+	svc.Annotations = mergeStringMap(current.Annotations, svc.Annotations)
+	svc.ResourceVersion = current.ResourceVersion
+	svc.Spec.Type = current.Spec.Type
+	if current.Spec.ClusterIP != "" {
+		svc.Spec.ClusterIP = current.Spec.ClusterIP
+	}
+	if len(current.Spec.ClusterIPs) > 0 {
+		svc.Spec.ClusterIPs = current.Spec.ClusterIPs
+	}
+	for i, currentPort := range current.Spec.Ports {
+		for j, desiredPort := range svc.Spec.Ports {
+			if currentPort.Name == desiredPort.Name &&
+				currentPort.Port == desiredPort.Port &&
+				currentPort.Protocol == desiredPort.Protocol &&
+				currentPort.NodePort != 0 {
+				svc.Spec.Ports[j].NodePort = current.Spec.Ports[i].NodePort
+				break
+			}
+		}
+	}
+	if len(current.Spec.IPFamilies) > 0 {
+		svc.Spec.IPFamilies = current.Spec.IPFamilies
+	}
+	if current.Spec.IPFamilyPolicy != nil {
+		svc.Spec.IPFamilyPolicy = current.Spec.IPFamilyPolicy
+	}
+	if current.Spec.HealthCheckNodePort != 0 {
+		svc.Spec.HealthCheckNodePort = current.Spec.HealthCheckNodePort
+	}
+	svc.Spec.ExternalIPs = current.Spec.ExternalIPs
+	svc.Spec.SessionAffinity = current.Spec.SessionAffinity
+	svc.Spec.ExternalTrafficPolicy = current.Spec.ExternalTrafficPolicy
+	svc.Spec.InternalTrafficPolicy = current.Spec.InternalTrafficPolicy
+	svc.Spec.LoadBalancerIP = current.Spec.LoadBalancerIP
+	svc.Spec.LoadBalancerClass = current.Spec.LoadBalancerClass
+	svc.Spec.LoadBalancerSourceRanges = current.Spec.LoadBalancerSourceRanges
+	svc.Spec.AllocateLoadBalancerNodePorts = current.Spec.AllocateLoadBalancerNodePorts
+	if _, err := client.CoreV1().Services(svc.Namespace).Update(ctx, svc, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update service %s/%s: %w", svc.Namespace, svc.Name, err)
+	}
+	return nil
+}

--- a/server/storage_bootstrap.go
+++ b/server/storage_bootstrap.go
@@ -1,0 +1,658 @@
+package server
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	localPathNamespace                 = "local-path-storage"
+	localPathProvisionerName           = "casos.io/local-path-provisioner"
+	localPathStorageClass              = "local-path"
+	localPathManagedSpecHashAnnotation = "casos.io/managed-spec-hash"
+	localPathPreserveSpecAnnotation    = "casos.io/preserve-user-spec"
+)
+
+type localPathProvisionerConfig struct {
+	NodePathMap []localPathNodePathMap `json:"nodePathMap"`
+}
+
+type localPathNodePathMap struct {
+	Node  string   `json:"node"`
+	Paths []string `json:"paths"`
+}
+
+func ensureDefaultStorageProvisioner(ctx context.Context, client kubernetes.Interface, cfg Config) error {
+	if !path.IsAbs(cfg.DataDir) {
+		return fmt.Errorf("dataDir must be absolute to enable local-path storage: %s", cfg.DataDir)
+	}
+	rootDir := path.Join(cfg.DataDir, "local-path-provisioner")
+	configData, err := localPathConfigData(rootDir, cfg.LocalPathHelperImage)
+	if err != nil {
+		return err
+	}
+	if err := ensureNamespace(ctx, client, localPathNamespace); err != nil {
+		return err
+	}
+	if err := ensureLocalPathServiceAccount(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureLocalPathClusterRole(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureLocalPathClusterRoleBinding(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureLocalPathConfigMap(ctx, client, configData); err != nil {
+		return err
+	}
+	if err := ensureLocalPathDeployment(ctx, client, hashConfigData(configData), cfg.LocalPathProvisionerImage); err != nil {
+		return err
+	}
+	return ensureLocalPathStorageClass(ctx, client)
+}
+
+func ensureNamespace(ctx context.Context, client kubernetes.Interface, name string) error {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	_, err := client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("create namespace %s: %w", name, err)
+	}
+	return nil
+}
+
+func ensureLocalPathServiceAccount(ctx context.Context, client kubernetes.Interface) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "local-path-provisioner-service-account",
+			Namespace: localPathNamespace,
+			Labels:    localPathLabels(),
+		},
+	}
+	return createOrUpdateServiceAccount(ctx, client, sa)
+}
+
+func ensureLocalPathClusterRole(ctx context.Context, client kubernetes.Interface) error {
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "local-path-provisioner-role",
+			Labels: localPathLabels(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes", "configmaps", "pods", "pods/log"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"persistentvolumeclaims"},
+				Verbs:     []string{"get", "list", "watch", "update", "patch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"persistentvolumes"},
+				Verbs:     []string{"get", "list", "watch", "create", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"events"},
+				Verbs:     []string{"create", "patch", "update"},
+			},
+			{
+				APIGroups: []string{"storage.k8s.io"},
+				Resources: []string{"storageclasses"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"coordination.k8s.io"},
+				Resources: []string{"leases"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+		},
+	}
+	return createOrUpdateClusterRole(ctx, client, role)
+}
+
+func ensureLocalPathClusterRoleBinding(ctx context.Context, client kubernetes.Interface) error {
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "local-path-provisioner-bind",
+			Labels: localPathLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "local-path-provisioner-role",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "local-path-provisioner-service-account",
+				Namespace: localPathNamespace,
+			},
+		},
+	}
+	return createOrUpdateClusterRoleBinding(ctx, client, binding)
+}
+
+func localPathConfigData(rootDir, helperImage string) (map[string]string, error) {
+	quotedRootDir := shellQuote(rootDir)
+	configBytes, err := json.Marshal(localPathProvisionerConfig{
+		NodePathMap: []localPathNodePathMap{
+			{Node: "DEFAULT_PATH_FOR_NON_LISTED_NODES", Paths: []string{rootDir}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal local path provisioner config: %w", err)
+	}
+	return map[string]string{
+		"config.json": string(configBytes),
+		"helperPod.yaml": fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: helper-pod
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  tolerations:
+    - key: node.kubernetes.io/disk-pressure
+      operator: Exists
+      effect: NoSchedule
+  containers:
+    - name: helper-pod
+      image: %s
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: false
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsUser: 0
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+`, helperImage),
+		"setup": `#!/bin/sh
+set -eu
+SAFE_ROOT=` + quotedRootDir + `
+case "${VOL_DIR:-}" in
+  "$SAFE_ROOT"/*) ;;
+  *) echo "refusing unsafe volume path: ${VOL_DIR:-<empty>}" >&2; exit 1 ;;
+esac
+mkdir -p "$VOL_DIR"
+chmod 0777 "$VOL_DIR"
+`,
+		"teardown": `#!/bin/sh
+set -eu
+SAFE_ROOT=` + quotedRootDir + `
+case "${VOL_DIR:-}" in
+  "$SAFE_ROOT"/*) ;;
+  *) echo "refusing unsafe volume path: ${VOL_DIR:-<empty>}" >&2; exit 1 ;;
+esac
+rm -rf "$VOL_DIR"
+`,
+	}, nil
+}
+
+func ensureLocalPathConfigMap(ctx context.Context, client kubernetes.Interface, data map[string]string) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "local-path-config",
+			Namespace: localPathNamespace,
+			Labels:    localPathLabels(),
+		},
+		Data: data,
+	}
+	return createOrUpdateConfigMap(ctx, client, cm)
+}
+
+func ensureLocalPathDeployment(ctx context.Context, client kubernetes.Interface, configHash, provisionerImage string) error {
+	replicas := int32(1)
+	allowPrivilegeEscalation := false
+	readOnlyRootFilesystem := true
+	runAsNonRoot := true
+	runAsUser := int64(65534)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "local-path-provisioner",
+			Namespace: localPathNamespace,
+			Labels:    localPathLabels(),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: localPathSelectorLabels(),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: localPathLabels(),
+					Annotations: map[string]string{
+						"casos.io/local-path-config-hash": configHash,
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "local-path-provisioner-service-account",
+					Tolerations: []corev1.Toleration{
+						{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            "local-path-provisioner",
+							Image:           provisionerImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command: []string{
+								"local-path-provisioner",
+								"--debug",
+								"start",
+								"--config",
+								"/etc/config/config.json",
+								"--helper-pod-file",
+								"/etc/config/helperPod.yaml",
+								"--service-account-name",
+								"local-path-provisioner-service-account",
+								"--provisioner-name",
+								localPathProvisionerName,
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+									},
+								},
+								{
+									Name:  "CONFIG_MOUNT_PATH",
+									Value: "/etc/config/",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+								ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
+								RunAsNonRoot:             &runAsNonRoot,
+								RunAsUser:                &runAsUser,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "config-volume", MountPath: "/etc/config/"},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config-volume",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "local-path-config"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return reconcileLocalPathDeployment(ctx, client, deployment)
+}
+
+func ensureLocalPathStorageClass(ctx context.Context, client kubernetes.Interface) error {
+	bindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+	allowExpansion := true
+	hasDefault, err := hasDefaultStorageClass(ctx, client, localPathStorageClass)
+	if err != nil {
+		return err
+	}
+	class := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        localPathStorageClass,
+			Labels:      localPathLabels(),
+			Annotations: localPathStorageClassAnnotations(!hasDefault),
+		},
+		Provisioner:          localPathProvisionerName,
+		ReclaimPolicy:        ptr(corev1.PersistentVolumeReclaimDelete),
+		VolumeBindingMode:    &bindingMode,
+		AllowVolumeExpansion: &allowExpansion,
+	}
+	return createOrPatchStorageClassDefaultAnnotations(ctx, client, class)
+}
+
+func localPathLabels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       "local-path-provisioner",
+		"app.kubernetes.io/managed-by": "casos",
+	}
+}
+
+func localPathSelectorLabels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name": "local-path-provisioner",
+	}
+}
+
+func localPathStorageClassAnnotations(isDefault bool) map[string]string {
+	if !isDefault {
+		return nil
+	}
+	return map[string]string{
+		"storageclass.kubernetes.io/is-default-class":      "true",
+		"storageclass.beta.kubernetes.io/is-default-class": "true",
+	}
+}
+
+func hashConfigData(data map[string]string) string {
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, key := range keys {
+		b.WriteString(key)
+		b.WriteByte('=')
+		b.WriteString(data[key])
+		b.WriteByte('\n')
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return fmt.Sprintf("%x", sum[:])
+}
+
+func createOrUpdateServiceAccount(ctx context.Context, client kubernetes.Interface, sa *corev1.ServiceAccount) error {
+	current, err := client.CoreV1().ServiceAccounts(sa.Namespace).Get(ctx, sa.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = client.CoreV1().ServiceAccounts(sa.Namespace).Create(ctx, sa, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create serviceaccount %s/%s: %w", sa.Namespace, sa.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get serviceaccount %s/%s: %w", sa.Namespace, sa.Name, err)
+	}
+	sa.Labels = mergeStringMap(current.Labels, sa.Labels)
+	sa.Annotations = mergeStringMap(current.Annotations, sa.Annotations)
+	sa.Secrets = current.Secrets
+	sa.ImagePullSecrets = current.ImagePullSecrets
+	sa.AutomountServiceAccountToken = current.AutomountServiceAccountToken
+	sa.ResourceVersion = current.ResourceVersion
+	if _, err := client.CoreV1().ServiceAccounts(sa.Namespace).Update(ctx, sa, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update serviceaccount %s/%s: %w", sa.Namespace, sa.Name, err)
+	}
+	return nil
+}
+
+func createOrUpdateClusterRole(ctx context.Context, client kubernetes.Interface, role *rbacv1.ClusterRole) error {
+	current, err := client.RbacV1().ClusterRoles().Get(ctx, role.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = client.RbacV1().ClusterRoles().Create(ctx, role, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create clusterrole %s: %w", role.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get clusterrole %s: %w", role.Name, err)
+	}
+	role.Labels = mergeStringMap(current.Labels, role.Labels)
+	role.Annotations = mergeStringMap(current.Annotations, role.Annotations)
+	role.ResourceVersion = current.ResourceVersion
+	if _, err := client.RbacV1().ClusterRoles().Update(ctx, role, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update clusterrole %s: %w", role.Name, err)
+	}
+	return nil
+}
+
+func createOrUpdateClusterRoleBinding(ctx context.Context, client kubernetes.Interface, binding *rbacv1.ClusterRoleBinding) error {
+	current, err := client.RbacV1().ClusterRoleBindings().Get(ctx, binding.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = client.RbacV1().ClusterRoleBindings().Create(ctx, binding, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create clusterrolebinding %s: %w", binding.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get clusterrolebinding %s: %w", binding.Name, err)
+	}
+	binding.Labels = mergeStringMap(current.Labels, binding.Labels)
+	binding.Annotations = mergeStringMap(current.Annotations, binding.Annotations)
+	binding.ResourceVersion = current.ResourceVersion
+	if _, err := client.RbacV1().ClusterRoleBindings().Update(ctx, binding, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update clusterrolebinding %s: %w", binding.Name, err)
+	}
+	return nil
+}
+
+func createOrUpdateConfigMap(ctx context.Context, client kubernetes.Interface, cm *corev1.ConfigMap) error {
+	current, err := client.CoreV1().ConfigMaps(cm.Namespace).Get(ctx, cm.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = client.CoreV1().ConfigMaps(cm.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create configmap %s/%s: %w", cm.Namespace, cm.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get configmap %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+	cm.Labels = mergeStringMap(current.Labels, cm.Labels)
+	cm.Annotations = mergeStringMap(current.Annotations, cm.Annotations)
+	cm.ResourceVersion = current.ResourceVersion
+	if _, err := client.CoreV1().ConfigMaps(cm.Namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update configmap %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+	return nil
+}
+
+func createOrUpdateDeployment(ctx context.Context, client kubernetes.Interface, deployment *appsv1.Deployment) error {
+	current, err := client.AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = client.AppsV1().Deployments(deployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
+	}
+	deployment.Labels = mergeStringMap(current.Labels, deployment.Labels)
+	deployment.Annotations = mergeStringMap(current.Annotations, deployment.Annotations)
+	deployment.ResourceVersion = current.ResourceVersion
+	if _, err := client.AppsV1().Deployments(deployment.Namespace).Update(ctx, deployment, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
+	}
+	return nil
+}
+
+func reconcileLocalPathDeployment(ctx context.Context, client kubernetes.Interface, deployment *appsv1.Deployment) error {
+	desiredHash, err := hashLocalPathDeploymentSpec(deployment.Spec)
+	if err != nil {
+		return fmt.Errorf("hash deployment %s/%s spec: %w", deployment.Namespace, deployment.Name, err)
+	}
+	current, err := client.AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		deployment.Annotations = mergeStringMap(deployment.Annotations, map[string]string{
+			localPathManagedSpecHashAnnotation: desiredHash,
+		})
+		_, err := client.AppsV1().Deployments(deployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
+	}
+
+	if current.Annotations[localPathPreserveSpecAnnotation] == "true" {
+		updated := current.DeepCopy()
+		updated.Labels = mergeStringMap(updated.Labels, deployment.Labels)
+		updated.Annotations = mergeStringMap(updated.Annotations, deployment.Annotations)
+		if _, err := client.AppsV1().Deployments(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("patch deployment %s/%s metadata: %w", deployment.Namespace, deployment.Name, err)
+		}
+		return nil
+	}
+
+	currentHash, err := hashLocalPathDeploymentSpec(current.Spec)
+	if err != nil {
+		return fmt.Errorf("hash current deployment %s/%s spec: %w", deployment.Namespace, deployment.Name, err)
+	}
+	if currentHash == desiredHash && current.Annotations[localPathManagedSpecHashAnnotation] == desiredHash {
+		return nil
+	}
+
+	deployment.Annotations = mergeStringMap(deployment.Annotations, map[string]string{
+		localPathManagedSpecHashAnnotation: desiredHash,
+	})
+	deployment.ResourceVersion = current.ResourceVersion
+	deployment.Labels = mergeStringMap(current.Labels, deployment.Labels)
+	deployment.Annotations = mergeStringMap(current.Annotations, deployment.Annotations)
+	if _, err := client.AppsV1().Deployments(deployment.Namespace).Update(ctx, deployment, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
+	}
+	return nil
+}
+
+func hashLocalPathDeploymentSpec(spec appsv1.DeploymentSpec) (string, error) {
+	managed := struct {
+		Replicas *int32
+		Selector *metav1.LabelSelector
+		Template struct {
+			Labels      map[string]string
+			Annotations map[string]string
+			Spec        struct {
+				ServiceAccountName string
+				Tolerations        []corev1.Toleration
+				Containers         []corev1.Container
+				Volumes            []corev1.Volume
+			}
+		}
+	}{
+		Replicas: spec.Replicas,
+		Selector: spec.Selector,
+	}
+	managed.Template.Labels = spec.Template.Labels
+	managed.Template.Annotations = spec.Template.Annotations
+	managed.Template.Spec.ServiceAccountName = spec.Template.Spec.ServiceAccountName
+	managed.Template.Spec.Tolerations = spec.Template.Spec.Tolerations
+	managed.Template.Spec.Containers = spec.Template.Spec.Containers
+	managed.Template.Spec.Volumes = spec.Template.Spec.Volumes
+	return hashJSON(managed)
+}
+
+func createOrPatchStorageClassDefaultAnnotations(ctx context.Context, client kubernetes.Interface, class *storagev1.StorageClass) error {
+	current, err := client.StorageV1().StorageClasses().Get(ctx, class.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = client.StorageV1().StorageClasses().Create(ctx, class, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create storageclass %s: %w", class.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get storageclass %s: %w", class.Name, err)
+	}
+
+	// The StorageClass CRUD UI can change mutable fields such as reclaimPolicy
+	// and allowVolumeExpansion. On restart, only reconcile default annotations.
+	copied := current.DeepCopy()
+	if copied.Annotations == nil {
+		copied.Annotations = map[string]string{}
+	}
+	desiredDefault := class.Annotations["storageclass.kubernetes.io/is-default-class"] == "true"
+	if desiredDefault {
+		copied.Annotations["storageclass.kubernetes.io/is-default-class"] = "true"
+		copied.Annotations["storageclass.beta.kubernetes.io/is-default-class"] = "true"
+	} else {
+		delete(copied.Annotations, "storageclass.kubernetes.io/is-default-class")
+		delete(copied.Annotations, "storageclass.beta.kubernetes.io/is-default-class")
+	}
+	if _, err := client.StorageV1().StorageClasses().Update(ctx, copied, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update storageclass %s: %w", class.Name, err)
+	}
+	return nil
+}
+
+func mergeStringMap(base map[string]string, overlay map[string]string) map[string]string {
+	if len(base) == 0 && len(overlay) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(base)+len(overlay))
+	for key, value := range base {
+		merged[key] = value
+	}
+	for key, value := range overlay {
+		merged[key] = value
+	}
+	return merged
+}
+
+func hashJSON(value interface{}) (string, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum[:]), nil
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func hasDefaultStorageClass(ctx context.Context, client kubernetes.Interface, ignore string) (bool, error) {
+	classes, err := client.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("list storageclasses: %w", err)
+	}
+	for _, class := range classes.Items {
+		if class.Name == ignore {
+			continue
+		}
+		if class.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" ||
+			class.Annotations["storageclass.beta.kubernetes.io/is-default-class"] == "true" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func ptr[T any](value T) *T {
+	return &value
+}

--- a/web/src/DeploymentExposeModal.js
+++ b/web/src/DeploymentExposeModal.js
@@ -3,6 +3,24 @@ import {Form, Input, InputNumber, Modal, Select} from "antd";
 import * as ServiceBackend from "./backend/ServiceBackend";
 import * as Setting from "./Setting";
 
+function getDefaultExposePorts(deploy) {
+  const containerPort = deploy?.ports?.find((port) => Number(port.port) > 0)?.port;
+  const numericPort = Number(containerPort);
+  const port = numericPort > 0 ? numericPort : 80;
+  return {
+    port,
+    targetPort: port,
+  };
+}
+
+function getDefaultExposeSelector(deploy) {
+  const entries = Object.entries(deploy?.selector || {}).filter(([key, value]) => key && value);
+  if (entries.length > 0) {
+    return Object.fromEntries(entries);
+  }
+  return deploy?.name ? {"app": deploy.name} : {};
+}
+
 function DeploymentExposeModal({deploy, open, onClose}) {
   const [form] = Form.useForm();
   const [submitting, setSubmitting] = React.useState(false);
@@ -10,10 +28,11 @@ function DeploymentExposeModal({deploy, open, onClose}) {
 
   useEffect(() => {
     if (open && !prevOpen.current && deploy) {
+      const defaults = getDefaultExposePorts(deploy);
       form.setFieldsValue({
         name: deploy.name,
-        port: 80,
-        targetPort: 80,
+        port: defaults.port,
+        targetPort: defaults.targetPort,
         type: "ClusterIP",
       });
     }
@@ -26,7 +45,7 @@ function DeploymentExposeModal({deploy, open, onClose}) {
         namespace: deploy.namespace,
         name: values.name,
         type: values.type,
-        selector: {"app": deploy.name},
+        selector: getDefaultExposeSelector(deploy),
         ports: [{
           name: "http",
           protocol: "TCP",


### PR DESCRIPTION
﻿## Problem

A number of App Store charts can reach Helm resource creation but still fail in a local CasOS cluster because the cluster bootstrap path is missing platform dependencies that standard Kubernetes distributions usually provide by default.

Observed symptoms included:

- in-cluster DNS lookup failures for service names
- PVC scheduling/binding stalls for charts using StatefulSets or persistent storage
- Deployment expose flows needing better selector and port inference

## Root Cause

CasOS already has the Kubernetes API/resource shape, but the local runtime layer did not consistently provide DNS and default storage capabilities expected by common Helm charts. This made failures look like chart/network issues even when the underlying gap was in the local cluster substrate.

## Fix

- Bootstrap a CasOS-managed CoreDNS path for fresh local clusters, while skipping takeover when an existing `kube-system/kube-dns` Service is not managed by CasOS.
- Bootstrap a local-path provisioner and default `local-path` StorageClass for local PVC workloads.
- Keep existing StorageClass CRUD behavior safe: if `local-path` already exists, bootstrap only reconciles default-class annotations instead of overwriting mutable UI-edited fields like reclaim policy or expansion.
- Make CoreDNS/local-path images configurable through server config keys while preserving the current defaults.
- Improve Deployment expose inference by deriving selectors and ports from all containers rather than assuming only the first container.
- Remove unrelated apiserver flag changes from this PR so the diff stays focused on platform bootstrap.

## Review Follow-ups Addressed

- Rebased onto current upstream `master`, including the StorageClass CRUD work.
- Avoided overwriting user-edited `local-path` StorageClass fields on restart.
- Preserved Kubernetes-managed ServiceAccount fields and Service immutable/operational fields during reconciliation.
- Added guardrails around existing non-CasOS `kube-dns` Services to avoid silently taking over a distribution-provided DNS Service.
- Added local-path helper path validation before setup/teardown removes directories.
- Kept one PR to one commit.

## Validation

- `go test ./server ./controllers`
- `ocr review --from origin/master --to HEAD --format json --audience agent`
- Verified this branch contains exactly one commit on top of upstream `master`.

## OCR Notes

Final OCR completed successfully. No Critical/High findings remained.

Remaining Medium/Low items are follow-up/product tradeoffs rather than required fixes for this PR:

- helper pod still runs as root because local-path setup/teardown must create, chmod, and remove node filesystem directories
- CoreDNS Service type is preserved to avoid disrupting an existing running DNS Service, though this also means CasOS does not force it back to ClusterIP
- StorageClass default annotation reconciliation still uses Get/Update without conflict retry
- CoreDNS/Corefile/resource tuning and HA replica count are still fixed defaults

## Scope

This PR targets local App Store platform dependencies. It intentionally does not try to solve chart-specific default values, third-party repository quality, or every production-grade Kubernetes distribution option in one patch.
