### PR TITLE
fix: improve app store install flow diagnostics

### DIFF
--- a/store/helm.go
+++ b/store/helm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -161,7 +162,11 @@ func fetchIndexFile(repoURL string) (*repo.IndexFile, error) {
 	indexURL := strings.TrimRight(repoURL, "/") + "/index.yaml"
 	resp, err := helmGet(indexURL)
 	if err != nil {
-		return nil, fmt.Errorf("fetch index: %w", err)
+		return nil, fmt.Errorf(
+			"fetch index %q: %w",
+			redactURLForError(indexURL),
+			sanitizeErrorMessage(err, indexURL, repoURL),
+		)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
@@ -297,14 +302,18 @@ func pullOCIChart(repoURL, version string) (*registry.PullResult, error) {
 		if !strings.Contains(ref, "@") {
 			tags, err := rc.Tags(ref)
 			if err != nil {
-				return nil, fmt.Errorf("list oci tags: %w", err)
+				return nil, fmt.Errorf(
+					"list oci tags for %q: %w",
+					redactURLForError(repoURL),
+					sanitizeErrorMessage(err, repoURL, ref),
+				)
 			}
 			if len(tags) == 0 {
-				return nil, fmt.Errorf("no tags found for %s", repoURL)
+				return nil, fmt.Errorf("no tags found for %s", redactURLForError(repoURL))
 			}
 			resolvedVersion = latestOCISemverTag(tags)
 			if resolvedVersion == "" {
-				return nil, fmt.Errorf("no semver tags found for %s", repoURL)
+				return nil, fmt.Errorf("no semver tags found for %s", redactURLForError(repoURL))
 			}
 		}
 	}
@@ -312,14 +321,18 @@ func pullOCIChart(repoURL, version string) (*registry.PullResult, error) {
 	pullRef := ref
 	if resolvedVersion != "" {
 		if strings.Contains(ref, "@") {
-			return nil, fmt.Errorf("oci digest reference %s cannot be used with version %q", repoURL, resolvedVersion)
+			return nil, fmt.Errorf("oci digest reference %s cannot be used with version %q", redactURLForError(repoURL), resolvedVersion)
 		}
 		pullRef = fmt.Sprintf("%s:%s", ref, resolvedVersion)
 	}
 
 	pull, err := rc.Pull(pullRef, registry.PullOptWithChart(true))
 	if err != nil {
-		return nil, fmt.Errorf("pull oci chart: %w", err)
+		return nil, fmt.Errorf(
+			"pull oci chart %q: %w",
+			redactURLForError(repoURL),
+			sanitizeErrorMessage(err, repoURL, ref, pullRef),
+		)
 	}
 	return pull, nil
 }
@@ -363,7 +376,7 @@ func fetchOCIChartSummary(repoURL string) ([]HelmChartSummary, error) {
 	}
 	meta := pull.Chart.Meta
 	if meta == nil {
-		return nil, fmt.Errorf("chart metadata not found for %s", repoURL)
+		return nil, fmt.Errorf("chart metadata not found for %s", redactURLForError(repoURL))
 	}
 	return []HelmChartSummary{
 		{
@@ -379,14 +392,202 @@ func fetchOCIChartSummary(repoURL string) ([]HelmChartSummary, error) {
 
 // ---------- Chart loader ----------
 
+func redactURLForError(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	parsed, addedScheme, err := parseURLForRedaction(raw)
+	if err != nil {
+		return fallbackRedactCredentialSegment(raw)
+	}
+	if parsed.User != nil {
+		parsed.User = url.User("REDACTED")
+	}
+	if parsed.RawQuery != "" {
+		query := parsed.Query()
+		for key := range query {
+			if isCredentialQueryKey(key) {
+				query.Set(key, "REDACTED")
+			}
+		}
+		parsed.RawQuery = query.Encode()
+	}
+	redacted := parsed.String()
+	if addedScheme {
+		return strings.TrimPrefix(redacted, "redact://")
+	}
+	return redacted
+}
+
+func parseURLForRedaction(raw string) (*url.URL, bool, error) {
+	work := raw
+	addedScheme := false
+	if !strings.Contains(raw, "://") {
+		work = "redact://" + raw
+		addedScheme = true
+	}
+	parsed, err := url.Parse(work)
+	return parsed, addedScheme, err
+}
+
+func isCredentialQueryKey(key string) bool {
+	switch strings.ToLower(key) {
+	case "access_key", "accesskey", "access_token", "apikey", "api_key", "api_secret", "app_key", "app_secret", "auth", "auth_token", "cert", "client_secret", "credential", "key", "password", "passwd", "private_key", "refresh_token", "sas_token", "secret", "secret_key", "secretkey", "session_token", "shared_access_key", "sign", "signature", "token":
+		return true
+	default:
+		return false
+	}
+}
+
+func fallbackRedactCredentialSegment(raw string) string {
+	redacted := fallbackRedactCredentialQuery(raw)
+	at := strings.Index(raw, "@")
+	if at <= 0 {
+		return redacted
+	}
+	start := strings.LastIndex(raw[:at], "://")
+	if start >= 0 {
+		start += 3
+	} else {
+		start = 0
+	}
+	candidate := raw[start:at]
+	if candidate == "" || strings.ContainsAny(candidate, "/?#") {
+		return redacted
+	}
+	if looksLikeHostPort(candidate) {
+		return redacted
+	}
+	return redacted[:start] + "REDACTED" + redacted[at:]
+}
+
+// fallbackRedactCredentialQuery handles malformed URLs that url.Parse cannot
+// process, for example invalid percent escapes in sensitive query values.
+func fallbackRedactCredentialQuery(raw string) string {
+	queryStart := strings.Index(raw, "?")
+	if queryStart < 0 {
+		return raw
+	}
+	queryEnd := len(raw)
+	if fragmentStart := strings.Index(raw[queryStart+1:], "#"); fragmentStart >= 0 {
+		queryEnd = queryStart + 1 + fragmentStart
+	}
+	query := raw[queryStart+1 : queryEnd]
+	parts := strings.Split(query, "&")
+	changed := false
+	for i, part := range parts {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok || value == "" || !isCredentialQueryKey(key) {
+			continue
+		}
+		parts[i] = key + "=REDACTED"
+		changed = true
+	}
+	if !changed {
+		return raw
+	}
+	return raw[:queryStart+1] + strings.Join(parts, "&") + raw[queryEnd:]
+}
+
+// looksLikeHostPort avoids treating malformed host:port text before an "@"
+// as userinfo when the parser has already rejected the whole string.
+func looksLikeHostPort(value string) bool {
+	host, port, ok := strings.Cut(value, ":")
+	if !ok || host == "" || port == "" {
+		return false
+	}
+	for _, r := range port {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	for _, r := range host {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+type sanitizedDisplayError struct {
+	message string
+	cause   error
+}
+
+func (e *sanitizedDisplayError) Error() string {
+	return e.message
+}
+
+func (e *sanitizedDisplayError) Unwrap() error {
+	return e.cause
+}
+
+func sanitizeErrorMessage(err error, rawValues ...string) error {
+	if err == nil {
+		return nil
+	}
+	message := err.Error()
+	values := make([]string, 0, len(rawValues)*2)
+	seen := make(map[string]struct{}, len(rawValues)*2)
+	for _, raw := range rawValues {
+		for _, candidate := range redactionCandidates(raw) {
+			if _, ok := seen[candidate]; ok {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			values = append(values, candidate)
+		}
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return len(values[i]) > len(values[j])
+	})
+	for _, raw := range values {
+		message = strings.ReplaceAll(message, raw, redactURLForError(raw))
+	}
+	if message == err.Error() {
+		return err
+	}
+	return &sanitizedDisplayError{message: message, cause: err}
+}
+
+func redactionCandidates(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	candidates := []string{raw}
+	parsed, addedScheme, err := parseURLForRedaction(raw)
+	if err != nil {
+		return candidates
+	}
+	normalized := parsed.String()
+	if addedScheme {
+		normalized = strings.TrimPrefix(normalized, "redact://")
+	}
+	if normalized != raw {
+		candidates = append(candidates, normalized)
+	}
+	return candidates
+}
+
 func loadChart(chartName, repoURL, version string) (*chart.Chart, error) {
 	if isOCIRepo(repoURL) {
-		return loadOCIChart(repoURL, version)
+		ch, err := loadOCIChart(repoURL, version)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"load chart %q from OCI repo %q version %q: %w",
+				chartName,
+				redactURLForError(repoURL),
+				version,
+				err,
+			)
+		}
+		return ch, nil
 	}
 
 	idx, err := fetchIndexFile(repoURL)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load chart %q from repo %q version %q: fetch index.yaml failed: %w", chartName, redactURLForError(repoURL), version, err)
 	}
 
 	versions, ok := idx.Entries[chartName]
@@ -414,7 +615,18 @@ func loadChart(chartName, repoURL, version string) (*chart.Chart, error) {
 		if ociVersion == "" {
 			ociVersion = entry.Version
 		}
-		return loadOCIChart(chartURL, ociVersion)
+		ch, err := loadOCIChart(chartURL, ociVersion)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"load chart %q from repo %q version %q: index.yaml resolved to OCI chart URL %q: %w",
+				chartName,
+				redactURLForError(repoURL),
+				ociVersion,
+				redactURLForError(chartURL),
+				err,
+			)
+		}
+		return ch, nil
 	}
 	if !strings.HasPrefix(chartURL, "http") {
 		chartURL = strings.TrimRight(repoURL, "/") + "/" + strings.TrimLeft(chartURL, "/")
@@ -422,18 +634,50 @@ func loadChart(chartName, repoURL, version string) (*chart.Chart, error) {
 
 	resp, err := helmGet(chartURL)
 	if err != nil {
-		return nil, fmt.Errorf("download chart: %w", err)
+		return nil, fmt.Errorf(
+			"load chart %q from repo %q version %q: download chart archive %q failed: %w",
+			chartName,
+			redactURLForError(repoURL),
+			entry.Version,
+			redactURLForError(chartURL),
+			sanitizeErrorMessage(err, chartURL, repoURL),
+		)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("download chart: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf(
+			"load chart %q from repo %q version %q: chart archive %q returned HTTP %d",
+			chartName,
+			redactURLForError(repoURL),
+			entry.Version,
+			redactURLForError(chartURL),
+			resp.StatusCode,
+		)
 	}
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"load chart %q from repo %q version %q: read chart archive %q failed: %w",
+			chartName,
+			redactURLForError(repoURL),
+			entry.Version,
+			redactURLForError(chartURL),
+			err,
+		)
 	}
-	return loader.LoadArchive(bytes.NewReader(data))
+	ch, err := loader.LoadArchive(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf(
+			"load chart %q from repo %q version %q: parse chart archive %q failed: %w",
+			chartName,
+			redactURLForError(repoURL),
+			entry.Version,
+			redactURLForError(chartURL),
+			err,
+		)
+	}
+	return ch, nil
 }
 
 func parseValues(valuesYAML string) (map[string]interface{}, error) {

--- a/web/src/backend/HelmBackend.test.js
+++ b/web/src/backend/HelmBackend.test.js
@@ -1,0 +1,68 @@
+/* eslint-env jest */
+
+jest.mock("../Setting", () => ({
+  ServerUrl: "http://localhost:9000",
+  getAcceptLanguage: () => "en",
+}));
+
+import {TextDecoder} from "util";
+import {installHelmChartStream} from "./HelmBackend";
+
+global.TextDecoder = TextDecoder;
+
+function makeChunk(text) {
+  return Uint8Array.from(Buffer.from(text, "utf8"));
+}
+
+function mockStreamResponse(chunks) {
+  let index = 0;
+  return {
+    body: {
+      getReader() {
+        return {
+          async read() {
+            if (index >= chunks.length) {
+              return {done: true};
+            }
+            return {done: false, value: makeChunk(chunks[index++])};
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("installHelmChartStream", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("returns ABORTED when the server aborts the install stream", async() => {
+    global.fetch = jest.fn().mockResolvedValue(mockStreamResponse([
+      "data: creating 1 resource(s)\n\n",
+      "data: ABORTED\n\n",
+    ]));
+
+    const onLine = jest.fn();
+    const status = await installHelmChartStream({releaseName: "demo"}, onLine);
+
+    expect(status).toBe("ABORTED");
+    expect(onLine).toHaveBeenCalledTimes(2);
+    expect(onLine).toHaveBeenNthCalledWith(1, "creating 1 resource(s)");
+    expect(onLine).toHaveBeenNthCalledWith(2, "ABORTED");
+  });
+
+  test("returns DONE when the server completes the install stream", async() => {
+    global.fetch = jest.fn().mockResolvedValue(mockStreamResponse([
+      "data: creating 1 resource(s)\n\n",
+      "data: DONE\n\n",
+    ]));
+
+    const onLine = jest.fn();
+    const status = await installHelmChartStream({releaseName: "demo"}, onLine);
+
+    expect(status).toBe("DONE");
+    expect(onLine).toHaveBeenCalledTimes(2);
+    expect(onLine).toHaveBeenNthCalledWith(2, "DONE");
+  });
+});


### PR DESCRIPTION
## Problem

When App Store installs failed, the product often surfaced low-context messages such as resource-not-ready or generic wait errors. That made it hard to tell whether the failure came from chart defaults, missing cluster capabilities, or a real Helm/runtime error.

This PR previously also included recommended install value changes. Those product-behavior defaults have been removed from this PR so the change stays focused on diagnostics.

## Root Cause

The install path did not provide enough normalized diagnostics back to the UI and could leak sensitive repository credentials in some error messages. The stream client also needed focused coverage for terminal install states such as `ABORTED` and `DONE`.

## Fix

- improve Helm install diagnostics so wait failures are easier to interpret
- redact repository credentials from Helm/chart loading errors, including URL userinfo and common credential query parameters
- add fallback redaction for malformed URLs that cannot be parsed normally
- keep App Store install values unchanged in this PR
- add frontend coverage for Helm install stream terminal states

## Validation

- `go test ./store`
- attempted frontend test with `yarn test --runTestsByPath src/backend/HelmBackend.test.js --watchAll=false`, but this repo has no `test` script in `web/package.json`
- Alibaba Open Code Review was run after the change
- verified this PR still contains exactly one commit on top of `master`

## OCR Notes

OCR initially flagged that this PR mixed diagnostics with recommended values behavior. The recommended values files and `js-yaml` dependency were removed from this PR.

OCR also flagged credential redaction edge cases. This PR now covers userinfo redaction, common sensitive query keys, token-only userinfo fallback, malformed query fallback, and host:port false-positive avoidance.

OCR still recommends Go unit tests for the redaction helpers. The local repository publishing rule currently says not to upload `*_test.go` files, so no Go test file is included here.

## Scope

This PR improves install diagnostics, error redaction, and stream-state coverage. It does not change chart default values, service exposure defaults, storage, DNS, ingress, or platform bootstrap behavior.
