### PR TITLE
fix: scope admission blocking to workload intent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,8 @@ jobs:
             iproute2 \
             iptables \
             qemu-system-x86 \
-            qemu-utils
+            qemu-utils \
+            sshpass
 
           sudo modprobe kvm || true
           if [[ ! -e /dev/kvm ]]; then
@@ -258,17 +259,30 @@ jobs:
             -pidfile "$vm_dir/qemu.pid"
 
           ssh_ready=false
+          sshpass_file="$vm_dir/sshpass.txt"
+          printf '%s' "$worker_ssh_password" > "$sshpass_file"
+          chmod 600 "$sshpass_file"
           for i in {1..60}; do
-            echo "Worker VM SSH port check: attempt $i/60..." >&2
-            if (exec 3<>"/dev/tcp/${worker_vm_ip}/22") 2>/dev/null; then
-              exec 3<&- 3>&-
+            echo "Worker VM SSH authentication check: attempt $i/60..." >&2
+            if sshpass -f "$sshpass_file" ssh \
+              -o ConnectTimeout=5 \
+              -o ConnectionAttempts=1 \
+              -o KbdInteractiveAuthentication=no \
+              -o LogLevel=ERROR \
+              -o NumberOfPasswordPrompts=1 \
+              -o PreferredAuthentications=password \
+              -o PubkeyAuthentication=no \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              "root@${worker_vm_ip}" true </dev/null 2>/dev/null; then
               ssh_ready=true
               break
             fi
             sleep 5
           done
+          rm -f "$sshpass_file"
           if [[ "$ssh_ready" != "true" ]]; then
-            echo "Worker VM SSH port did not become reachable after 60 attempts" >&2
+            echo "Worker VM SSH credentials did not become usable after 60 attempts" >&2
             echo "---- VM serial log ----" >&2
             sudo cat "$vm_dir/serial.log" >&2 || true
             exit 1

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -23,3 +23,5 @@ socks5Proxy   = 127.0.0.1:10808
 apiserverPort = 6443
 apiserverBind = 127.0.0.1
 dataDir       = /var/lib/casos
+ingressControllerEnabled = true
+serviceLBEnabled = true

--- a/controllers/ingress.go
+++ b/controllers/ingress.go
@@ -18,14 +18,15 @@ type ingressRule struct {
 }
 
 type ingressSummary struct {
-	Namespace       string        `json:"namespace"`
-	Name            string        `json:"name"`
-	IngressClass    string        `json:"ingressClass"`
-	Rules           []ingressRule `json:"rules"`
-	TLSEnabled      bool          `json:"tlsEnabled"`
-	TLSSecretName   string        `json:"tlsSecretName"`
-	CreatedAt       string        `json:"createdAt"`
-	ResourceVersion string        `json:"resourceVersion"`
+	Namespace             string        `json:"namespace"`
+	Name                  string        `json:"name"`
+	IngressClass          string        `json:"ingressClass"`
+	Rules                 []ingressRule `json:"rules"`
+	TLSEnabled            bool          `json:"tlsEnabled"`
+	TLSSecretName         string        `json:"tlsSecretName"`
+	LoadBalancerAddresses []string      `json:"loadBalancerAddresses,omitempty"`
+	CreatedAt             string        `json:"createdAt"`
+	ResourceVersion       string        `json:"resourceVersion"`
 }
 
 func toIngressSummary(ing networkingv1.Ingress) ingressSummary {
@@ -65,15 +66,24 @@ func toIngressSummary(ing networkingv1.Ingress) ingressSummary {
 	if tlsEnabled {
 		tlsSecretName = ing.Spec.TLS[0].SecretName
 	}
+	loadBalancerAddresses := make([]string, 0, len(ing.Status.LoadBalancer.Ingress))
+	for _, address := range ing.Status.LoadBalancer.Ingress {
+		if address.IP != "" {
+			loadBalancerAddresses = append(loadBalancerAddresses, address.IP)
+		} else if address.Hostname != "" {
+			loadBalancerAddresses = append(loadBalancerAddresses, address.Hostname)
+		}
+	}
 	return ingressSummary{
-		Namespace:       ing.Namespace,
-		Name:            ing.Name,
-		IngressClass:    cls,
-		Rules:           rules,
-		TLSEnabled:      tlsEnabled,
-		TLSSecretName:   tlsSecretName,
-		CreatedAt:       ing.CreationTimestamp.UTC().Format("2006-01-02 15:04:05"),
-		ResourceVersion: ing.ResourceVersion,
+		Namespace:             ing.Namespace,
+		Name:                  ing.Name,
+		IngressClass:          cls,
+		Rules:                 rules,
+		TLSEnabled:            tlsEnabled,
+		TLSSecretName:         tlsSecretName,
+		LoadBalancerAddresses: loadBalancerAddresses,
+		CreatedAt:             ing.CreationTimestamp.UTC().Format("2006-01-02 15:04:05"),
+		ResourceVersion:       ing.ResourceVersion,
 	}
 }
 

--- a/controllers/ingress_test.go
+++ b/controllers/ingress_test.go
@@ -1,0 +1,16 @@
+package controllers
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func TestIngressSummaryIncludesPublishedAddresses(t *testing.T) {
+	summary := toIngressSummary(networkingv1.Ingress{Status: networkingv1.IngressStatus{LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+		Ingress: []networkingv1.IngressLoadBalancerIngress{{IP: "192.0.2.10"}, {Hostname: "ingress.example.test"}},
+	}}})
+	if len(summary.LoadBalancerAddresses) != 2 || summary.LoadBalancerAddresses[0] != "192.0.2.10" || summary.LoadBalancerAddresses[1] != "ingress.example.test" {
+		t.Fatalf("expected published Ingress addresses, got %v", summary.LoadBalancerAddresses)
+	}
+}

--- a/controllers/service.go
+++ b/controllers/service.go
@@ -20,14 +20,15 @@ type portSummary struct {
 }
 
 type serviceSummary struct {
-	Namespace       string            `json:"namespace"`
-	Name            string            `json:"name"`
-	Type            string            `json:"type"`
-	ClusterIP       string            `json:"clusterIP"`
-	Selector        map[string]string `json:"selector"`
-	Ports           []portSummary     `json:"ports"`
-	CreatedAt       string            `json:"createdAt"`
-	ResourceVersion string            `json:"resourceVersion"`
+	Namespace             string            `json:"namespace"`
+	Name                  string            `json:"name"`
+	Type                  string            `json:"type"`
+	ClusterIP             string            `json:"clusterIP"`
+	Selector              map[string]string `json:"selector"`
+	Ports                 []portSummary     `json:"ports"`
+	LoadBalancerAddresses []string          `json:"loadBalancerAddresses,omitempty"`
+	CreatedAt             string            `json:"createdAt"`
+	ResourceVersion       string            `json:"resourceVersion"`
 }
 
 func toSvcSummary(svc corev1.Service) serviceSummary {
@@ -41,15 +42,24 @@ func toSvcSummary(svc corev1.Service) serviceSummary {
 			NodePort:   p.NodePort,
 		})
 	}
+	loadBalancerAddresses := make([]string, 0, len(svc.Status.LoadBalancer.Ingress))
+	for _, ingress := range svc.Status.LoadBalancer.Ingress {
+		if ingress.IP != "" {
+			loadBalancerAddresses = append(loadBalancerAddresses, ingress.IP)
+		} else if ingress.Hostname != "" {
+			loadBalancerAddresses = append(loadBalancerAddresses, ingress.Hostname)
+		}
+	}
 	return serviceSummary{
-		Namespace:       svc.Namespace,
-		Name:            svc.Name,
-		Type:            string(svc.Spec.Type),
-		ClusterIP:       svc.Spec.ClusterIP,
-		Selector:        svc.Spec.Selector,
-		Ports:           ports,
-		CreatedAt:       svc.CreationTimestamp.UTC().Format("2006-01-02 15:04:05"),
-		ResourceVersion: svc.ResourceVersion,
+		Namespace:             svc.Namespace,
+		Name:                  svc.Name,
+		Type:                  string(svc.Spec.Type),
+		ClusterIP:             svc.Spec.ClusterIP,
+		Selector:              svc.Spec.Selector,
+		Ports:                 ports,
+		LoadBalancerAddresses: loadBalancerAddresses,
+		CreatedAt:             svc.CreationTimestamp.UTC().Format("2006-01-02 15:04:05"),
+		ResourceVersion:       svc.ResourceVersion,
 	}
 }
 

--- a/controllers/service_test.go
+++ b/controllers/service_test.go
@@ -1,0 +1,16 @@
+package controllers
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestServiceSummaryIncludesLoadBalancerHostname(t *testing.T) {
+	summary := toSvcSummary(corev1.Service{Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{
+		Ingress: []corev1.LoadBalancerIngress{{Hostname: "lb.example.test"}},
+	}}})
+	if len(summary.LoadBalancerAddresses) != 1 || summary.LoadBalancerAddresses[0] != "lb.example.test" {
+		t.Fatalf("expected LoadBalancer hostname, got %v", summary.LoadBalancerAddresses)
+	}
+}

--- a/deploy/installer.go
+++ b/deploy/installer.go
@@ -28,6 +28,15 @@ sysctl --system >/dev/null
 test -e /proc/sys/net/bridge/bridge-nf-call-iptables`); err != nil {
 		return fmt.Errorf("configure Kubernetes kernel networking: %w", err)
 	}
+	if _, err := runner.RunRootContext(ctx, fmt.Sprintf(`set -e
+if [ -f /run/systemd/resolve/resolv.conf ]; then
+  ln -sfn /run/systemd/resolve/resolv.conf %[1]s
+else
+  ln -sfn /etc/resolv.conf %[1]s
+fi
+test -f %[1]s`, nodeDeployResolverPath)); err != nil {
+		return fmt.Errorf("configure node resolver: %w", err)
+	}
 
 	d.logStep(nodeDeployPhaseConfiguring, "Configuring containerd")
 	if err := runner.WriteFileContext(ctx, "/etc/containerd/config.toml", GenerateContainerdConfig(d.config.SandboxImage, d.config.Socks5Proxy), "0644"); err != nil {

--- a/deploy/kubelet.go
+++ b/deploy/kubelet.go
@@ -19,10 +19,11 @@ kind: KubeletConfiguration
 cgroupDriver: systemd
 failSwapOn: false
 containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
+resolvConf: %s
 clusterDNS:
   - %s
 clusterDomain: cluster.local
-`, nodeDeployClusterDNS)
+`, nodeDeployResolverPath, nodeDeployClusterDNS)
 }
 
 func kubeletService(nodeName string) string {

--- a/deploy/node_bootstrap.go
+++ b/deploy/node_bootstrap.go
@@ -2,16 +2,24 @@ package deploy
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/beego/beego/logs"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 )
 
 type nodeBootstrapState struct {
@@ -25,7 +33,15 @@ type NodeDeployer struct {
 	log        NodeDeployLogger
 }
 
-const flannelDaemonSetName = "kube-flannel-ds"
+const (
+	workerProbeAttemptTimeout = 2 * time.Minute
+	// Kubernetes VolumeBinding waits up to 600 seconds by default. Give the
+	// storage probe time to finish instead of deleting its first consumer early.
+	workerStorageProbeAttemptTimeout = 12 * time.Minute
+	workerFlannelReadyTimeout        = 5 * time.Minute
+	flannelDaemonSetName             = "kube-flannel-ds"
+	workerBootstrapTaintKey          = "casos.io/bootstrap"
+)
 
 func NewNodeDeployer(config Config, restConfig *rest.Config, log NodeDeployLogger) *NodeDeployer {
 	if log == nil {
@@ -106,13 +122,19 @@ func (d *NodeDeployer) Deploy(ctx context.Context, opts NodeDeployOptions) (*Nod
 	if err != nil {
 		return nil, fmt.Errorf("waiting for node registration: %w", err)
 	}
+	if err = d.ensureWorkerBootstrapTaint(ctx, opts.NodeName); err != nil {
+		return nil, fmt.Errorf("protect worker during bootstrap: %w", err)
+	}
 
 	if err = d.startKubeProxy(ctx, runner); err != nil {
 		return nil, err
 	}
 
 	d.logStep(nodeDeployPhaseWaiting, "Waiting for Flannel to become Ready on the worker")
-	if err = d.waitForFlannelReady(ctx, opts.NodeName); err != nil {
+	flannelCtx, cancelFlannel := context.WithTimeout(ctx, workerFlannelReadyTimeout)
+	err = d.waitForFlannelReady(flannelCtx, opts.NodeName)
+	cancelFlannel()
+	if err != nil {
 		return nil, fmt.Errorf("waiting for Flannel readiness: %w", err)
 	}
 
@@ -135,6 +157,87 @@ func (d *NodeDeployer) Deploy(ctx context.Context, opts NodeDeployOptions) (*Nod
 
 	d.logStep(nodeDeployPhaseReady, "Node registered and Ready")
 	return &NodeDeployResult{ManagedPrivateKey: keyPair.PrivateKey}, nil
+}
+
+func ensureWorkerBootstrapTaint(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+	desired := corev1.Taint{Key: workerBootstrapTaintKey, Value: "true", Effect: corev1.TaintEffectNoSchedule}
+	changed := false
+	found := false
+	taints := make([]corev1.Taint, 0, len(node.Spec.Taints)+1)
+	for _, taint := range node.Spec.Taints {
+		if taint.Key != workerBootstrapTaintKey {
+			taints = append(taints, taint)
+			continue
+		}
+		if !found {
+			found = true
+			taints = append(taints, desired)
+			if taint != desired {
+				changed = true
+			}
+		} else {
+			changed = true
+		}
+	}
+	if !found {
+		taints = append(taints, desired)
+		changed = true
+	}
+	if changed {
+		node.Spec.Taints = taints
+	}
+	return changed
+}
+
+func removeWorkerBootstrapTaint(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+	taints := make([]corev1.Taint, 0, len(node.Spec.Taints))
+	changed := false
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == workerBootstrapTaintKey {
+			changed = true
+			continue
+		}
+		taints = append(taints, taint)
+	}
+	if changed {
+		node.Spec.Taints = taints
+	}
+	return changed
+}
+
+func (d *NodeDeployer) ensureWorkerBootstrapTaint(ctx context.Context, nodeName string) error {
+	return d.updateWorkerBootstrapTaint(ctx, nodeName, ensureWorkerBootstrapTaint)
+}
+
+func (d *NodeDeployer) removeWorkerBootstrapTaint(ctx context.Context, nodeName string) error {
+	return d.updateWorkerBootstrapTaint(ctx, nodeName, removeWorkerBootstrapTaint)
+}
+
+func (d *NodeDeployer) updateWorkerBootstrapTaint(ctx context.Context, nodeName string, mutate func(*corev1.Node) bool) error {
+	if d.restConfig == nil {
+		return fmt.Errorf("apiserver rest config is required")
+	}
+	client, err := kubernetes.NewForConfig(d.restConfig)
+	if err != nil {
+		return err
+	}
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if !mutate(node) {
+			return nil
+		}
+		_, err = client.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 func (d *NodeDeployer) waitForFlannelReady(ctx context.Context, nodeName string) error {
@@ -377,6 +480,927 @@ func (d *NodeDeployer) waitForNodeReady(ctx context.Context, nodeName string) er
 		}
 	}
 }
+
+// WaitForOperational verifies the platform prerequisites that make a worker
+// safe for application scheduling. Node Ready alone does not prove that CNI,
+// DNS, or the default storage path is usable.
+func workerOperationalDeadlineError(lastReason string, cause error) error {
+	if lastReason == "" {
+		return cause
+	}
+	return fmt.Errorf("worker operational readiness: %s: %w", lastReason, cause)
+}
+
+func (d *NodeDeployer) WaitForOperational(ctx context.Context, nodeName, validationRun string) error {
+	if d.restConfig == nil {
+		return fmt.Errorf("apiserver rest config is required")
+	}
+	client, err := kubernetes.NewForConfig(d.restConfig)
+	if err != nil {
+		return err
+	}
+	deadlineTimer, deadline := deploymentWaitDeadline(ctx)
+	ticker := time.NewTicker(3 * time.Second)
+	defer deadlineTimer.Stop()
+	defer ticker.Stop()
+	var lastReason string
+	for {
+		select {
+		case <-ctx.Done():
+			return workerOperationalDeadlineError(lastReason, ctx.Err())
+		case <-deadline:
+			if lastReason == "" {
+				lastReason = "platform prerequisites are not ready"
+			}
+			return workerOperationalDeadlineError(lastReason, context.DeadlineExceeded)
+		case <-ticker.C:
+			reason, ready, err := workerOperationalState(ctx, client, nodeName, validationRun, d.config.StorageProbeImage)
+			if err != nil {
+				return err
+			}
+			if ready {
+				d.logStep(nodeDeployPhaseReady, "Worker operational validation passed")
+				if err := d.removeWorkerBootstrapTaint(ctx, nodeName); err != nil {
+					return fmt.Errorf("remove worker bootstrap taint: %w", err)
+				}
+				return nil
+			}
+			if reason != lastReason {
+				lastReason = reason
+				d.logStep(nodeDeployPhaseWaiting, "Worker operational validation: "+reason)
+			}
+		}
+	}
+}
+
+func workerOperationalState(ctx context.Context, client kubernetes.Interface, nodeName, validationRun, storageProbeImage string) (string, bool, error) {
+	node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return "node is not registered", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if !isNodeReady(node) {
+		return "node is not Ready", false, nil
+	}
+	if node.Spec.PodCIDR == "" {
+		return "node has no PodCIDR", false, nil
+	}
+
+	flannelPods, err := client.CoreV1().Pods("kube-flannel").List(ctx, metav1.ListOptions{
+		LabelSelector: "k8s-app=flannel",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return "", false, err
+	}
+	if !anyReadyPod(flannelPods.Items) {
+		return "Flannel is not Ready on the worker", false, nil
+	}
+
+	dns, err := client.AppsV1().Deployments("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return "CoreDNS Deployment is missing", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if dns.Status.AvailableReplicas < 1 {
+		return coreDNSReadinessReason(ctx, client, dns), false, nil
+	}
+
+	if _, err := client.StorageV1().StorageClasses().Get(ctx, "local-path", metav1.GetOptions{}); apierrors.IsNotFound(err) {
+		return "default local-path StorageClass is missing", false, nil
+	} else if err != nil {
+		return "", false, err
+	}
+	hostname := nodeName
+	if node.Labels["kubernetes.io/hostname"] != "" {
+		hostname = node.Labels["kubernetes.io/hostname"]
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, workerStorageProbeAttemptTimeout)
+	err = waitForStorageProbe(probeCtx, client, nodeName, hostname, validationRun, storageProbeImage)
+	cancel()
+	if err != nil {
+		return "storage probe: " + err.Error(), false, nil
+	}
+	probeCtx, cancel = context.WithTimeout(ctx, workerProbeAttemptTimeout)
+	err = waitForSchedulerProbe(probeCtx, client, nodeName, hostname, validationRun, storageProbeImage)
+	cancel()
+	if err != nil {
+		return "scheduler probe: " + err.Error(), false, nil
+	}
+	probeCtx, cancel = context.WithTimeout(ctx, workerProbeAttemptTimeout)
+	err = waitForServiceProbe(probeCtx, client, nodeName, validationRun, storageProbeImage)
+	cancel()
+	if err != nil {
+		return "service probe: " + err.Error(), false, nil
+	}
+	return "", true, nil
+}
+
+func anyReadyPod(pods []corev1.Pod) bool {
+	for i := range pods {
+		if pods[i].DeletionTimestamp == nil && isPodReady(pods[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func coreDNSReadinessReason(ctx context.Context, client kubernetes.Interface, deployment *appsv1.Deployment) string {
+	pods, err := client.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=coredns,app.kubernetes.io/managed-by=casos",
+	})
+	if err != nil {
+		return "CoreDNS is not Available (unable to inspect Pods: " + err.Error() + ")"
+	}
+	for _, pod := range pods.Items {
+		for _, status := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+			if status.State.Waiting != nil {
+				reason := status.State.Waiting.Reason
+				if reason == "" {
+					reason = "waiting"
+				}
+				if status.State.Waiting.Message != "" {
+					return coreDNSPodFailureReason(fmt.Sprintf("CoreDNS Pod %s container %s is %s: %s", pod.Name, status.Name, reason, status.State.Waiting.Message), client, pod)
+				}
+				return coreDNSPodFailureReason(fmt.Sprintf("CoreDNS Pod %s container %s is %s", pod.Name, status.Name, reason), client, pod)
+			}
+			if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+				terminated := status.State.Terminated
+				return coreDNSPodFailureReason(fmt.Sprintf("CoreDNS Pod %s container %s terminated with %s (exit code %d): %s", pod.Name, status.Name, terminated.Reason, terminated.ExitCode, terminated.Message), client, pod)
+			}
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			return fmt.Sprintf("CoreDNS Pod %s is %s: %s", pod.Name, pod.Status.Phase, pod.Status.Message)
+		}
+	}
+	return fmt.Sprintf(
+		"CoreDNS is not Available (desired=%d ready=%d available=%d updated=%d)",
+		deployment.Status.Replicas,
+		deployment.Status.ReadyReplicas,
+		deployment.Status.AvailableReplicas,
+		deployment.Status.UpdatedReplicas,
+	)
+}
+
+func coreDNSPodFailureReason(reason string, client kubernetes.Interface, pod corev1.Pod) string {
+	if !strings.Contains(reason, "CrashLoopBackOff") && !strings.Contains(reason, "terminated") {
+		return reason
+	}
+	tailLines := int64(40)
+	logCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.CoreV1().Pods("kube-system").GetLogs(pod.Name, &corev1.PodLogOptions{
+		Container: "coredns",
+		Previous:  true,
+		TailLines: &tailLines,
+	}).Stream(logCtx)
+	if err != nil {
+		return fmt.Sprintf("%s (unable to read CoreDNS logs: %v)", reason, err)
+	}
+	defer stream.Close()
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		return fmt.Sprintf("%s (unable to read CoreDNS logs: %v)", reason, err)
+	}
+	logs := strings.TrimSpace(string(data))
+	if logs == "" {
+		return reason
+	}
+	logs = strings.ReplaceAll(logs, "\r\n", " | ")
+	logs = strings.ReplaceAll(logs, "\n", " | ")
+	if len(logs) > 2000 {
+		logs = logs[len(logs)-2000:]
+	}
+	return fmt.Sprintf("%s: logs: %s", reason, logs)
+}
+
+func isPodReady(pod corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func waitForProbePodDeleted(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		_, err := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForProbePVCDeleted(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		_, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func storageProbeName(nodeName, validationRun string) string {
+	digest := sha256.Sum256([]byte(nodeName + "\x00" + validationRun))
+	return "casos-storage-" + hex.EncodeToString(digest[:])[:16]
+}
+
+func podFailureReason(pod corev1.Pod) string {
+	parts := []string{"phase=" + string(pod.Status.Phase)}
+	if pod.Status.Reason != "" {
+		parts = append(parts, "reason="+pod.Status.Reason)
+	}
+	if pod.Status.Message != "" {
+		parts = append(parts, "message="+pod.Status.Message)
+	}
+	for _, status := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+		if status.State.Terminated != nil {
+			terminated := status.State.Terminated
+			parts = append(parts, fmt.Sprintf("container=%s terminated=%s exit=%d message=%s", status.Name, terminated.Reason, terminated.ExitCode, terminated.Message))
+			continue
+		}
+		if status.State.Waiting != nil {
+			parts = append(parts, fmt.Sprintf("container=%s waiting=%s message=%s", status.Name, status.State.Waiting.Reason, status.State.Waiting.Message))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func storageProbeState(client kubernetes.Interface, namespace, name string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	parts := make([]string, 0, 8)
+	objectUIDs := make(map[string]struct{}, 2)
+
+	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err == nil {
+		pvcState := fmt.Sprintf("PVC phase=%s uid=%s", pvc.Status.Phase, pvc.UID)
+		selectedNode := pvc.Annotations["volume.kubernetes.io/selected-node"]
+		if selectedNode == "" {
+			selectedNode = "missing"
+		}
+		pvcState += " selected-node=" + selectedNode
+		if pvc.Spec.VolumeName != "" {
+			pvcState += " volume=" + pvc.Spec.VolumeName
+		}
+		parts = append(parts, pvcState)
+		if pvc.UID != "" {
+			objectUIDs[string(pvc.UID)] = struct{}{}
+		}
+		if pvc.Spec.VolumeName != "" {
+			if pv, pvErr := client.CoreV1().PersistentVolumes().Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{}); pvErr == nil {
+				pvState := "PV phase=" + string(pv.Status.Phase)
+				if pv.Status.Reason != "" {
+					pvState += " reason=" + pv.Status.Reason
+				}
+				if pv.Status.Message != "" {
+					pvState += " message=" + pv.Status.Message
+				}
+				parts = append(parts, pvState)
+			}
+		}
+	} else if !apierrors.IsNotFound(err) {
+		parts = append(parts, "PVC inspection failed: "+err.Error())
+	}
+
+	pod, err := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err == nil {
+		parts = append(parts, "Pod "+podFailureReason(*pod))
+		if pod.UID != "" {
+			objectUIDs[string(pod.UID)] = struct{}{}
+		}
+	} else if !apierrors.IsNotFound(err) {
+		parts = append(parts, "Pod inspection failed: "+err.Error())
+	}
+
+	events, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: "involvedObject.name=" + name,
+	})
+	if err == nil && len(events.Items) > 0 {
+		currentEvents := events.Items[:0]
+		for i := range events.Items {
+			event := events.Items[i]
+			if event.InvolvedObject.Name != name {
+				continue
+			}
+			if event.InvolvedObject.UID != "" {
+				if _, ok := objectUIDs[string(event.InvolvedObject.UID)]; !ok {
+					continue
+				}
+			}
+			currentEvents = append(currentEvents, event)
+		}
+		sort.SliceStable(currentEvents, func(i, j int) bool {
+			return storageEventTime(currentEvents[i]).Before(storageEventTime(currentEvents[j]))
+		})
+		start := len(currentEvents) - 6
+		if start < 0 {
+			start = 0
+		}
+		eventParts := make([]string, 0, len(currentEvents)-start)
+		for i := start; i < len(currentEvents); i++ {
+			event := currentEvents[i]
+			message := strings.TrimSpace(event.Message)
+			if message != "" {
+				eventParts = append(eventParts, fmt.Sprintf(
+					"%s %s/%s: %s",
+					event.Type,
+					event.InvolvedObject.Kind,
+					event.Reason,
+					message,
+				))
+			}
+		}
+		if len(eventParts) > 0 {
+			parts = append(parts, "events="+strings.Join(eventParts, " | "))
+		}
+	}
+
+	deployment, err := client.AppsV1().Deployments("local-path-storage").Get(ctx, "local-path-provisioner", metav1.GetOptions{})
+	if err == nil {
+		parts = append(parts, fmt.Sprintf(
+			"provisioner desired=%d ready=%d available=%d updated=%d",
+			deployment.Status.Replicas,
+			deployment.Status.ReadyReplicas,
+			deployment.Status.AvailableReplicas,
+			deployment.Status.UpdatedReplicas,
+		))
+	} else if apierrors.IsNotFound(err) {
+		parts = append(parts, "provisioner Deployment missing")
+	} else {
+		parts = append(parts, "provisioner Deployment inspection failed: "+err.Error())
+	}
+
+	provisionerPods, err := client.CoreV1().Pods("local-path-storage").List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=local-path-provisioner",
+	})
+	if err != nil {
+		parts = append(parts, "provisioner Pod inspection failed: "+err.Error())
+	} else if len(provisionerPods.Items) == 0 {
+		parts = append(parts, "provisioner Pods=none")
+	} else {
+		for i := range provisionerPods.Items {
+			provisionerPod := provisionerPods.Items[i]
+			parts = append(parts, "provisioner Pod "+provisionerPod.Name+" "+podFailureReason(provisionerPod))
+			if logs := storagePodLogs(ctx, client, "local-path-storage", provisionerPod.Name, "local-path-provisioner"); logs != "" {
+				parts = append(parts, "provisioner logs="+logs)
+			}
+		}
+	}
+
+	storagePods, err := client.CoreV1().Pods("local-path-storage").List(ctx, metav1.ListOptions{})
+	if err == nil {
+		for i := range storagePods.Items {
+			storagePod := storagePods.Items[i]
+			if !strings.HasPrefix(storagePod.Name, "helper-pod-") {
+				continue
+			}
+			parts = append(parts, "helper Pod "+storagePod.Name+" "+podFailureReason(storagePod))
+			if logs := storagePodLogs(ctx, client, "local-path-storage", storagePod.Name, "helper-pod"); logs != "" {
+				parts = append(parts, "helper logs="+logs)
+			}
+		}
+	}
+
+	if len(parts) == 0 {
+		return "no storage probe state available"
+	}
+	return strings.Join(parts, "; ")
+}
+
+func storageEventTime(event corev1.Event) time.Time {
+	if !event.EventTime.Time.IsZero() {
+		return event.EventTime.Time
+	}
+	if event.Series != nil && !event.Series.LastObservedTime.Time.IsZero() {
+		return event.Series.LastObservedTime.Time
+	}
+	if !event.LastTimestamp.Time.IsZero() {
+		return event.LastTimestamp.Time
+	}
+	if !event.FirstTimestamp.Time.IsZero() {
+		return event.FirstTimestamp.Time
+	}
+	return event.CreationTimestamp.Time
+}
+
+func storagePodLogs(ctx context.Context, client kubernetes.Interface, namespace, podName, containerName string) string {
+	tailLines := int64(50)
+	stream, err := client.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: containerName,
+		TailLines: &tailLines,
+	}).Stream(ctx)
+	if err != nil {
+		return ""
+	}
+	defer stream.Close()
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		return ""
+	}
+	logs := strings.TrimSpace(string(data))
+	logs = strings.ReplaceAll(logs, "\r\n", " | ")
+	logs = strings.ReplaceAll(logs, "\n", " | ")
+	if len(logs) > 3000 {
+		logs = logs[len(logs)-3000:]
+	}
+	return logs
+}
+
+func waitForStorageProbe(ctx context.Context, client kubernetes.Interface, nodeName, hostname, validationRun, image string) error {
+	if image == "" {
+		image = "docker.io/library/busybox:1.37.0"
+	}
+	const namespace = "kube-system"
+	name := storageProbeName(nodeName, validationRun)
+	cleanup := func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := deleteStorageProbeResources(cleanupCtx, client, namespace, name); err != nil {
+			logs.Warning("failed to delete storage probe resources %s/%s: %v", namespace, name, err)
+		}
+	}
+	cleanup()
+	cleanupCtx, cancelCleanup := context.WithTimeout(ctx, 15*time.Second)
+	if err := waitForProbePodDeleted(cleanupCtx, client, namespace, name); err != nil {
+		cancelCleanup()
+		return fmt.Errorf("wait for stale storage probe Pod deletion: %w", err)
+	}
+	if err := waitForProbePVCDeleted(cleanupCtx, client, namespace, name); err != nil {
+		cancelCleanup()
+		return fmt.Errorf("wait for stale storage probe PVC deletion: %w", err)
+	}
+	cancelCleanup()
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: map[string]string{"casos.io/probe": "worker-storage"}},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: stringPtr("local-path"),
+			Resources: corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Mi"),
+			}},
+		},
+	}
+	if _, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create storage probe PVC: %w", err)
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: map[string]string{"casos.io/probe": "worker-storage"}},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{"kubernetes.io/hostname": hostname},
+			Tolerations: []corev1.Toleration{{
+				Key:      "casos.io/bootstrap",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name: "storage-probe", Image: image, ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:      []string{"sh", "-c", "echo casos > /data/probe && test \"$(cat /data/probe)\" = casos"},
+				VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+			}},
+			Volumes: []corev1.Volume{{Name: "data", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: name}}}},
+		},
+	}
+	if _, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		cleanup()
+		return fmt.Errorf("create storage probe Pod: %w", err)
+	}
+	defer cleanup()
+	deadlineTimer, deadline := deploymentWaitDeadline(ctx)
+	ticker := time.NewTicker(2 * time.Second)
+	defer deadlineTimer.Stop()
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%w (%s)", ctx.Err(), storageProbeState(client, namespace, name))
+		case <-deadline:
+			return fmt.Errorf("timed out waiting for storage probe (%s)", storageProbeState(client, namespace, name))
+		case <-ticker.C:
+			current, err := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("get storage probe Pod: %w", err)
+			}
+			switch current.Status.Phase {
+			case corev1.PodSucceeded:
+				return nil
+			case corev1.PodFailed:
+				return fmt.Errorf("storage probe Pod failed: %s", podFailureReason(*current))
+			}
+		}
+	}
+}
+
+func deleteStorageProbeResources(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
+	errors := make([]string, 0, 2)
+	if err := client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		errors = append(errors, "delete Pod: "+err.Error())
+	}
+	if err := client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		errors = append(errors, "delete PVC: "+err.Error())
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("%s", strings.Join(errors, "; "))
+	}
+	return nil
+}
+
+func schedulerProbeName(nodeName, validationRun string) string {
+	digest := sha256.Sum256([]byte(nodeName + "\x00" + validationRun))
+	return "casos-scheduler-" + hex.EncodeToString(digest[:])[:16]
+}
+
+func serviceProbeName(nodeName, validationRun string) string {
+	digest := sha256.Sum256([]byte(nodeName + "\x00" + validationRun))
+	return "casos-service-" + hex.EncodeToString(digest[:])[:16]
+}
+
+func workerProbeImage(image string) string {
+	if image == "" {
+		return "docker.io/library/busybox:1.37.0"
+	}
+	return image
+}
+
+type serviceProbePlacement struct {
+	serverNodeName string
+	serverHostname string
+	clientHostname string
+}
+
+func selectServiceProbePlacement(nodes []corev1.Node, targetNodeName string) (serviceProbePlacement, error) {
+	var target *corev1.Node
+	for i := range nodes {
+		if nodes[i].Name == targetNodeName {
+			target = &nodes[i]
+			break
+		}
+	}
+	if target == nil {
+		return serviceProbePlacement{}, fmt.Errorf("target worker %s is not registered", targetNodeName)
+	}
+	placement := serviceProbePlacement{
+		serverNodeName: target.Name,
+		serverHostname: nodeHostname(target),
+		clientHostname: nodeHostname(target),
+	}
+	for i := range nodes {
+		node := &nodes[i]
+		if node.Name == targetNodeName || isControlPlaneNode(node) || !isNodeReady(node) || nodePodCIDR(node) == "" {
+			continue
+		}
+		placement.serverNodeName = node.Name
+		placement.serverHostname = nodeHostname(node)
+		break
+	}
+	return placement, nil
+}
+
+func nodeHostname(node *corev1.Node) string {
+	if node == nil {
+		return ""
+	}
+	if hostname := node.Labels[corev1.LabelHostname]; hostname != "" {
+		return hostname
+	}
+	return node.Name
+}
+
+func isControlPlaneNode(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+	_, controlPlane := node.Labels["node-role.kubernetes.io/control-plane"]
+	_, master := node.Labels["node-role.kubernetes.io/master"]
+	return controlPlane || master
+}
+
+func workerBootstrapProbeTolerations() []corev1.Toleration {
+	return []corev1.Toleration{{
+		Key:      "casos.io/bootstrap",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}}
+}
+
+func waitForSchedulerProbe(ctx context.Context, client kubernetes.Interface, nodeName, hostname, validationRun, image string) error {
+	const namespace = "kube-system"
+	name := schedulerProbeName(nodeName, validationRun)
+	cleanup := func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := client.CoreV1().Pods(namespace).Delete(cleanupCtx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			logs.Warning("failed to delete scheduler probe Pod %s/%s: %v", namespace, name, err)
+		}
+	}
+	cleanup()
+	cleanupCtx, cancelCleanup := context.WithTimeout(ctx, 15*time.Second)
+	err := waitForProbePodDeleted(cleanupCtx, client, namespace, name)
+	cancelCleanup()
+	if err != nil {
+		return fmt.Errorf("wait for stale scheduler probe Pod deletion: %w", err)
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: map[string]string{"casos.io/probe": "scheduler-placement"}},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			NodeSelector:  map[string]string{"kubernetes.io/hostname": hostname},
+			Tolerations: []corev1.Toleration{{
+				Key:      workerBootstrapTaintKey,
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+			Containers: []corev1.Container{{
+				Name: "scheduler-probe", Image: workerProbeImage(image), ImagePullPolicy: corev1.PullIfNotPresent,
+				Command: []string{"sh", "-c", "echo casos-scheduler"},
+			}},
+		},
+	}
+	if _, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		cleanup()
+		return fmt.Errorf("create scheduler probe Pod: %w", err)
+	}
+	defer cleanup()
+	deadlineTimer, deadline := deploymentWaitDeadline(ctx)
+	ticker := time.NewTicker(2 * time.Second)
+	defer deadlineTimer.Stop()
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("timed out waiting for scheduler probe")
+		case <-ticker.C:
+			current, err := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("get scheduler probe Pod: %w", err)
+			}
+			if current.Spec.NodeName != "" && current.Spec.NodeName != nodeName {
+				return fmt.Errorf("scheduler placed probe on %s instead of %s", current.Spec.NodeName, nodeName)
+			}
+			switch current.Status.Phase {
+			case corev1.PodSucceeded:
+				if current.Spec.NodeName != nodeName {
+					return fmt.Errorf("scheduler probe succeeded without binding to %s", nodeName)
+				}
+				return nil
+			case corev1.PodFailed:
+				return fmt.Errorf("scheduler probe Pod failed")
+			}
+		}
+	}
+}
+
+func waitForServiceProbe(ctx context.Context, client kubernetes.Interface, nodeName, validationRun, image string) error {
+	const namespace = "kube-system"
+	name := serviceProbeName(nodeName, validationRun)
+	clientName := name + "-client"
+	cleanupCtx, cancelCleanup := context.WithTimeout(ctx, 15*time.Second)
+	defer cancelCleanup()
+	if err := deleteServiceProbeResources(cleanupCtx, client, namespace, name, clientName); err != nil {
+		return err
+	}
+	if err := waitForServiceProbeResourcesDeleted(cleanupCtx, client, namespace, name, clientName); err != nil {
+		return err
+	}
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list nodes for service probe: %w", err)
+	}
+	placement, err := selectServiceProbePlacement(nodes.Items, nodeName)
+	if err != nil {
+		return err
+	}
+	labels := map[string]string{"casos.io/probe": "service-routing", "casos.io/probe-name": name}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+		Spec:       corev1.ServiceSpec{Selector: labels, Ports: []corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)}}},
+	}
+	createdService, err := client.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("create service probe Service: %w", err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := deleteServiceProbeResources(cleanupCtx, client, namespace, name, clientName); err != nil {
+			logs.Warning("failed to delete service probe resources %s/%s: %v", namespace, name, err)
+		}
+	}()
+	serverPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+		Spec: corev1.PodSpec{
+			NodeSelector:  map[string]string{corev1.LabelHostname: placement.serverHostname},
+			Tolerations:   workerBootstrapProbeTolerations(),
+			RestartPolicy: corev1.RestartPolicyAlways,
+			Containers: []corev1.Container{{
+				Name: "service-server", Image: workerProbeImage(image), ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:        []string{"sh", "-c", "mkdir -p /tmp/www && echo casos-service > /tmp/www/index.html && httpd -f -p 8080 -h /tmp/www"},
+				ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/", Port: intstr.FromInt(8080), Scheme: corev1.URISchemeHTTP}}, InitialDelaySeconds: 1, PeriodSeconds: 2, TimeoutSeconds: 2, FailureThreshold: 5},
+			}},
+		},
+	}
+	if _, err := client.CoreV1().Pods(namespace).Create(ctx, serverPod, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create service probe server Pod: %w", err)
+	}
+	serverPod, err = waitForServiceProbePodReady(ctx, client, namespace, name)
+	if err != nil {
+		return err
+	}
+	if serverPod.Spec.NodeName != placement.serverNodeName {
+		return fmt.Errorf("service probe server scheduled on %s instead of %s", serverPod.Spec.NodeName, placement.serverNodeName)
+	}
+	if serverPod.Status.PodIP == "" {
+		return fmt.Errorf("service probe server has no PodIP")
+	}
+	clusterIP, err := waitForServiceProbeClusterIP(ctx, client, namespace, createdService.Name)
+	if err != nil {
+		return err
+	}
+	clientPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: clientName, Namespace: namespace, Labels: map[string]string{"casos.io/probe": "service-routing-client"}},
+		Spec: corev1.PodSpec{
+			NodeSelector:  map[string]string{corev1.LabelHostname: placement.clientHostname},
+			Tolerations:   workerBootstrapProbeTolerations(),
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name: "service-client", Image: workerProbeImage(image), ImagePullPolicy: corev1.PullIfNotPresent,
+				Command: []string{"sh", "-c", serviceProbeClientCommand(serverPod.Status.PodIP, clusterIP)},
+			}},
+		},
+	}
+	if _, err := client.CoreV1().Pods(namespace).Create(ctx, clientPod, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create service probe client Pod: %w", err)
+	}
+	clientPod, err = waitForServiceProbePodSucceeded(ctx, client, namespace, clientName)
+	if err != nil {
+		return err
+	}
+	if clientPod.Spec.NodeName != nodeName {
+		return fmt.Errorf("service probe client scheduled on %s instead of %s", clientPod.Spec.NodeName, nodeName)
+	}
+	return nil
+}
+
+func serviceProbeClientCommand(serverPodIP, clusterIP string) string {
+	return fmt.Sprintf("nslookup kubernetes.default.svc >/dev/null && i=0; while [ $i -lt 30 ]; do wget -qO- http://%s:8080/ | grep -q casos-service && wget -qO- http://%s:80/ | grep -q casos-service && exit 0; i=$((i+1)); sleep 1; done; exit 1", serverPodIP, clusterIP)
+}
+
+func waitForServiceProbeClusterIP(ctx context.Context, client kubernetes.Interface, namespace, name string) (string, error) {
+	deadlineTimer, deadline := deploymentWaitDeadline(ctx)
+	ticker := time.NewTicker(2 * time.Second)
+	defer deadlineTimer.Stop()
+	defer ticker.Stop()
+	for {
+		current, err := client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("get service probe Service: %w", err)
+		}
+		if err == nil && current.Spec.ClusterIP != "" && current.Spec.ClusterIP != corev1.ClusterIPNone {
+			return current.Spec.ClusterIP, nil
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-deadline:
+			return "", fmt.Errorf("timed out waiting for service probe ClusterIP")
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForServiceProbePodReady(ctx context.Context, client kubernetes.Interface, namespace, name string) (*corev1.Pod, error) {
+	deadlineTimer, deadline := deploymentWaitDeadline(ctx)
+	ticker := time.NewTicker(2 * time.Second)
+	defer deadlineTimer.Stop()
+	defer ticker.Stop()
+	for {
+		pod, err := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// The kubelet may not have created the Pod status yet.
+		} else if err != nil {
+			return nil, fmt.Errorf("get service probe server Pod: %w", err)
+		} else if pod.Status.Phase == corev1.PodFailed {
+			return nil, fmt.Errorf("service probe server Pod failed")
+		} else if isPodReady(*pod) {
+			return pod, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline:
+			return nil, fmt.Errorf("timed out waiting for service probe server Pod")
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForServiceProbePodSucceeded(ctx context.Context, client kubernetes.Interface, namespace, name string) (*corev1.Pod, error) {
+	deadlineTimer, deadline := deploymentWaitDeadline(ctx)
+	ticker := time.NewTicker(2 * time.Second)
+	defer deadlineTimer.Stop()
+	defer ticker.Stop()
+	for {
+		pod, err := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// The kubelet may not have created the Pod status yet.
+		} else if err != nil {
+			return nil, fmt.Errorf("get service probe client Pod: %w", err)
+		} else {
+			switch pod.Status.Phase {
+			case corev1.PodSucceeded:
+				return pod, nil
+			case corev1.PodFailed:
+				return nil, fmt.Errorf("service probe client Pod failed")
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline:
+			return nil, fmt.Errorf("timed out waiting for service probe client Pod")
+		case <-ticker.C:
+		}
+	}
+}
+
+func deleteServiceProbeResources(ctx context.Context, client kubernetes.Interface, namespace, serviceName, clientName string) error {
+	if err := client.CoreV1().Pods(namespace).Delete(ctx, clientName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete service probe client Pod: %w", err)
+	}
+	if err := client.CoreV1().Pods(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete service probe server Pod: %w", err)
+	}
+	if err := client.CoreV1().Services(namespace).Delete(ctx, serviceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete service probe Service: %w", err)
+	}
+	return nil
+}
+
+func waitForServiceProbeResourcesDeleted(ctx context.Context, client kubernetes.Interface, namespace, serviceName, clientName string) error {
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		_, serverErr := client.CoreV1().Pods(namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		_, clientErr := client.CoreV1().Pods(namespace).Get(ctx, clientName, metav1.GetOptions{})
+		_, serviceErr := client.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		if serverErr != nil && !apierrors.IsNotFound(serverErr) {
+			return fmt.Errorf("check service probe server deletion: %w", serverErr)
+		}
+		if clientErr != nil && !apierrors.IsNotFound(clientErr) {
+			return fmt.Errorf("check service probe client deletion: %w", clientErr)
+		}
+		if serviceErr != nil && !apierrors.IsNotFound(serviceErr) {
+			return fmt.Errorf("check service probe Service deletion: %w", serviceErr)
+		}
+		if apierrors.IsNotFound(serverErr) && apierrors.IsNotFound(clientErr) && apierrors.IsNotFound(serviceErr) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for previous service probe resources to be deleted")
+		case <-ticker.C:
+		}
+	}
+}
+
+func stringPtr(value string) *string { return &value }
 
 func isNodeReady(node *corev1.Node) bool {
 	if node == nil {

--- a/deploy/node_bootstrap_test.go
+++ b/deploy/node_bootstrap_test.go
@@ -1,0 +1,125 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/casosorg/casos/object"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestProbeNamesAreScopedToValidationRun(t *testing.T) {
+	for name, makeName := range map[string]func(string, string) string{
+		"storage":   storageProbeName,
+		"scheduler": schedulerProbeName,
+		"service":   serviceProbeName,
+	} {
+		t.Run(name, func(t *testing.T) {
+			first := makeName("worker-1", "task-1")
+			second := makeName("worker-1", "task-2")
+			if first == second {
+				t.Fatalf("probe names collide across validation runs: %q", first)
+			}
+			if len(first) > 63 || len(second) > 63 {
+				t.Fatalf("probe name exceeds DNS label limit: %q / %q", first, second)
+			}
+		})
+	}
+}
+
+func TestNodeDeployApiserverProbeStatus(t *testing.T) {
+	tests := map[string]bool{
+		"200":  true,
+		"204":  true,
+		"401":  true,
+		"403":  true,
+		"400":  false,
+		"404":  false,
+		"500":  false,
+		"503":  false,
+		"":     false,
+		"20":   false,
+		"2000": false,
+	}
+	for status, expected := range tests {
+		if got := isNodeDeployApiserverProbeStatus(status); got != expected {
+			t.Errorf("status %q: expected %t, got %t", status, expected, got)
+		}
+	}
+}
+
+func TestAnyReadyProbePodIgnoresStaleUnreadyPod(t *testing.T) {
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "stale"}, Status: corev1.PodStatus{Phase: corev1.PodFailed}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "current"}, Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}},
+	}
+	if !anyReadyPod(pods) {
+		t.Fatal("expected the ready non-terminating Pod to satisfy readiness")
+	}
+}
+
+func TestDeleteStorageProbeResourcesReturnsDeleteErrors(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("delete", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("apiserver unavailable")
+	})
+	if err := deleteStorageProbeResources(context.Background(), client, "kube-system", "probe"); err == nil {
+		t.Fatal("expected cleanup failure to be observable")
+	}
+}
+
+func TestMachineNodeDeployCompletionFailsWhenMachineStatusUpdateFails(t *testing.T) {
+	success, phase, message := machineNodeDeployCompletion(errors.New("database unavailable"))
+	if success {
+		t.Fatal("expected task completion to fail when machine status persistence fails")
+	}
+	if phase != object.MachineNodeDeployPhaseFailed {
+		t.Fatalf("expected failed phase, got %q", phase)
+	}
+	if !strings.Contains(message, "database unavailable") {
+		t.Fatalf("expected persistence error in task message, got %q", message)
+	}
+}
+
+func TestServiceProbeClientCommandChecksClusterDNS(t *testing.T) {
+	command := serviceProbeClientCommand("10.244.1.2", "10.96.0.42")
+	if !strings.Contains(command, "nslookup kubernetes.default.svc") {
+		t.Fatalf("service probe does not verify cluster DNS: %q", command)
+	}
+}
+
+func TestWorkerBootstrapTaintIsIdempotentAndPreservesOtherTaints(t *testing.T) {
+	node := &corev1.Node{Spec: corev1.NodeSpec{Taints: []corev1.Taint{{
+		Key: "dedicated", Value: "worker", Effect: corev1.TaintEffectNoSchedule,
+	}}}}
+	if !ensureWorkerBootstrapTaint(node) {
+		t.Fatal("expected the bootstrap taint to be added")
+	}
+	if ensureWorkerBootstrapTaint(node) {
+		t.Fatal("expected applying the same bootstrap taint to be idempotent")
+	}
+	if len(node.Spec.Taints) != 2 || node.Spec.Taints[0].Key != "dedicated" || node.Spec.Taints[1].Key != workerBootstrapTaintKey {
+		t.Fatalf("unexpected taints after reconciliation: %#v", node.Spec.Taints)
+	}
+}
+
+func TestServiceProbeUsesAnotherReadyWorkerWhenAvailable(t *testing.T) {
+	ready := []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}
+	nodes := []corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "target", Labels: map[string]string{corev1.LabelHostname: "target-host"}}, Spec: corev1.NodeSpec{PodCIDR: "10.244.1.0/24"}, Status: corev1.NodeStatus{Conditions: ready}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "peer", Labels: map[string]string{corev1.LabelHostname: "peer-host"}}, Spec: corev1.NodeSpec{PodCIDRs: []string{"10.244.2.0/24"}}, Status: corev1.NodeStatus{Conditions: ready}},
+	}
+	placement, err := selectServiceProbePlacement(nodes, "target")
+	if err != nil {
+		t.Fatalf("select placement: %v", err)
+	}
+	if placement.clientHostname != "target-host" || placement.serverHostname != "peer-host" {
+		t.Fatalf("expected cross-worker service validation, got %#v", placement)
+	}
+}

--- a/deploy/preflight.go
+++ b/deploy/preflight.go
@@ -90,14 +90,23 @@ func RunNodeDeployPreflight(ctx context.Context, runner *NodeDeploySSHRunner, ap
 		// The bootstrap kubeconfig embeds the apiserver CA, but this early
 		// reachability probe runs before those files exist on the target node.
 		encodedURL := base64.StdEncoding.EncodeToString([]byte(trimmedURL))
-		cmd := fmt.Sprintf("apiserver_url=$(printf %%s %s | base64 -d) && curl -kfsS --connect-timeout 5 \"$apiserver_url/readyz\" >/dev/null", shellSingleQuote(encodedURL))
-		if _, err = runner.RunContext(ctx, cmd); err != nil {
+		cmd := fmt.Sprintf("apiserver_url=$(printf %%s %s | base64 -d) && curl -ksS --connect-timeout 5 --output /dev/null --write-out %%{http_code} \"$apiserver_url/readyz\"", shellSingleQuote(encodedURL))
+		status, err := runner.RunContext(ctx, cmd)
+		if err != nil {
 			return nil, fmt.Errorf("apiserver is not reachable from target: %w", err)
+		}
+		if !isNodeDeployApiserverProbeStatus(status) {
+			return nil, fmt.Errorf("apiserver readiness probe returned HTTP status %q", strings.TrimSpace(status))
 		}
 		result.ApiserverOK = true
 	}
 
 	return result, nil
+}
+
+func isNodeDeployApiserverProbeStatus(status string) bool {
+	status = strings.TrimSpace(status)
+	return (len(status) == 3 && status[0] == '2') || status == "401" || status == "403"
 }
 
 func ResolveNodeDeployApiserverURL(ctx context.Context, runner *NodeDeploySSHRunner, fallbackURL string) string {

--- a/deploy/service.go
+++ b/deploy/service.go
@@ -308,13 +308,32 @@ func (s *Service) runMachineNodeDeployTask(parentCtx context.Context, taskId int
 		logTask(object.MachineNodeDeployLogLevelInfo, "CasOS managed SSH key installed")
 	}
 
-	logTask(object.MachineNodeDeployLogLevelInfo, "Node deployment completed")
-	if err = object.UpdateMachineNodeDeployStatus(machine.Owner, machine.Name, object.MachineStatusDeployed); err != nil {
-		logTask(object.MachineNodeDeployLogLevelError, "Failed to update machine status after completed node deployment: "+err.Error())
-		_ = object.FinishMachineNodeDeployTask(taskId, true, object.MachineNodeDeployPhaseReady, "machine status update failed: "+err.Error())
+	logTask(object.MachineNodeDeployLogLevelInfo, "Worker installed; validating network, DNS, and storage readiness")
+	if err = deployer.WaitForOperational(ctx, task.NodeName, strconv.FormatInt(taskId, 10)); err != nil {
+		logTask(object.MachineNodeDeployLogLevelError, "Worker operational validation failed: "+err.Error())
+		_ = object.UpdateMachineNodeDeployStatus(machine.Owner, machine.Name, object.MachineStatusFailed)
+		if finishErr := object.FinishMachineNodeDeployTask(taskId, false, object.MachineNodeDeployPhaseFailed, err.Error()); finishErr != nil {
+			logTask(object.MachineNodeDeployLogLevelError, "Failed to finish node deployment task: "+finishErr.Error())
+		}
 		return
 	}
-	_ = object.FinishMachineNodeDeployTask(taskId, true, object.MachineNodeDeployPhaseReady, "")
+
+	logTask(object.MachineNodeDeployLogLevelInfo, "Worker is operational")
+	statusErr := object.UpdateMachineNodeDeployStatus(machine.Owner, machine.Name, object.MachineStatusOperational)
+	if statusErr != nil {
+		logTask(object.MachineNodeDeployLogLevelError, "Failed to update machine status after completed node deployment: "+statusErr.Error())
+	}
+	success, phase, message := machineNodeDeployCompletion(statusErr)
+	if finishErr := object.FinishMachineNodeDeployTask(taskId, success, phase, message); finishErr != nil {
+		logTask(object.MachineNodeDeployLogLevelError, "Failed to finish node deployment task: "+finishErr.Error())
+	}
+}
+
+func machineNodeDeployCompletion(statusErr error) (bool, string, string) {
+	if statusErr != nil {
+		return false, object.MachineNodeDeployPhaseFailed, "machine status update failed: " + statusErr.Error()
+	}
+	return true, object.MachineNodeDeployPhaseReady, ""
 }
 
 func cleanupMachineNodeDeployPanic(taskId int64, owner, machineName, message string) {

--- a/deploy/types.go
+++ b/deploy/types.go
@@ -13,6 +13,7 @@ const (
 	defaultNodeDeployCNIVersion = "v1.5.1"
 	nodeDeployClusterCIDR       = "10.244.0.0/16"
 	nodeDeployClusterDNS        = "10.43.0.10"
+	nodeDeployResolverPath      = "/etc/casos-resolv.conf"
 	nodeDeployPhasePreflight    = "preflight"
 	nodeDeployPhaseInstalling   = "installing"
 	nodeDeployPhaseConfiguring  = "configuring"
@@ -118,16 +119,18 @@ type Config struct {
 	ApiserverPort      int
 	SandboxImage       string
 	Socks5Proxy        string
+	StorageProbeImage  string
 	GenerateKubeconfig KubeconfigGenerator
 }
 
 func ConfigFromServerConfig(cfg server.Config) Config {
 	return Config{
-		AdvertiseAddress: cfg.AdvertiseAddress,
-		ApiserverBind:    cfg.ApiserverBind,
-		ApiserverPort:    cfg.ApiserverPort,
-		SandboxImage:     cfg.SandboxImage,
-		Socks5Proxy:      cfg.Socks5Proxy,
+		AdvertiseAddress:  cfg.AdvertiseAddress,
+		ApiserverBind:     cfg.ApiserverBind,
+		ApiserverPort:     cfg.ApiserverPort,
+		SandboxImage:      cfg.SandboxImage,
+		Socks5Proxy:       cfg.Socks5Proxy,
+		StorageProbeImage: cfg.StorageProbeImage,
 		GenerateKubeconfig: func(nodeName, apiserverURL string) (*NodeKubeconfig, error) {
 			wk, err := server.GenerateWorkerKubeconfigForServer(cfg, nodeName, apiserverURL)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -67,6 +67,11 @@ func main() {
 			if err := server.Bootstrap(ctx, adminCfg, srvCfg); err != nil {
 				logs.Warning("bootstrap: %v", err)
 			}
+			if srvCfg.ServiceLBEnabled {
+				if err := server.StartServiceLB(ctx, adminCfg); err != nil {
+					logs.Warning("start service load balancer: %v", err)
+				}
+			}
 			if err := server.StartScheduler(ctx, srvCfg); err != nil {
 				logs.Warning("start scheduler: %v", err)
 			}

--- a/object/machine.go
+++ b/object/machine.go
@@ -5,9 +5,10 @@ import (
 )
 
 const (
-	MachineStatusDeploying = "Deploying"
-	MachineStatusDeployed  = "Deployed"
-	MachineStatusFailed    = "Failed"
+	MachineStatusDeploying   = "Deploying"
+	MachineStatusDeployed    = "Deployed"
+	MachineStatusOperational = "Operational"
+	MachineStatusFailed      = "Failed"
 )
 
 type Machine struct {

--- a/object/machine_node_deploy.go
+++ b/object/machine_node_deploy.go
@@ -51,6 +51,7 @@ var (
 
 type MachineNodeDeployTask struct {
 	Id           int64     `xorm:"pk autoincr" json:"id"`
+	ActiveKey    *string   `xorm:"char(64) unique" json:"-"`
 	Owner        string    `xorm:"varchar(100) notnull index" json:"owner"`
 	MachineName  string    `xorm:"varchar(100) notnull index" json:"machineName"`
 	NodeName     string    `xorm:"varchar(100) notnull" json:"nodeName"`
@@ -103,6 +104,7 @@ func CreateMachineNodeDeployTask(owner, machineName, nodeName, apiserverURL stri
 		}
 	}
 
+	activeKey := machineNodeDeployActiveKey(owner, machineName)
 	result, err := withMachineNodeDeployTransaction(func(session *xorm.Session) (interface{}, error) {
 		machine := &Machine{}
 		foundMachine, err := session.
@@ -131,6 +133,7 @@ func CreateMachineNodeDeployTask(owner, machineName, nodeName, apiserverURL stri
 
 		now := time.Now().UTC()
 		task := &MachineNodeDeployTask{
+			ActiveKey:    &activeKey,
 			Owner:        owner,
 			MachineName:  machineName,
 			NodeName:     nodeName,
@@ -153,6 +156,11 @@ func CreateMachineNodeDeployTask(owner, machineName, nodeName, apiserverURL stri
 		return nil, fmt.Errorf("create node deployment task returned invalid result")
 	}
 	return task, nil
+}
+
+func machineNodeDeployActiveKey(owner, machineName string) string {
+	digest := sha256.Sum256([]byte(owner + "\x00" + machineName))
+	return fmt.Sprintf("%x", digest[:])
 }
 
 func GetMachineNodeDeployTask(id int64) (*MachineNodeDeployTask, error) {
@@ -214,8 +222,9 @@ func FailActiveMachineNodeDeployTasks(reason string) error {
 	now := time.Now().UTC()
 	_, err := ormer.Engine.
 		Where("status IN (?, ?)", MachineNodeDeployStatusPending, MachineNodeDeployStatusRunning).
-		Cols("status", "phase", "error_msg", "finished_at", "updated_at").
+		Cols("active_key", "status", "phase", "error_msg", "finished_at", "updated_at").
 		Update(&MachineNodeDeployTask{
+			ActiveKey:  nil,
 			Status:     MachineNodeDeployStatusFailed,
 			Phase:      MachineNodeDeployPhaseFailed,
 			ErrorMsg:   reason,
@@ -284,8 +293,9 @@ func FinishMachineNodeDeployTask(id int64, success bool, phase, errorMsg string)
 	now := time.Now().UTC()
 	affected, err := ormer.Engine.ID(id).
 		Where("status IN (?, ?)", MachineNodeDeployStatusPending, MachineNodeDeployStatusRunning).
-		Cols("status", "phase", "error_msg", "finished_at", "updated_at").
+		Cols("active_key", "status", "phase", "error_msg", "finished_at", "updated_at").
 		Update(&MachineNodeDeployTask{
+			ActiveKey:  nil,
 			Status:     status,
 			Phase:      phase,
 			ErrorMsg:   errorMsg,
@@ -543,7 +553,7 @@ func UpdateMachineNodeDeployStatus(owner, name, status string) error {
 
 func isValidMachineStatus(status string) bool {
 	switch status {
-	case MachineStatusDeploying, MachineStatusDeployed, MachineStatusFailed:
+	case MachineStatusDeploying, MachineStatusDeployed, MachineStatusOperational, MachineStatusFailed:
 		return true
 	default:
 		return false

--- a/object/machine_node_deploy_test.go
+++ b/object/machine_node_deploy_test.go
@@ -1,0 +1,65 @@
+package object
+
+import (
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+	"xorm.io/xorm"
+)
+
+func TestMachineNodeDeployActiveKeyEnforcesOneActiveTask(t *testing.T) {
+	previousOrmer := ormer
+	engine, err := xorm.NewEngine("sqlite", "file:machine-node-deploy-active-key-test?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("create test engine: %v", err)
+	}
+	engine.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		_ = engine.Close()
+		ormer = previousOrmer
+	})
+	ormer = &Ormer{Engine: engine}
+
+	if err := engine.Sync2(new(Machine), new(MachineNodeDeployTask)); err != nil {
+		t.Fatalf("create task tables: %v", err)
+	}
+	if _, err := engine.Insert(&Machine{Owner: "admin", Name: "worker-1"}); err != nil {
+		t.Fatalf("create machine: %v", err)
+	}
+
+	first, err := CreateMachineNodeDeployTask("admin", "worker-1", "worker-1", "https://127.0.0.1:6443")
+	if err != nil {
+		t.Fatalf("create first task: %v", err)
+	}
+	if first.ActiveKey == nil {
+		t.Fatal("expected active task to have an arbitration key")
+	}
+	duplicate := &MachineNodeDeployTask{
+		ActiveKey:   first.ActiveKey,
+		Owner:       "admin",
+		MachineName: "worker-1",
+		NodeName:    "worker-1",
+		Status:      MachineNodeDeployStatusPending,
+		Phase:       MachineNodeDeployPhaseQueued,
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+	if _, err := engine.Insert(duplicate); err == nil {
+		t.Fatal("expected the database to reject a duplicate active key")
+	}
+
+	if err := FinishMachineNodeDeployTask(first.Id, false, MachineNodeDeployPhaseFailed, "failed"); err != nil {
+		t.Fatalf("finish first task: %v", err)
+	}
+	stored, err := GetMachineNodeDeployTask(first.Id)
+	if err != nil {
+		t.Fatalf("read finished task: %v", err)
+	}
+	if stored.ActiveKey != nil {
+		t.Fatalf("expected a finished task to release its active key, got %q", *stored.ActiveKey)
+	}
+	if _, err := CreateMachineNodeDeployTask("admin", "worker-1", "worker-1", "https://127.0.0.1:6443"); err != nil {
+		t.Fatalf("create replacement task: %v", err)
+	}
+}

--- a/server/admission.go
+++ b/server/admission.go
@@ -4,17 +4,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/beego/beego/logs"
 	"github.com/casosorg/casos/object"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
+
+const admissionValidatePath = "/admission/validate"
 
 // RegisterAdmissionHandler mounts the ValidatingAdmissionWebhook endpoint on mux.
 func RegisterAdmissionHandler(mux *http.ServeMux) {
-	mux.HandleFunc("/admission/validate", admissionValidateHandler)
+	mux.HandleFunc(admissionValidatePath, admissionValidateHandler)
 }
 
 func admissionValidateHandler(w http.ResponseWriter, r *http.Request) {
@@ -30,12 +35,28 @@ func admissionValidateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req := review.Request
-	allowed, err := object.EnforceAdmissionPolicy(
-		req.UserInfo.Username,
-		req.Namespace,
-		req.Resource.Resource,
-		string(req.Operation),
-	)
+	if req == nil {
+		writeAdmissionResponse(w, &admissionv1.AdmissionReview{
+			TypeMeta: metav1.TypeMeta{APIVersion: "admission.k8s.io/v1", Kind: "AdmissionReview"},
+			Response: &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result:  &metav1.Status{Message: "admission request is missing"},
+			},
+		})
+		return
+	}
+	// Requests are allowed without a Casbin lookup only for the small set of
+	// authenticated control-plane identities enumerated below.
+	allowed := true
+	var err error
+	if shouldEnforceAdmissionPolicy(req) {
+		allowed, err = object.EnforceAdmissionPolicy(
+			req.UserInfo.Username,
+			req.Namespace,
+			req.Resource.Resource,
+			string(req.Operation),
+		)
+	}
 
 	resp := &admissionv1.AdmissionReview{
 		TypeMeta: metav1.TypeMeta{APIVersion: "admission.k8s.io/v1", Kind: "AdmissionReview"},
@@ -55,9 +76,19 @@ func admissionValidateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Image vulnerability check: only for Pod-creating operations.
-	if req.Resource.Resource == "pods" && (req.Operation == admissionv1.Create || req.Operation == admissionv1.Update) {
-		if denyMsg := checkPodImages(req.Object.Raw); denyMsg != "" {
+	// Check user-owned workload templates before they are accepted. Pods later
+	// created by the workload controller inherit that already-approved template
+	// and must not be blocked by a scan result that changed after installation.
+	triggerUnknownScans := shouldTriggerImageScans(req)
+	if shouldCheckWorkloadTemplateImages(req) {
+		if denyMsg := checkWorkloadTemplateImages(req.Resource.Group, req.Resource.Resource, req.Object.Raw, triggerUnknownScans); denyMsg != "" {
+			resp.Response.Allowed = false
+			resp.Response.Result = &metav1.Status{Message: denyMsg}
+			writeAdmissionResponse(w, resp)
+			return
+		}
+	} else if shouldCheckPodImages(req) {
+		if denyMsg := checkPodImages(req.Object.Raw, triggerUnknownScans); denyMsg != "" {
 			resp.Response.Allowed = false
 			resp.Response.Result = &metav1.Status{Message: denyMsg}
 			writeAdmissionResponse(w, resp)
@@ -68,20 +99,203 @@ func admissionValidateHandler(w http.ResponseWriter, r *http.Request) {
 	writeAdmissionResponse(w, resp)
 }
 
+func shouldTriggerImageScans(req *admissionv1.AdmissionRequest) bool {
+	return req != nil && (req.DryRun == nil || !*req.DryRun)
+}
+
+func shouldEnforceAdmissionPolicy(req *admissionv1.AdmissionRequest) bool {
+	if req == nil {
+		return false
+	}
+	if isTrustedControlPlaneUser(req.UserInfo.Username, req.UserInfo.Groups) {
+		return false
+	}
+	return true
+}
+
+func isTrustedControlPlaneUser(username string, groups []string) bool {
+	// These identities are issued by the local CA or Kubernetes service-account
+	// authenticator. Impersonating them requires explicit cluster-level RBAC,
+	// which already grants enough authority to alter admission configuration.
+	if isWorkloadControllerUser(username) || username == "system:kube-scheduler" {
+		return true
+	}
+	if !strings.HasPrefix(username, "system:node:") {
+		return false
+	}
+	for _, group := range groups {
+		if group == "system:nodes" {
+			return true
+		}
+	}
+	return false
+}
+
+// Platform components must be able to restart and scale even when an image's
+// cached Trivy result is stale or critical. Application namespaces remain
+// subject to the normal image admission policy.
+func isPlatformNamespace(namespace string) bool {
+	switch namespace {
+	case "kube-system", "kube-flannel", "local-path-storage":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldCheckPodImages(req *admissionv1.AdmissionRequest) bool {
+	if req == nil || req.Resource.Resource != "pods" {
+		return false
+	}
+	if req.SubResource != "" || isWorkloadControllerPodRequest(req) {
+		return false
+	}
+	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Update {
+		return false
+	}
+	return true
+}
+
+func shouldCheckWorkloadTemplateImages(req *admissionv1.AdmissionRequest) bool {
+	if req == nil || req.SubResource != "" {
+		return false
+	}
+	if isWorkloadControllerUser(req.UserInfo.Username) {
+		return false
+	}
+	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Update {
+		return false
+	}
+	if isPlatformNamespace(req.Namespace) && isPlatformBootstrapUser(req.UserInfo.Username, req.UserInfo.Groups) {
+		return false
+	}
+	_, ok := workloadPodSpecPath(req.Resource.Group, req.Resource.Resource)
+	return ok
+}
+
+type workloadPodSpecLocation struct {
+	group string
+	path  []string
+}
+
+var workloadPodSpecLocations = map[string]workloadPodSpecLocation{
+	"deployments":            {group: "apps", path: []string{"spec", "template", "spec"}},
+	"statefulsets":           {group: "apps", path: []string{"spec", "template", "spec"}},
+	"daemonsets":             {group: "apps", path: []string{"spec", "template", "spec"}},
+	"replicasets":            {group: "apps", path: []string{"spec", "template", "spec"}},
+	"jobs":                   {group: "batch", path: []string{"spec", "template", "spec"}},
+	"cronjobs":               {group: "batch", path: []string{"spec", "jobTemplate", "spec", "template", "spec"}},
+	"replicationcontrollers": {group: "", path: []string{"spec", "template", "spec"}},
+}
+
+func workloadPodSpecPath(group, resource string) ([]string, bool) {
+	location, ok := workloadPodSpecLocations[resource]
+	if !ok || location.group != group {
+		return nil, false
+	}
+	return location.path, true
+}
+
+func isPlatformBootstrapUser(username string, groups []string) bool {
+	// AdminRestConfig is the only in-process bootstrap client and is issued this
+	// exact user/group pair by ensureCerts. Requiring both avoids treating an
+	// arbitrary account named admin as trusted.
+	if username != "admin" {
+		return false
+	}
+	for _, group := range groups {
+		if group == "system:masters" {
+			return true
+		}
+	}
+	return false
+}
+
+func isWorkloadControllerPodRequest(req *admissionv1.AdmissionRequest) bool {
+	if req == nil || req.Resource.Resource != "pods" {
+		return false
+	}
+	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Update && req.Operation != admissionv1.Delete {
+		return false
+	}
+	return isWorkloadControllerUser(req.UserInfo.Username)
+}
+
+func isWorkloadControllerUser(username string) bool {
+	const serviceAccountPrefix = "system:serviceaccount:kube-system:"
+	if !strings.HasPrefix(username, serviceAccountPrefix) {
+		return username == "system:kube-controller-manager"
+	}
+	switch strings.TrimPrefix(username, serviceAccountPrefix) {
+	case "replicaset-controller", "replication-controller", "statefulset-controller", "daemon-set-controller", "job-controller", "cronjob-controller", "deployment-controller":
+		return true
+	default:
+		return false
+	}
+}
+
 // checkPodImages extracts images from the Pod spec, checks Trivy cache, and
 // triggers async scans for unknown images. Returns a non-empty denial message
 // if any image has CRITICAL vulnerabilities in the cache.
-func checkPodImages(raw []byte) string {
-	var pod corev1.Pod
-	if err := json.Unmarshal(raw, &pod); err != nil {
+func checkPodImages(raw []byte, triggerUnknownScans bool) string {
+	podSpec, found, err := decodePodSpec(raw, "spec")
+	if err != nil {
+		return fmt.Sprintf("failed to parse Pod for image policy: %v", err)
+	}
+	if !found {
+		return "failed to parse Pod for image policy: spec is missing"
+	}
+	return checkPodSpecImages(podSpec, triggerUnknownScans)
+}
+
+// checkWorkloadTemplateImages intentionally fails closed on parse errors. The
+// caller limits this function to built-in workload API groups, so malformed
+// input must not bypass a security check.
+func checkWorkloadTemplateImages(group, resource string, raw []byte, triggerUnknownScans bool) string {
+	path, ok := workloadPodSpecPath(group, resource)
+	if !ok {
 		return ""
 	}
+	podSpec, found, err := decodePodSpec(raw, path...)
+	if err != nil {
+		return fmt.Sprintf("failed to parse %s for image policy: %v", resource, err)
+	}
+	if !found {
+		if resource == "replicationcontrollers" {
+			// ReplicationController intentionally permits a nil template; without
+			// one it cannot create Pods, so there are no images to validate.
+			return ""
+		}
+		return fmt.Sprintf("failed to parse %s for image policy: Pod template spec is missing", resource)
+	}
+	return checkPodSpecImages(podSpec, triggerUnknownScans)
+}
 
+func decodePodSpec(raw []byte, fields ...string) (corev1.PodSpec, bool, error) {
+	var object map[string]interface{}
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return corev1.PodSpec{}, false, err
+	}
+	specMap, found, err := unstructured.NestedMap(object, fields...)
+	if err != nil || !found {
+		return corev1.PodSpec{}, found, err
+	}
+	var podSpec corev1.PodSpec
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(specMap, &podSpec); err != nil {
+		return corev1.PodSpec{}, false, err
+	}
+	return podSpec, true, nil
+}
+
+func checkPodSpecImages(spec corev1.PodSpec, triggerUnknownScans bool) string {
 	var images []string
-	for _, c := range pod.Spec.InitContainers {
+	for _, c := range spec.InitContainers {
 		images = append(images, c.Image)
 	}
-	for _, c := range pod.Spec.Containers {
+	for _, c := range spec.Containers {
+		images = append(images, c.Image)
+	}
+	for _, c := range spec.EphemeralContainers {
 		images = append(images, c.Image)
 	}
 
@@ -92,8 +306,10 @@ func checkPodImages(raw []byte) string {
 			continue
 		}
 		if result == nil {
-			// No cache yet — allow this time and kick off a background scan.
-			object.TriggerScan(image)
+			// Dry-run admission must remain side-effect free.
+			if triggerUnknownScans {
+				object.TriggerScan(image)
+			}
 			continue
 		}
 		if result.Status == "done" && result.Critical > 0 {

--- a/server/admission_test.go
+++ b/server/admission_test.go
@@ -1,0 +1,343 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
+)
+
+func TestGenericSystemIdentityDoesNotBypassAdmission(t *testing.T) {
+	req := &admissionv1.AdmissionRequest{
+		Resource:  metav1.GroupVersionResource{Resource: "pods"},
+		Operation: admissionv1.Create,
+		UserInfo: authenticationv1.UserInfo{
+			Username: "system:serviceaccount:default:installer",
+			Groups:   []string{"system:serviceaccounts", "system:authenticated"},
+		},
+	}
+	if !shouldEnforceAdmissionPolicy(req) {
+		t.Fatal("a generic authenticated service account bypassed admission policy")
+	}
+}
+
+func TestTrustedControlPlaneIdentitiesBypassCasbin(t *testing.T) {
+	for _, userInfo := range []authenticationv1.UserInfo{
+		{Username: "system:kube-controller-manager"},
+		{Username: "system:kube-scheduler"},
+		{Username: "system:node:worker-1", Groups: []string{"system:nodes", "system:authenticated"}},
+	} {
+		req := &admissionv1.AdmissionRequest{
+			Resource: metav1.GroupVersionResource{Resource: "pods"},
+			UserInfo: userInfo,
+		}
+		if shouldEnforceAdmissionPolicy(req) {
+			t.Fatalf("trusted control-plane identity %q was subject to end-user Casbin policy", userInfo.Username)
+		}
+	}
+}
+
+func TestPlatformPodLabelDoesNotAuthenticateCaller(t *testing.T) {
+	pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+		"app.kubernetes.io/managed-by": "casos",
+	}}}
+	raw, err := json.Marshal(&pod)
+	if err != nil {
+		t.Fatalf("encode Pod: %v", err)
+	}
+	req := &admissionv1.AdmissionRequest{
+		Namespace: "kube-system",
+		Resource:  metav1.GroupVersionResource{Resource: "pods"},
+		Operation: admissionv1.Create,
+		Object:    runtime.RawExtension{Raw: raw},
+		UserInfo:  authenticationv1.UserInfo{Username: "alice"},
+	}
+	if !shouldEnforceAdmissionPolicy(req) || !shouldCheckPodImages(req) {
+		t.Fatal("a user-controlled platform label bypassed admission")
+	}
+}
+
+func TestForgedOwnerReferenceDoesNotBypassPodAdmission(t *testing.T) {
+	controller := true
+	pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+		APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "forged", Controller: &controller,
+	}}}}
+	raw, err := json.Marshal(&pod)
+	if err != nil {
+		t.Fatalf("encode Pod: %v", err)
+	}
+	req := &admissionv1.AdmissionRequest{
+		Resource:  metav1.GroupVersionResource{Resource: "pods"},
+		Operation: admissionv1.Create,
+		Object:    runtime.RawExtension{Raw: raw},
+		UserInfo:  authenticationv1.UserInfo{Username: "alice"},
+	}
+	if isWorkloadControllerPodRequest(req) {
+		t.Fatal("a user-controlled ownerReference bypassed admission")
+	}
+	if !shouldEnforceAdmissionPolicy(req) || !shouldCheckPodImages(req) {
+		t.Fatal("forged Pod did not remain subject to policy and image checks")
+	}
+}
+
+func TestReplicaSetTemplateIsImageChecked(t *testing.T) {
+	req := &admissionv1.AdmissionRequest{
+		Namespace: "default",
+		Resource:  metav1.GroupVersionResource{Group: "apps", Resource: "replicasets"},
+		Operation: admissionv1.Create,
+	}
+	if !shouldCheckWorkloadTemplateImages(req) {
+		t.Fatal("ReplicaSet templates must be checked before controller-created Pods are exempted")
+	}
+}
+
+func TestWorkloadTemplateChecksOnlyBuiltInAPIGroups(t *testing.T) {
+	for _, tc := range []struct {
+		group, resource string
+		want            bool
+	}{
+		{group: "apps", resource: "deployments", want: true},
+		{group: "batch", resource: "jobs", want: true},
+		{group: "", resource: "replicationcontrollers", want: true},
+		{group: "example.com", resource: "deployments", want: false},
+		{group: "apps", resource: "jobs", want: false},
+	} {
+		req := &admissionv1.AdmissionRequest{
+			Namespace: "default",
+			Resource:  metav1.GroupVersionResource{Group: tc.group, Resource: tc.resource},
+			Operation: admissionv1.Create,
+		}
+		if got := shouldCheckWorkloadTemplateImages(req); got != tc.want {
+			t.Fatalf("group=%q resource=%q: got %v, want %v", tc.group, tc.resource, got, tc.want)
+		}
+	}
+}
+
+func TestControllerDerivedWorkloadIsNotRechecked(t *testing.T) {
+	req := &admissionv1.AdmissionRequest{
+		Namespace: "default",
+		Resource:  metav1.GroupVersionResource{Group: "apps", Resource: "replicasets"},
+		Operation: admissionv1.Create,
+		UserInfo:  authenticationv1.UserInfo{Username: "system:kube-controller-manager"},
+	}
+	if shouldEnforceAdmissionPolicy(req) {
+		t.Fatal("controller-derived ReplicaSet was subject to end-user Casbin policy")
+	}
+	if shouldCheckWorkloadTemplateImages(req) {
+		t.Fatal("controller-derived ReplicaSet rechecked an already-approved Pod template")
+	}
+}
+
+func TestMalformedWorkloadsFailImageParsing(t *testing.T) {
+	if message := checkPodImages([]byte(`{"spec":`), false); message == "" {
+		t.Fatal("malformed Pod bypassed image checks")
+	}
+	for resource, location := range workloadPodSpecLocations {
+		if message := checkWorkloadTemplateImages(location.group, resource, []byte(`{"spec":`), false); message == "" {
+			t.Fatalf("malformed %s bypassed image checks", resource)
+		}
+	}
+}
+
+func TestDecodeWorkloadPodSpecIsVersionAgnostic(t *testing.T) {
+	raw := []byte(`{
+		"apiVersion":"extensions/v1beta1",
+		"kind":"Deployment",
+		"spec":{"template":{"spec":{"terminationGracePeriodSeconds":30,"containers":[{"name":"app","image":"example/app:v1"}]}}}
+	}`)
+	path, ok := workloadPodSpecPath("apps", "deployments")
+	if !ok {
+		t.Fatal("Deployment Pod spec path is missing")
+	}
+	spec, found, err := decodePodSpec(raw, path...)
+	if err != nil || !found {
+		t.Fatalf("decode version-skewed workload: found=%v err=%v", found, err)
+	}
+	if len(spec.Containers) != 1 || spec.Containers[0].Image != "example/app:v1" {
+		t.Fatalf("unexpected Pod spec: %#v", spec)
+	}
+	if spec.TerminationGracePeriodSeconds == nil || *spec.TerminationGracePeriodSeconds != 30 {
+		t.Fatalf("integer field was not preserved: %#v", spec.TerminationGracePeriodSeconds)
+	}
+}
+
+func TestCasbinAdmissionWebhookRemainsRecoverable(t *testing.T) {
+	webhook := casbinAdmissionWebhook("https://127.0.0.1:9443/admission/validate", []byte("ca"))
+	if webhook.FailurePolicy == nil || *webhook.FailurePolicy != admissionregv1.Ignore {
+		t.Fatalf("expected fail-open recovery policy, got %v", webhook.FailurePolicy)
+	}
+	if len(webhook.Rules) != 1 || webhook.Rules[0].Rule.Scope == nil || *webhook.Rules[0].Rule.Scope != admissionregv1.AllScopes {
+		t.Fatalf("unexpected webhook scope: %#v", webhook.Rules)
+	}
+	if webhook.TimeoutSeconds == nil || *webhook.TimeoutSeconds != 3 {
+		t.Fatalf("expected bounded webhook timeout, got %v", webhook.TimeoutSeconds)
+	}
+	if webhook.SideEffects == nil || *webhook.SideEffects != admissionregv1.SideEffectClassNoneOnDryRun {
+		t.Fatalf("unexpected side-effect declaration: %v", webhook.SideEffects)
+	}
+}
+
+func TestDryRunDoesNotTriggerImageScans(t *testing.T) {
+	dryRun := true
+	if shouldTriggerImageScans(&admissionv1.AdmissionRequest{DryRun: &dryRun}) {
+		t.Fatal("dry-run admission was allowed to trigger background scans")
+	}
+	dryRun = false
+	if !shouldTriggerImageScans(&admissionv1.AdmissionRequest{DryRun: &dryRun}) {
+		t.Fatal("normal admission did not allow background scans")
+	}
+}
+
+func TestPlatformBootstrapExemptionRequiresGeneratedIdentity(t *testing.T) {
+	base := admissionv1.AdmissionRequest{
+		Namespace: "kube-system",
+		Resource:  metav1.GroupVersionResource{Group: "apps", Resource: "deployments"},
+		Operation: admissionv1.Create,
+	}
+	for _, tc := range []struct {
+		name     string
+		userInfo authenticationv1.UserInfo
+		want     bool
+	}{
+		{name: "generated admin", userInfo: authenticationv1.UserInfo{Username: "admin", Groups: []string{"system:masters"}}, want: false},
+		{name: "name only", userInfo: authenticationv1.UserInfo{Username: "admin"}, want: true},
+		{name: "group only", userInfo: authenticationv1.UserInfo{Username: "other", Groups: []string{"system:masters"}}, want: true},
+	} {
+		req := base
+		req.UserInfo = tc.userInfo
+		if got := shouldCheckWorkloadTemplateImages(&req); got != tc.want {
+			t.Fatalf("%s: got imageCheck=%v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestComponentKubeconfigUsesDedicatedIdentity(t *testing.T) {
+	dir := t.TempDir()
+	if err := ensureCerts(dir, "127.0.0.1", "127.0.0.1"); err != nil {
+		t.Fatalf("ensure certificates: %v", err)
+	}
+	path, err := ensureComponentKubeconfig(dir, "https://127.0.0.1:6443", "controller-manager")
+	if err != nil {
+		t.Fatalf("ensure component kubeconfig: %v", err)
+	}
+	config, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("load kubeconfig: %v", err)
+	}
+	auth := config.AuthInfos["controller-manager"]
+	if auth == nil {
+		t.Fatal("controller-manager auth info is missing")
+	}
+	block, _ := pem.Decode(auth.ClientCertificateData)
+	if block == nil {
+		t.Fatal("component client certificate is not PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse component client certificate: %v", err)
+	}
+	if cert.Subject.CommonName != "system:kube-controller-manager" {
+		t.Fatalf("component common name = %q", cert.Subject.CommonName)
+	}
+
+	caCertPEM, err := os.ReadFile(filepath.Join(dir, "ca.crt"))
+	if err != nil {
+		t.Fatalf("read CA certificate: %v", err)
+	}
+	caBlock, _ := pem.Decode(caCertPEM)
+	caCert, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse CA certificate: %v", err)
+	}
+	caKeyPEM, err := os.ReadFile(filepath.Join(dir, "ca.key"))
+	if err != nil {
+		t.Fatalf("read CA key: %v", err)
+	}
+	caKeyBlock, _ := pem.Decode(caKeyPEM)
+	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse CA key: %v", err)
+	}
+	componentKeyBlock, _ := pem.Decode(auth.ClientKeyData)
+	componentKey, err := x509.ParseECPrivateKey(componentKeyBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse component key: %v", err)
+	}
+	expiredTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(99),
+		Subject:      pkix.Name{CommonName: "system:kube-controller-manager"},
+		NotBefore:    time.Now().Add(-2 * time.Hour),
+		NotAfter:     time.Now().Add(-time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	expiredDER, err := x509.CreateCertificate(rand.Reader, expiredTemplate, caCert, &componentKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create expired component certificate: %v", err)
+	}
+	auth.ClientCertificateData = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: expiredDER})
+	if err := clientcmd.WriteToFile(*config, path); err != nil {
+		t.Fatalf("write expired component kubeconfig: %v", err)
+	}
+	if _, err := ensureComponentKubeconfig(dir, "https://127.0.0.1:6443", "controller-manager"); err != nil {
+		t.Fatalf("renew expired component certificate: %v", err)
+	}
+	renewedConfig, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("load renewed component kubeconfig: %v", err)
+	}
+	renewedBlock, _ := pem.Decode(renewedConfig.AuthInfos["controller-manager"].ClientCertificateData)
+	renewed, err := x509.ParseCertificate(renewedBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse renewed component certificate: %v", err)
+	}
+	if !renewed.NotAfter.After(time.Now()) {
+		t.Fatal("expired component certificate was reused")
+	}
+
+	// A legacy kubeconfig using the admin certificate must be replaced on the
+	// next startup, not retained indefinitely by the old write-once behavior.
+	if err := os.WriteFile(path, []byte("legacy"), 0o600); err != nil {
+		t.Fatalf("write legacy kubeconfig: %v", err)
+	}
+	if _, err := ensureComponentKubeconfig(dir, "https://127.0.0.1:6443", "controller-manager"); err != nil {
+		t.Fatalf("rewrite component kubeconfig: %v", err)
+	}
+	if data, err := os.ReadFile(filepath.Clean(path)); err != nil || string(data) == "legacy" {
+		t.Fatalf("legacy component kubeconfig was not replaced: %v", err)
+	}
+}
+
+func TestComponentIdentitiesHaveKubernetesBootstrapBindings(t *testing.T) {
+	want := map[string]bool{
+		"system:kube-controller-manager": false,
+		"system:kube-scheduler":          false,
+	}
+	for _, binding := range bootstrappolicy.ClusterRoleBindings() {
+		for _, subject := range binding.Subjects {
+			if _, ok := want[subject.Name]; ok {
+				want[subject.Name] = true
+			}
+		}
+	}
+	for identity, found := range want {
+		if !found {
+			t.Fatalf("Kubernetes bootstrap RBAC does not bind %s", identity)
+		}
+	}
+}

--- a/server/apiserver.go
+++ b/server/apiserver.go
@@ -22,6 +22,11 @@ import (
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 )
 
+const (
+	serviceClusterIPRange = "10.43.0.0/16"
+	kubernetesServiceIP   = "10.43.0.1"
+)
+
 // Start launches kine and the apiserver in-process.
 // The returned channel is closed once the apiserver /readyz endpoint responds 200.
 func Start(ctx context.Context, cfg Config) (<-chan struct{}, error) {
@@ -142,7 +147,7 @@ func buildApiserverArgs(cfg Config, certDir, etcdEndpoint, authzKubeconfig strin
 		"--bind-address=0.0.0.0",
 		fmt.Sprintf("--secure-port=%d", cfg.ApiserverPort),
 		"--etcd-servers=" + etcdEndpoint,
-		"--service-cluster-ip-range=10.43.0.0/16",
+		"--service-cluster-ip-range=" + serviceClusterIPRange,
 		"--allow-privileged=true",
 		"--authorization-mode=" + authzMode(authzKubeconfig),
 		"--enable-admission-plugins=NodeRestriction,ValidatingAdmissionWebhook",

--- a/server/apiserver.go
+++ b/server/apiserver.go
@@ -150,7 +150,7 @@ func buildApiserverArgs(cfg Config, certDir, etcdEndpoint, authzKubeconfig strin
 		"--service-cluster-ip-range=" + serviceClusterIPRange,
 		"--allow-privileged=true",
 		"--authorization-mode=" + authzMode(authzKubeconfig),
-		"--enable-admission-plugins=NodeRestriction,ValidatingAdmissionWebhook",
+		"--enable-admission-plugins=NodeRestriction,DefaultIngressClass,ValidatingAdmissionWebhook",
 		"--tls-cert-file=" + filepath.Join(certDir, "apiserver.crt"),
 		"--tls-private-key-file=" + filepath.Join(certDir, "apiserver.key"),
 		"--client-ca-file=" + filepath.Join(certDir, "ca.crt"),

--- a/server/bootstrap.go
+++ b/server/bootstrap.go
@@ -16,6 +16,11 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	casbinAdmissionWebhookName = "admission.casbin.io"
+	casbinAdmissionConfigName  = "casbin-admission"
+)
+
 // Bootstrap creates CasOS-managed cluster add-ons. It is idempotent and safe
 // to call on every startup; individual add-ons can be disabled in config.
 func Bootstrap(ctx context.Context, cfg *rest.Config, srvCfg Config) error {
@@ -46,6 +51,33 @@ func Bootstrap(ctx context.Context, cfg *rest.Config, srvCfg Config) error {
 	return errors.Join(errs...)
 }
 
+// casbinAdmissionWebhook returns the cluster-wide webhook used by the
+// co-located CasOS control plane. FailurePolicy is intentionally Ignore: the
+// endpoint is served by the same process as the control plane, so failing
+// closed would make a local outage prevent recovery. Callers must keep the URL
+// reachable from the API server or policy enforcement is silently bypassed.
+func casbinAdmissionWebhook(url string, caData []byte) admissionregv1.ValidatingWebhook {
+	sideEffects := admissionregv1.SideEffectClassNoneOnDryRun
+	failurePolicy := admissionregv1.Ignore
+	allScopes := admissionregv1.AllScopes
+	timeoutSeconds := int32(3)
+	return admissionregv1.ValidatingWebhook{
+		Name:         casbinAdmissionWebhookName,
+		ClientConfig: admissionregv1.WebhookClientConfig{URL: &url, CABundle: caData},
+		Rules: []admissionregv1.RuleWithOperations{{
+			Operations: []admissionregv1.OperationType{admissionregv1.OperationAll},
+			Rule: admissionregv1.Rule{
+				APIGroups: []string{"*"}, APIVersions: []string{"*"}, Resources: []string{"*"}, Scope: &allScopes,
+			},
+		}},
+		NamespaceSelector:       &metav1.LabelSelector{},
+		SideEffects:             &sideEffects,
+		FailurePolicy:           &failurePolicy,
+		TimeoutSeconds:          &timeoutSeconds,
+		AdmissionReviewVersions: []string{"v1"},
+	}
+}
+
 // ensureCasbinWebhook registers the ValidatingWebhookConfiguration that routes
 // admission requests to the casos Casbin enforcement server.
 func ensureCasbinWebhook(ctx context.Context, client kubernetes.Interface, cfg Config) error {
@@ -55,38 +87,10 @@ func ensureCasbinWebhook(ctx context.Context, client kubernetes.Interface, cfg C
 		return fmt.Errorf("read CA for webhook: %w", err)
 	}
 
-	url := fmt.Sprintf("https://127.0.0.1:%d/admission/validate", cfg.WebhookPort)
-	sideEffects := admissionregv1.SideEffectClassNone
-	failurePolicy := admissionregv1.Ignore
-	all := admissionregv1.AllScopes
+	url := fmt.Sprintf("https://127.0.0.1:%d%s", cfg.WebhookPort, admissionValidatePath)
 	whConfig := &admissionregv1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{Name: "casbin-admission"},
-		Webhooks: []admissionregv1.ValidatingWebhook{
-			{
-				Name: "admission.casbin.io",
-				ClientConfig: admissionregv1.WebhookClientConfig{
-					URL:      &url,
-					CABundle: caData,
-				},
-				Rules: []admissionregv1.RuleWithOperations{
-					{
-						Operations: []admissionregv1.OperationType{
-							admissionregv1.OperationAll,
-						},
-						Rule: admissionregv1.Rule{
-							APIGroups:   []string{"*"},
-							APIVersions: []string{"*"},
-							Resources:   []string{"*"},
-							Scope:       &all,
-						},
-					},
-				},
-				NamespaceSelector:       &metav1.LabelSelector{},
-				SideEffects:             &sideEffects,
-				FailurePolicy:           &failurePolicy,
-				AdmissionReviewVersions: []string{"v1"},
-			},
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: casbinAdmissionConfigName},
+		Webhooks:   []admissionregv1.ValidatingWebhook{casbinAdmissionWebhook(url, caData)},
 	}
 
 	ar := client.AdmissionregistrationV1().ValidatingWebhookConfigurations()
@@ -96,12 +100,12 @@ func ensureCasbinWebhook(ctx context.Context, client kubernetes.Interface, cfg C
 		logrus.Warnf("delete legacy casbin-gatekeeper webhook: %v", err)
 	}
 
-	existing, err := ar.Get(ctx, "casbin-admission", metav1.GetOptions{})
+	existing, err := ar.Get(ctx, casbinAdmissionConfigName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		if _, err := ar.Create(ctx, whConfig, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("create casbin-admission webhook: %w", err)
 		}
-		logrus.Info("created ValidatingWebhookConfiguration casbin-admission")
+		logrus.Infof("created ValidatingWebhookConfiguration %s", casbinAdmissionConfigName)
 		return nil
 	}
 	if err != nil {
@@ -111,7 +115,7 @@ func ensureCasbinWebhook(ctx context.Context, client kubernetes.Interface, cfg C
 	if _, err := ar.Update(ctx, whConfig, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("update casbin-admission webhook: %w", err)
 	}
-	logrus.Info("updated ValidatingWebhookConfiguration casbin-admission")
+	logrus.Infof("updated ValidatingWebhookConfiguration %s", casbinAdmissionConfigName)
 	return nil
 }
 

--- a/server/bootstrap.go
+++ b/server/bootstrap.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// Bootstrap creates cluster-wide resources required for worker-node components
-// to function correctly. It is idempotent — safe to call on every startup.
+// Bootstrap creates CasOS-managed cluster add-ons. It is idempotent and safe
+// to call on every startup; individual add-ons can be disabled in config.
 func Bootstrap(ctx context.Context, cfg *rest.Config, srvCfg Config) error {
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
@@ -32,6 +32,14 @@ func Bootstrap(ctx context.Context, cfg *rest.Config, srvCfg Config) error {
 	errs = append(errs, ensureNodeProxierBinding(ctx, client))
 	errs = append(errs, ensureFlannel(ctx, client, srvCfg))
 	errs = append(errs, ensureClusterDNS(ctx, client, srvCfg))
+	if srvCfg.IngressControllerEnabled {
+		errs = append(errs, ensureIngressController(ctx, client, srvCfg))
+	} else {
+		errs = append(errs, cleanupIngressController(ctx, client))
+	}
+	if !srvCfg.ServiceLBEnabled {
+		errs = append(errs, cleanupServiceLB(ctx, client))
+	}
 	if srvCfg.StorageProvisionerEnabled {
 		errs = append(errs, ensureDefaultStorageProvisioner(ctx, client, srvCfg))
 	}

--- a/server/bootstrap_test.go
+++ b/server/bootstrap_test.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateOrUpdateDeploymentDoesNotMutateDesiredObject(t *testing.T) {
+	desired := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "demo", Image: "demo:1"}}},
+			},
+		},
+	}
+	original := desired.DeepCopy()
+	if err := createOrUpdateDeployment(context.Background(), fake.NewSimpleClientset(), desired); err != nil {
+		t.Fatalf("create deployment: %v", err)
+	}
+	if !apiequality.Semantic.DeepEqual(desired, original) {
+		t.Fatalf("desired deployment was mutated\nwant: %#v\n got: %#v", original.Spec, desired.Spec)
+	}
+}
+
+func TestWaitForServiceDeletedWaitsUntilObjectDisappears(t *testing.T) {
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"}}
+	client := fake.NewSimpleClientset(service)
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		_ = client.Tracker().Delete(corev1.SchemeGroupVersion.WithResource("services"), "kube-system", "kube-dns")
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := waitForServiceDeleted(ctx, client, "kube-system", "kube-dns"); err != nil {
+		t.Fatalf("wait for service deletion: %v", err)
+	}
+}

--- a/server/certs.go
+++ b/server/certs.go
@@ -341,23 +341,25 @@ func ensureServiceAccountKey(dir string) error {
 	return writePEM(pubFile, "PUBLIC KEY", pubDER)
 }
 
-// ensureComponentKubeconfig writes <name>.kubeconfig inside certDir, embedding
-// admin client certs as base64 to avoid Windows path escaping issues.
+// ensureComponentKubeconfig writes <name>.kubeconfig inside certDir with the
+// component's standard Kubernetes identity. It always refreshes the kubeconfig
+// so installations created by older releases stop reusing the admin identity.
 func ensureComponentKubeconfig(certDir, apiserverURL, name string) (string, error) {
 	path := filepath.Join(certDir, name+".kubeconfig")
-	if fileExists(path) {
-		return path, nil
+	commonNames := map[string]string{
+		"controller-manager": "system:kube-controller-manager",
+		"scheduler":          "system:kube-scheduler",
+	}
+	commonName, ok := commonNames[name]
+	if !ok {
+		return "", fmt.Errorf("unsupported component identity %q", name)
 	}
 
 	caData, err := os.ReadFile(filepath.Join(certDir, "ca.crt"))
 	if err != nil {
 		return "", err
 	}
-	certData, err := os.ReadFile(filepath.Join(certDir, "admin.crt"))
-	if err != nil {
-		return "", err
-	}
-	keyData, err := os.ReadFile(filepath.Join(certDir, "admin.key"))
+	certData, keyData, err := newComponentClientCredentials(certDir, name, commonName)
 	if err != nil {
 		return "", err
 	}
@@ -389,10 +391,94 @@ users:
 		base64.StdEncoding.EncodeToString(keyData),
 	)
 
-	if err := os.WriteFile(path, []byte(kubeconfig), 0o600); err != nil {
+	if err := writeFileAtomically(path, []byte(kubeconfig), 0o600); err != nil {
 		return "", err
 	}
 	return path, nil
+}
+
+func newComponentClientCredentials(certDir, name, commonName string) ([]byte, []byte, error) {
+	caCertPEM, err := os.ReadFile(filepath.Join(certDir, "ca.crt"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read component CA certificate: %w", err)
+	}
+	caBlock, _ := pem.Decode(caCertPEM)
+	if caBlock == nil {
+		return nil, nil, fmt.Errorf("decode component CA certificate")
+	}
+	caCert, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse component CA certificate: %w", err)
+	}
+
+	caKeyPEM, err := os.ReadFile(filepath.Join(certDir, "ca.key"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read component CA key: %w", err)
+	}
+	caKeyBlock, _ := pem.Decode(caKeyPEM)
+	if caKeyBlock == nil {
+		return nil, nil, fmt.Errorf("decode component CA key")
+	}
+	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse component CA key: %w", err)
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate component %s client key: %w", name, err)
+	}
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate component %s certificate serial: %w", name, err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create component %s client certificate: %w", name, err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal component %s client key: %w", name, err)
+	}
+	certData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyData := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if certData == nil || keyData == nil {
+		return nil, nil, fmt.Errorf("encode component %s client credentials", name)
+	}
+	return certData, keyData, nil
+}
+
+func writeFileAtomically(path string, data []byte, mode os.FileMode) (err error) {
+	temp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer func() {
+		_ = temp.Close()
+		_ = os.Remove(tempPath)
+	}()
+	if err := temp.Chmod(mode); err != nil {
+		return err
+	}
+	if _, err := temp.Write(data); err != nil {
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, path)
 }
 
 // AdminRestConfig returns a rest.Config that authenticates to the apiserver

--- a/server/certs.go
+++ b/server/certs.go
@@ -496,7 +496,7 @@ func uniqueIPs(addrs ...string) []net.IP {
 }
 
 func desiredAPIServerIPs(ip, advertiseIP string) []net.IP {
-	return uniqueIPs(append([]string{"127.0.0.1", ip, advertiseIP}, allInterfaceIPs()...)...)
+	return uniqueIPs(append([]string{"127.0.0.1", kubernetesServiceIP, ip, advertiseIP}, allInterfaceIPs()...)...)
 }
 
 func apiServerServingCertUsable(certFile, keyFile string, desiredIPs []net.IP, caCert *x509.Certificate) bool {

--- a/server/config.go
+++ b/server/config.go
@@ -24,7 +24,10 @@ type Config struct {
 	FlannelImage              string // Flannel daemon image used by the built-in network bootstrap
 	FlannelCNIPluginImage     string // Flannel CNI plugin image installed on worker hosts
 	StorageProbeImage         string // Image used by worker storage readiness probes
+	IngressControllerImage    string // Traefik image used by the built-in Ingress controller
 	StorageProvisionerEnabled bool   // install the built-in local-path provisioner for local clusters
+	IngressControllerEnabled  bool   // install the built-in Traefik controller
+	ServiceLBEnabled          bool   // run the built-in bare-metal LoadBalancer controller
 }
 
 // ConfigFromAppConf reads server config from the beego app.conf.
@@ -61,14 +64,17 @@ func ConfigFromAppConf() (Config, error) {
 	}
 
 	storageProvisionerEnabled := conf.GetConfigBoolDefault("storageProvisionerEnabled", true)
+	ingressControllerEnabled := conf.GetConfigBoolDefault("ingressControllerEnabled", false)
+	serviceLBEnabled := conf.GetConfigBoolDefault("serviceLBEnabled", false)
 	coreDNSImage := conf.GetConfigStringDefault("coreDNSImage", "docker.1ms.run/coredns/coredns:1.12.4")
 	localPathProvisionerImage := conf.GetConfigStringDefault("localPathProvisionerImage", "docker.1ms.run/rancher/local-path-provisioner:v0.0.32")
 	localPathHelperImage := conf.GetConfigStringDefault("localPathHelperImage", "docker.1ms.run/library/busybox:1.37.0")
 	flannelImage := conf.GetConfigStringDefault("flannelImage", defaultFlannelImage)
 	flannelCNIPluginImage := conf.GetConfigStringDefault("flannelCNIPluginImage", defaultFlannelCNIPluginImage)
 	storageProbeImage := conf.GetConfigStringDefault("storageProbeImage", "docker.1ms.run/library/busybox:1.37.0")
+	ingressControllerImage := conf.GetConfigStringDefault("ingressControllerImage", defaultIngressControllerImage)
 
-	return Config{
+	config := Config{
 		DataDir:                   dataDir,
 		ApiserverBind:             bind,
 		AdvertiseAddress:          advertise,
@@ -83,8 +89,22 @@ func ConfigFromAppConf() (Config, error) {
 		FlannelImage:              flannelImage,
 		FlannelCNIPluginImage:     flannelCNIPluginImage,
 		StorageProbeImage:         storageProbeImage,
+		IngressControllerImage:    ingressControllerImage,
 		StorageProvisionerEnabled: storageProvisionerEnabled,
-	}, nil
+		IngressControllerEnabled:  ingressControllerEnabled,
+		ServiceLBEnabled:          serviceLBEnabled,
+	}
+	if err := validateApplicationAccessConfig(config); err != nil {
+		return Config{}, err
+	}
+	return config, nil
+}
+
+func validateApplicationAccessConfig(config Config) error {
+	if config.IngressControllerEnabled && !config.ServiceLBEnabled {
+		return fmt.Errorf("ingressControllerEnabled requires serviceLBEnabled because the built-in Ingress Service uses LoadBalancerClass %q", serviceLBClass)
+	}
+	return nil
 }
 
 // injectDBName inserts dbName into a MySQL DSN of the form

--- a/server/config.go
+++ b/server/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	LocalPathHelperImage      string // helper pod image used by local-path-provisioner
 	FlannelImage              string // Flannel daemon image used by the built-in network bootstrap
 	FlannelCNIPluginImage     string // Flannel CNI plugin image installed on worker hosts
+	StorageProbeImage         string // Image used by worker storage readiness probes
 	StorageProvisionerEnabled bool   // install the built-in local-path provisioner for local clusters
 }
 
@@ -65,6 +66,7 @@ func ConfigFromAppConf() (Config, error) {
 	localPathHelperImage := conf.GetConfigStringDefault("localPathHelperImage", "docker.1ms.run/library/busybox:1.37.0")
 	flannelImage := conf.GetConfigStringDefault("flannelImage", defaultFlannelImage)
 	flannelCNIPluginImage := conf.GetConfigStringDefault("flannelCNIPluginImage", defaultFlannelCNIPluginImage)
+	storageProbeImage := conf.GetConfigStringDefault("storageProbeImage", "docker.1ms.run/library/busybox:1.37.0")
 
 	return Config{
 		DataDir:                   dataDir,
@@ -80,6 +82,7 @@ func ConfigFromAppConf() (Config, error) {
 		LocalPathHelperImage:      localPathHelperImage,
 		FlannelImage:              flannelImage,
 		FlannelCNIPluginImage:     flannelCNIPluginImage,
+		StorageProbeImage:         storageProbeImage,
 		StorageProvisionerEnabled: storageProvisionerEnabled,
 	}, nil
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,23 @@
+package server
+
+import "testing"
+
+func TestValidateApplicationAccessConfig(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{name: "both disabled", config: Config{}},
+		{name: "service LB only", config: Config{ServiceLBEnabled: true}},
+		{name: "complete data plane", config: Config{IngressControllerEnabled: true, ServiceLBEnabled: true}},
+		{name: "ingress without service LB", config: Config{IngressControllerEnabled: true}, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateApplicationAccessConfig(test.config)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("validate config error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/server/dns_bootstrap.go
+++ b/server/dns_bootstrap.go
@@ -3,21 +3,26 @@ package server
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
 
 const (
 	clusterDNSNamespace = "kube-system"
 	clusterDNSName      = "coredns"
+	clusterDNSServiceIP = "10.43.0.10"
 	// coreDNSRolloutRev forces a rollout when the managed CoreDNS pod template changes.
 	coreDNSRolloutRev = "4"
 )
@@ -144,7 +149,8 @@ func ensureCoreDNSService(ctx context.Context, client kubernetes.Interface) erro
 			Labels:    coreDNSLabels(),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: coreDNSSelectorLabels(),
+			ClusterIP: clusterDNSServiceIP,
+			Selector:  coreDNSSelectorLabels(),
 			Ports: []corev1.ServicePort{
 				{Name: "dns", Port: 53, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt(53)},
 				{Name: "dns-tcp", Port: 53, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(53)},
@@ -152,7 +158,28 @@ func ensureCoreDNSService(ctx context.Context, client kubernetes.Interface) erro
 			},
 		},
 	}
+	current, err := client.CoreV1().Services(clusterDNSNamespace).Get(ctx, svc.Name, metav1.GetOptions{})
+	if err == nil && current.Spec.ClusterIP != "" && current.Spec.ClusterIP != clusterDNSServiceIP {
+		if err := client.CoreV1().Services(clusterDNSNamespace).Delete(ctx, svc.Name, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("replace CoreDNS service %s/%s: %w", clusterDNSNamespace, svc.Name, err)
+		}
+		if err := waitForServiceDeleted(ctx, client, clusterDNSNamespace, svc.Name); err != nil {
+			return fmt.Errorf("wait to replace CoreDNS service %s/%s: %w", clusterDNSNamespace, svc.Name, err)
+		}
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get CoreDNS service %s/%s: %w", clusterDNSNamespace, svc.Name, err)
+	}
 	return createOrUpdateService(ctx, client, svc)
+}
+
+func waitForServiceDeleted(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
+	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
 }
 
 func ensureCoreDNSDeployment(ctx context.Context, client kubernetes.Interface, cfg Config) error {
@@ -191,6 +218,7 @@ func ensureCoreDNSDeployment(ctx context.Context, client kubernetes.Interface, c
 						{Key: "CriticalAddonsOnly", Operator: corev1.TolerationOpExists},
 						{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
 						{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Key: "casos.io/bootstrap", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
 					},
 					Containers: []corev1.Container{
 						{
@@ -198,6 +226,7 @@ func ensureCoreDNSDeployment(ctx context.Context, client kubernetes.Interface, c
 							Image:           cfg.CoreDNSImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args:            []string{"-conf", "/etc/coredns/Corefile"},
+							Env:             coreDNSEnv(cfg),
 							Ports: []corev1.ContainerPort{
 								{Name: "dns", ContainerPort: 53, Protocol: corev1.ProtocolUDP},
 								{Name: "dns-tcp", ContainerPort: 53, Protocol: corev1.ProtocolTCP},
@@ -283,6 +312,17 @@ func ensureCoreDNSDeployment(ctx context.Context, client kubernetes.Interface, c
 	return createOrUpdateDeployment(ctx, client, deployment)
 }
 
+func coreDNSEnv(cfg Config) []corev1.EnvVar {
+	if cfg.AdvertiseAddress == "" || cfg.ApiserverPort <= 0 {
+		return nil
+	}
+	return []corev1.EnvVar{
+		{Name: "KUBERNETES_SERVICE_HOST", Value: cfg.AdvertiseAddress},
+		{Name: "KUBERNETES_SERVICE_PORT", Value: strconv.Itoa(cfg.ApiserverPort)},
+		{Name: "KUBERNETES_SERVICE_PORT_HTTPS", Value: strconv.Itoa(cfg.ApiserverPort)},
+	}
+}
+
 func coreDNSLabels() map[string]string {
 	labels := coreDNSSelectorLabels()
 	labels["k8s-app"] = "kube-dns"
@@ -357,6 +397,11 @@ func createOrUpdateService(ctx context.Context, client kubernetes.Interface, svc
 	svc.Spec.LoadBalancerClass = current.Spec.LoadBalancerClass
 	svc.Spec.LoadBalancerSourceRanges = current.Spec.LoadBalancerSourceRanges
 	svc.Spec.AllocateLoadBalancerNodePorts = current.Spec.AllocateLoadBalancerNodePorts
+	if apiequality.Semantic.DeepEqual(current.Labels, svc.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, svc.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.Spec, svc.Spec) {
+		return nil
+	}
 	if _, err := client.CoreV1().Services(svc.Namespace).Update(ctx, svc, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("update service %s/%s: %w", svc.Namespace, svc.Name, err)
 	}

--- a/server/ingress_bootstrap.go
+++ b/server/ingress_bootstrap.go
@@ -1,0 +1,432 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	ingressControllerNamespace    = "kube-system"
+	ingressControllerName         = "traefik"
+	ingressControllerClass        = "traefik"
+	ingressControllerID           = "traefik.io/ingress-controller"
+	defaultIngressControllerImage = "docker.io/traefik:v3.3.4"
+)
+
+func ingressControllerLabels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       ingressControllerName,
+		"app.kubernetes.io/managed-by": "casos",
+	}
+}
+
+func validateIngressControllerOwnership(object metav1.Object) error {
+	if object.GetLabels()["app.kubernetes.io/managed-by"] != "casos" {
+		return fmt.Errorf("Ingress controller %T %s already exists and is not managed by CasOS", object, object.GetName())
+	}
+	return nil
+}
+
+func ensureIngressController(ctx context.Context, client kubernetes.Interface, cfg Config) error {
+	if err := ensureIngressControllerOwnership(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureNamespace(ctx, client, ingressControllerNamespace); err != nil {
+		return err
+	}
+	if err := createOrUpdateServiceAccount(ctx, client, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ingressControllerName,
+			Namespace: ingressControllerNamespace,
+			Labels:    ingressControllerLabels(),
+		},
+	}, validateIngressControllerOwnership); err != nil {
+		return err
+	}
+	if err := ensureIngressControllerClusterRole(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureIngressControllerClusterRoleBinding(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureIngressClass(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureIngressControllerService(ctx, client); err != nil {
+		return err
+	}
+	return ensureIngressControllerDeployment(ctx, client, cfg)
+}
+
+func cleanupIngressController(ctx context.Context, client kubernetes.Interface) error {
+	resources := []struct {
+		kind   string
+		get    func() (metav1.Object, error)
+		delete func() error
+	}{
+		{kind: "Deployment", get: func() (metav1.Object, error) {
+			return client.AppsV1().Deployments(ingressControllerNamespace).Get(ctx, ingressControllerName, metav1.GetOptions{})
+		}, delete: func() error {
+			return client.AppsV1().Deployments(ingressControllerNamespace).Delete(ctx, ingressControllerName, metav1.DeleteOptions{})
+		}},
+		{kind: "Service", get: func() (metav1.Object, error) {
+			return client.CoreV1().Services(ingressControllerNamespace).Get(ctx, ingressControllerName, metav1.GetOptions{})
+		}, delete: func() error {
+			return client.CoreV1().Services(ingressControllerNamespace).Delete(ctx, ingressControllerName, metav1.DeleteOptions{})
+		}},
+		{kind: "IngressClass", get: func() (metav1.Object, error) {
+			return client.NetworkingV1().IngressClasses().Get(ctx, ingressControllerClass, metav1.GetOptions{})
+		}, delete: func() error {
+			return client.NetworkingV1().IngressClasses().Delete(ctx, ingressControllerClass, metav1.DeleteOptions{})
+		}},
+		{kind: "ClusterRoleBinding", get: func() (metav1.Object, error) {
+			return client.RbacV1().ClusterRoleBindings().Get(ctx, "casos:traefik-ingress-controller", metav1.GetOptions{})
+		}, delete: func() error {
+			return client.RbacV1().ClusterRoleBindings().Delete(ctx, "casos:traefik-ingress-controller", metav1.DeleteOptions{})
+		}},
+		{kind: "ClusterRole", get: func() (metav1.Object, error) {
+			return client.RbacV1().ClusterRoles().Get(ctx, "casos:traefik-ingress-controller", metav1.GetOptions{})
+		}, delete: func() error {
+			return client.RbacV1().ClusterRoles().Delete(ctx, "casos:traefik-ingress-controller", metav1.DeleteOptions{})
+		}},
+		{kind: "ServiceAccount", get: func() (metav1.Object, error) {
+			return client.CoreV1().ServiceAccounts(ingressControllerNamespace).Get(ctx, ingressControllerName, metav1.GetOptions{})
+		}, delete: func() error {
+			return client.CoreV1().ServiceAccounts(ingressControllerNamespace).Delete(ctx, ingressControllerName, metav1.DeleteOptions{})
+		}},
+	}
+	errs := make([]error, 0)
+	for _, resource := range resources {
+		object, err := resource.get()
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			errs = append(errs, fmt.Errorf("get Ingress controller %s for cleanup: %w", resource.kind, err))
+			continue
+		}
+		if object.GetLabels()["app.kubernetes.io/managed-by"] != "casos" {
+			continue
+		}
+		if err := resource.delete(); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("delete Ingress controller %s %s: %w", resource.kind, object.GetName(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func ensureIngressControllerOwnership(ctx context.Context, client kubernetes.Interface) error {
+	checks := []struct {
+		kind string
+		get  func() (metav1.Object, error)
+	}{
+		{kind: "ServiceAccount", get: func() (metav1.Object, error) {
+			return client.CoreV1().ServiceAccounts(ingressControllerNamespace).Get(ctx, ingressControllerName, metav1.GetOptions{})
+		}},
+		{kind: "Service", get: func() (metav1.Object, error) {
+			return client.CoreV1().Services(ingressControllerNamespace).Get(ctx, ingressControllerName, metav1.GetOptions{})
+		}},
+		{kind: "Deployment", get: func() (metav1.Object, error) {
+			return client.AppsV1().Deployments(ingressControllerNamespace).Get(ctx, ingressControllerName, metav1.GetOptions{})
+		}},
+		{kind: "ClusterRole", get: func() (metav1.Object, error) {
+			return client.RbacV1().ClusterRoles().Get(ctx, "casos:traefik-ingress-controller", metav1.GetOptions{})
+		}},
+		{kind: "ClusterRoleBinding", get: func() (metav1.Object, error) {
+			return client.RbacV1().ClusterRoleBindings().Get(ctx, "casos:traefik-ingress-controller", metav1.GetOptions{})
+		}},
+		{kind: "IngressClass", get: func() (metav1.Object, error) {
+			return client.NetworkingV1().IngressClasses().Get(ctx, ingressControllerClass, metav1.GetOptions{})
+		}},
+	}
+	for _, check := range checks {
+		object, err := check.get()
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("check Ingress controller %s ownership: %w", check.kind, err)
+		}
+		if err := validateIngressControllerOwnership(object); err != nil {
+			return fmt.Errorf("check Ingress controller %s ownership: %w", check.kind, err)
+		}
+	}
+	return nil
+}
+
+func ensureIngressControllerClusterRole(ctx context.Context, client kubernetes.Interface) error {
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "casos:traefik-ingress-controller",
+			Labels: ingressControllerLabels(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services", "endpoints", "nodes", "secrets", "namespaces"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"discovery.k8s.io"},
+				Resources: []string{"endpointslices"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"ingresses", "ingressclasses"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"events"},
+				Verbs:     []string{"create", "update", "patch"},
+			},
+			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"ingresses/status"},
+				Verbs:     []string{"update", "patch"},
+			},
+		},
+	}
+	return createOrUpdateClusterRole(ctx, client, role, validateIngressControllerOwnership)
+}
+
+func ensureIngressControllerClusterRoleBinding(ctx context.Context, client kubernetes.Interface) error {
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "casos:traefik-ingress-controller",
+			Labels: ingressControllerLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "casos:traefik-ingress-controller",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      ingressControllerName,
+			Namespace: ingressControllerNamespace,
+		}},
+	}
+	return createOrUpdateClusterRoleBinding(ctx, client, binding, validateIngressControllerOwnership)
+}
+
+func ensureIngressClass(ctx context.Context, client kubernetes.Interface) error {
+	classes := client.NetworkingV1().IngressClasses()
+	defaultClassExists := false
+	existingClasses, err := classes.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list IngressClasses: %w", err)
+	}
+	for i := range existingClasses.Items {
+		class := &existingClasses.Items[i]
+		if class.Name != ingressControllerClass && class.Annotations["ingressclass.kubernetes.io/is-default-class"] == "true" {
+			defaultClassExists = true
+			break
+		}
+	}
+	desired := &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        ingressControllerClass,
+			Labels:      ingressControllerLabels(),
+			Annotations: map[string]string{},
+		},
+		Spec: networkingv1.IngressClassSpec{Controller: ingressControllerID},
+	}
+	if !defaultClassExists {
+		desired.Annotations["ingressclass.kubernetes.io/is-default-class"] = "true"
+	}
+	current, err := classes.Get(ctx, desired.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		if _, err := classes.Create(ctx, desired, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("create IngressClass %s: %w", desired.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get IngressClass %s: %w", desired.Name, err)
+	}
+	if current.Spec.Controller != desired.Spec.Controller {
+		return fmt.Errorf("IngressClass %s is owned by controller %s", desired.Name, current.Spec.Controller)
+	}
+	if current.Labels["app.kubernetes.io/managed-by"] != "casos" {
+		return fmt.Errorf("IngressClass %s already exists and is not managed by CasOS", desired.Name)
+	}
+	desired.Labels = mergeStringMap(current.Labels, desired.Labels)
+	desired.Annotations = mergeStringMap(current.Annotations, desired.Annotations)
+	if defaultClassExists {
+		delete(desired.Annotations, "ingressclass.kubernetes.io/is-default-class")
+	}
+	if apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.Spec, desired.Spec) {
+		return nil
+	}
+	desired.ResourceVersion = current.ResourceVersion
+	if _, err := classes.Update(ctx, desired, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update IngressClass %s: %w", desired.Name, err)
+	}
+	return nil
+}
+
+func ensureIngressControllerService(ctx context.Context, client kubernetes.Interface) error {
+	desired := buildIngressControllerService()
+	services := client.CoreV1().Services(ingressControllerNamespace)
+	current, err := services.Get(ctx, desired.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		if _, err := services.Create(ctx, desired, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("create Ingress controller Service: %w", err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get Ingress controller Service: %w", err)
+	}
+	if current.Labels["app.kubernetes.io/managed-by"] != "casos" {
+		return fmt.Errorf("Ingress controller Service %s/%s already exists and is not managed by CasOS", ingressControllerNamespace, ingressControllerName)
+	}
+	desired.Labels = mergeStringMap(current.Labels, desired.Labels)
+	desired.Annotations = mergeStringMap(current.Annotations, desired.Annotations)
+	desired.Spec.ClusterIP = current.Spec.ClusterIP
+	desired.Spec.ClusterIPs = current.Spec.ClusterIPs
+	desired.Spec.IPFamilies = current.Spec.IPFamilies
+	desired.Spec.IPFamilyPolicy = current.Spec.IPFamilyPolicy
+	desired.Spec.ExternalIPs = current.Spec.ExternalIPs
+	desired.Spec.SessionAffinity = current.Spec.SessionAffinity
+	desired.Spec.InternalTrafficPolicy = current.Spec.InternalTrafficPolicy
+	desired.Spec.LoadBalancerIP = current.Spec.LoadBalancerIP
+	desired.Spec.LoadBalancerClass = current.Spec.LoadBalancerClass
+	desired.Spec.LoadBalancerSourceRanges = current.Spec.LoadBalancerSourceRanges
+	desired.Spec.AllocateLoadBalancerNodePorts = current.Spec.AllocateLoadBalancerNodePorts
+	desired.Spec.HealthCheckNodePort = current.Spec.HealthCheckNodePort
+	for i := range desired.Spec.Ports {
+		for _, currentPort := range current.Spec.Ports {
+			if desired.Spec.Ports[i].Name == currentPort.Name {
+				desired.Spec.Ports[i].NodePort = currentPort.NodePort
+				break
+			}
+		}
+	}
+	if apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.Spec, desired.Spec) {
+		return nil
+	}
+	desired.ResourceVersion = current.ResourceVersion
+	if _, err := services.Update(ctx, desired, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update Ingress controller Service: %w", err)
+	}
+	return nil
+}
+
+func buildIngressControllerService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ingressControllerName,
+			Namespace: ingressControllerNamespace,
+			Labels:    ingressControllerLabels(),
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                  corev1.ServiceTypeLoadBalancer,
+			Selector:              ingressControllerLabels(),
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+			LoadBalancerClass:     ptr(serviceLBClass),
+			Ports: []corev1.ServicePort{
+				{Name: "web", Port: 80, TargetPort: intstr.FromInt(8000), Protocol: corev1.ProtocolTCP},
+				{Name: "websecure", Port: 443, TargetPort: intstr.FromInt(8443), Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+}
+
+func ensureIngressControllerDeployment(ctx context.Context, client kubernetes.Interface, cfg Config) error {
+	return createOrUpdateDeployment(ctx, client, buildIngressControllerDeployment(cfg), validateIngressControllerOwnership)
+}
+
+func buildIngressControllerDeployment(cfg Config) *appsv1.Deployment {
+	replicas := int32(1)
+	image := cfg.IngressControllerImage
+	if image == "" {
+		image = defaultIngressControllerImage
+	}
+	labels := ingressControllerLabels()
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ingressControllerName,
+			Namespace: ingressControllerNamespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: ingressControllerName,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot:   ptr(true),
+						RunAsUser:      ptr(int64(65532)),
+						RunAsGroup:     ptr(int64(65532)),
+						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+					},
+					Tolerations: []corev1.Toleration{
+						{Key: "CriticalAddonsOnly", Operator: corev1.TolerationOpExists},
+						{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Key: "casos.io/bootstrap", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+					},
+					Containers: []corev1.Container{{
+						Name:            ingressControllerName,
+						Image:           image,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Args: []string{
+							"--providers.kubernetesingress=true",
+							"--providers.kubernetesingress.ingressclass=" + ingressControllerClass,
+							"--providers.kubernetesingress.ingressendpoint.publishedservice=" + ingressControllerNamespace + "/" + ingressControllerName,
+							"--entrypoints.web.address=:8000",
+							"--entrypoints.websecure.address=:8443",
+							"--ping=true",
+						},
+						Ports: []corev1.ContainerPort{
+							{Name: "web", ContainerPort: 8000, Protocol: corev1.ProtocolTCP},
+							{Name: "websecure", ContainerPort: 8443, Protocol: corev1.ProtocolTCP},
+							{Name: "ping", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{
+								Path: "/ping", Port: intstr.FromInt(8080), Scheme: corev1.URISchemeHTTP,
+							}},
+							InitialDelaySeconds: 5, PeriodSeconds: 10, TimeoutSeconds: 5, FailureThreshold: 6,
+						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/ping", Port: intstr.FromInt(8080), Scheme: corev1.URISchemeHTTP}},
+							InitialDelaySeconds: 15, PeriodSeconds: 10, TimeoutSeconds: 5, FailureThreshold: 6,
+						},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr(false),
+							ReadOnlyRootFilesystem:   ptr(true),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
+							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+						},
+					}},
+				},
+			},
+		},
+	}
+	return deployment
+}

--- a/server/ingress_bootstrap_test.go
+++ b/server/ingress_bootstrap_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEnsureIngressClassDoesNotCreateSecondDefault(t *testing.T) {
+	client := fake.NewSimpleClientset(&networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx", Annotations: map[string]string{
+			"ingressclass.kubernetes.io/is-default-class": "true",
+		}},
+		Spec: networkingv1.IngressClassSpec{Controller: "k8s.io/ingress-nginx"},
+	})
+	if err := ensureIngressClass(context.Background(), client); err != nil {
+		t.Fatalf("ensure ingress class: %v", err)
+	}
+	created, err := client.NetworkingV1().IngressClasses().Get(context.Background(), ingressControllerClass, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get created ingress class: %v", err)
+	}
+	if created.Annotations["ingressclass.kubernetes.io/is-default-class"] == "true" {
+		t.Fatal("CasOS ingress class became default even though another default already exists")
+	}
+}
+
+func TestEnsureIngressClassYieldsDefaultToExistingController(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&networkingv1.IngressClass{ObjectMeta: metav1.ObjectMeta{
+			Name:        ingressControllerClass,
+			Labels:      ingressControllerLabels(),
+			Annotations: map[string]string{"ingressclass.kubernetes.io/is-default-class": "true"},
+		}, Spec: networkingv1.IngressClassSpec{Controller: ingressControllerID}},
+		&networkingv1.IngressClass{ObjectMeta: metav1.ObjectMeta{
+			Name: "nginx", Annotations: map[string]string{"ingressclass.kubernetes.io/is-default-class": "true"},
+		}, Spec: networkingv1.IngressClassSpec{Controller: "k8s.io/ingress-nginx"}},
+	)
+	if err := ensureIngressClass(context.Background(), client); err != nil {
+		t.Fatalf("ensure ingress class: %v", err)
+	}
+	stored, _ := client.NetworkingV1().IngressClasses().Get(context.Background(), ingressControllerClass, metav1.GetOptions{})
+	if stored.Annotations["ingressclass.kubernetes.io/is-default-class"] == "true" {
+		t.Fatal("CasOS ingress class remained default after another default appeared")
+	}
+}
+
+func TestEnsureIngressControllerRefusesUnmanagedDeploymentBeforeMutation(t *testing.T) {
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: ingressControllerName, Namespace: ingressControllerNamespace,
+		Labels: map[string]string{"app.kubernetes.io/managed-by": "helm"},
+	}}
+	client := fake.NewSimpleClientset(deployment)
+	if err := ensureIngressController(context.Background(), client, Config{}); err == nil {
+		t.Fatal("expected an unmanaged Deployment collision to be rejected")
+	}
+	stored, _ := client.AppsV1().Deployments(ingressControllerNamespace).Get(context.Background(), ingressControllerName, metav1.GetOptions{})
+	if stored.Labels["app.kubernetes.io/managed-by"] != "helm" {
+		t.Fatalf("unmanaged Deployment was mutated: %v", stored.Labels)
+	}
+}
+
+func TestEnsureIngressClassDoesNotTakeOverUnmanagedClass(t *testing.T) {
+	client := fake.NewSimpleClientset(&networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        ingressControllerClass,
+			Labels:      map[string]string{"app.kubernetes.io/managed-by": "helm"},
+			Annotations: map[string]string{"ingressclass.kubernetes.io/is-default-class": "false"},
+		},
+		Spec: networkingv1.IngressClassSpec{Controller: "traefik.io/ingress-controller"},
+	})
+	if err := ensureIngressClass(context.Background(), client); err == nil {
+		t.Fatal("expected an unmanaged IngressClass collision to be rejected")
+	}
+	stored, _ := client.NetworkingV1().IngressClasses().Get(context.Background(), ingressControllerClass, metav1.GetOptions{})
+	if stored.Labels["app.kubernetes.io/managed-by"] != "helm" || stored.Annotations["ingressclass.kubernetes.io/is-default-class"] != "false" {
+		t.Fatalf("unmanaged ingress class was taken over: labels=%v annotations=%v", stored.Labels, stored.Annotations)
+	}
+}
+
+func TestIngressControllerDeploymentUsesRestrictedSecurityContext(t *testing.T) {
+	container := buildIngressControllerDeployment(Config{}).Spec.Template.Spec.Containers[0]
+	if container.SecurityContext == nil || container.SecurityContext.AllowPrivilegeEscalation == nil || *container.SecurityContext.AllowPrivilegeEscalation {
+		t.Fatal("expected privilege escalation to be disabled")
+	}
+	if container.SecurityContext.ReadOnlyRootFilesystem == nil || !*container.SecurityContext.ReadOnlyRootFilesystem {
+		t.Fatal("expected a read-only root filesystem")
+	}
+	if container.LivenessProbe == nil {
+		t.Fatal("expected a liveness probe")
+	}
+	if container.Resources.Requests.Cpu().IsZero() || container.Resources.Requests.Memory().IsZero() {
+		t.Fatal("expected CPU and memory requests")
+	}
+	podContext := buildIngressControllerDeployment(Config{}).Spec.Template.Spec.SecurityContext
+	if podContext == nil || podContext.RunAsNonRoot == nil || !*podContext.RunAsNonRoot {
+		t.Fatal("expected ingress controller to run as non-root")
+	}
+}
+
+func TestEnsureIngressControllerServiceRefusesUnmanagedService(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: ingressControllerName, Namespace: ingressControllerNamespace,
+	}})
+	if err := ensureIngressControllerService(context.Background(), client); err == nil {
+		t.Fatal("expected an unmanaged Service collision to be rejected")
+	}
+}
+
+func TestEnsureIngressControllerDeploymentRefusesUnmanagedDeploymentAtMutation(t *testing.T) {
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: ingressControllerName, Namespace: ingressControllerNamespace,
+		Labels: map[string]string{"app.kubernetes.io/managed-by": "helm"},
+	}}
+	client := fake.NewSimpleClientset(deployment)
+	if err := ensureIngressControllerDeployment(context.Background(), client, Config{}); err == nil {
+		t.Fatal("expected the mutating path to reject an unmanaged Deployment")
+	}
+	stored, _ := client.AppsV1().Deployments(ingressControllerNamespace).Get(context.Background(), ingressControllerName, metav1.GetOptions{})
+	if stored.Labels["app.kubernetes.io/managed-by"] != "helm" {
+		t.Fatalf("unmanaged Deployment was adopted: %v", stored.Labels)
+	}
+}
+
+func TestEnsureIngressControllerClusterRoleRefusesUnmanagedRoleAtMutation(t *testing.T) {
+	role := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{
+		Name: "casos:traefik-ingress-controller", Labels: map[string]string{"app.kubernetes.io/managed-by": "helm"},
+	}}
+	client := fake.NewSimpleClientset(role)
+	if err := ensureIngressControllerClusterRole(context.Background(), client); err == nil {
+		t.Fatal("expected the mutating path to reject an unmanaged ClusterRole")
+	}
+	stored, _ := client.RbacV1().ClusterRoles().Get(context.Background(), role.Name, metav1.GetOptions{})
+	if stored.Labels["app.kubernetes.io/managed-by"] != "helm" {
+		t.Fatalf("unmanaged ClusterRole was adopted: %v", stored.Labels)
+	}
+}
+
+func TestCleanupIngressControllerDeletesOnlyManagedResources(t *testing.T) {
+	managed := ingressControllerLabels()
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: ingressControllerName, Namespace: ingressControllerNamespace, Labels: managed}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: ingressControllerName, Namespace: ingressControllerNamespace, Labels: map[string]string{"app.kubernetes.io/managed-by": "helm"}}},
+	)
+	if err := cleanupIngressController(context.Background(), client); err != nil {
+		t.Fatalf("cleanup ingress controller: %v", err)
+	}
+	if _, err := client.AppsV1().Deployments(ingressControllerNamespace).Get(context.Background(), ingressControllerName, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("managed Deployment was not deleted: %v", err)
+	}
+	if _, err := client.CoreV1().Services(ingressControllerNamespace).Get(context.Background(), ingressControllerName, metav1.GetOptions{}); err != nil {
+		t.Fatalf("foreign Service was deleted: %v", err)
+	}
+}

--- a/server/servicelb.go
+++ b/server/servicelb.go
@@ -1,0 +1,468 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"reflect"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	coordinationclient "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	serviceLBManagedIPsAnnotation = "casos.io/service-lb-managed-ips"
+	serviceLBDisabledAnnotation   = "casos.io/service-lb-disabled"
+	serviceLBEnabledAnnotation    = "casos.io/service-lb-enabled"
+	serviceLBClass                = "casos.io/service-lb"
+	serviceLBLeaderLease          = "casos-service-lb"
+)
+
+// StartServiceLB starts the built-in bare-metal LoadBalancer reconciler. It
+// publishes Ready Worker addresses and uses Service externalIPs so kube-proxy
+// can route LoadBalancer traffic without a cloud provider.
+func StartServiceLB(ctx context.Context, cfg *rest.Config) error {
+	if cfg == nil {
+		return fmt.Errorf("apiserver rest config is required")
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("service load balancer client: %w", err)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	coordination, err := coordinationclient.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("service load balancer coordination client: %w", err)
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("service load balancer identity: %w", err)
+	}
+	identity := fmt.Sprintf("%s-%d", hostname, os.Getpid())
+	elector, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock: &resourcelock.LeaseLock{
+			LeaseMeta:  metav1.ObjectMeta{Name: serviceLBLeaderLease, Namespace: ingressControllerNamespace},
+			Client:     coordination,
+			LockConfig: resourcelock.ResourceLockConfig{Identity: identity},
+		},
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		ReleaseOnCancel: true,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(leaderCtx context.Context) { runServiceLB(leaderCtx, client) },
+			OnStoppedLeading: func() { logrus.Warn("service load balancer leadership lost") },
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("service load balancer leader election: %w", err)
+	}
+	go elector.Run(ctx)
+	return nil
+}
+
+func runServiceLB(ctx context.Context, client kubernetes.Interface) {
+	const interval = 5 * time.Second
+	for {
+		if err := reconcileServiceLB(ctx, client); err != nil && ctx.Err() == nil {
+			logrus.Warnf("service load balancer reconciliation failed: %v", err)
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func reconcileServiceLB(ctx context.Context, client kubernetes.Interface) error {
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list nodes: %w", err)
+	}
+	services, err := client.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list LoadBalancer services: %w", err)
+	}
+	reconcileErrors := make([]error, 0)
+	for i := range services.Items {
+		service := &services.Items[i]
+		if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+			continue
+		}
+		if !serviceLBManages(service) {
+			if _, managed := service.Annotations[serviceLBManagedIPsAnnotation]; managed {
+				if err := cleanupLoadBalancerService(ctx, client, service); err != nil {
+					reconcileErrors = append(reconcileErrors, fmt.Errorf("clean up LoadBalancer service %s/%s: %w", service.Namespace, service.Name, err))
+				}
+			}
+			continue
+		}
+		nodeIPs, err := serviceLBNodeIPs(ctx, client, service, nodes.Items)
+		if err != nil {
+			reconcileErrors = append(reconcileErrors, fmt.Errorf("select LoadBalancer nodes for %s/%s: %w", service.Namespace, service.Name, err))
+			continue
+		}
+		if err := reconcileLoadBalancerService(ctx, client, service, nodeIPs); err != nil {
+			reconcileErrors = append(reconcileErrors, fmt.Errorf("reconcile LoadBalancer service %s/%s: %w", service.Namespace, service.Name, err))
+		}
+	}
+	return errors.Join(reconcileErrors...)
+}
+
+func cleanupServiceLB(ctx context.Context, client kubernetes.Interface) error {
+	services, err := client.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list services for ServiceLB cleanup: %w", err)
+	}
+	errs := make([]error, 0)
+	for i := range services.Items {
+		service := &services.Items[i]
+		if service.Annotations[serviceLBManagedIPsAnnotation] == "" {
+			continue
+		}
+		if err := cleanupLoadBalancerService(ctx, client, service); err != nil {
+			errs = append(errs, fmt.Errorf("clean up ServiceLB state for %s/%s: %w", service.Namespace, service.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func serviceLBManages(service *corev1.Service) bool {
+	if service == nil || service.Spec.Type != corev1.ServiceTypeLoadBalancer || service.Annotations[serviceLBDisabledAnnotation] == "true" {
+		return false
+	}
+	return (service.Spec.LoadBalancerClass != nil && *service.Spec.LoadBalancerClass == serviceLBClass) || service.Annotations[serviceLBEnabledAnnotation] == "true"
+}
+
+type serviceLBNode struct {
+	name string
+	ips  []string
+}
+
+func readyServiceLBNodes(nodes []corev1.Node) []serviceLBNode {
+	return readyNodeAddresses(nodes, false)
+}
+
+func readyNodeAddresses(nodes []corev1.Node, controlPlaneOnly bool) []serviceLBNode {
+	seen := map[string]struct{}{}
+	result := make([]serviceLBNode, 0)
+	for _, node := range nodes {
+		if !isReadyNode(node) || (controlPlaneOnly != isControlPlaneNode(node)) {
+			continue
+		}
+		externalAddresses := make([]string, 0)
+		internalAddresses := make([]string, 0)
+		for _, address := range node.Status.Addresses {
+			if address.Type != corev1.NodeExternalIP && address.Type != corev1.NodeInternalIP {
+				continue
+			}
+			ip := net.ParseIP(address.Address)
+			if ip == nil {
+				continue
+			}
+			value := ip.String()
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			if address.Type == corev1.NodeExternalIP {
+				externalAddresses = append(externalAddresses, value)
+			} else {
+				internalAddresses = append(internalAddresses, value)
+			}
+		}
+		addresses := externalAddresses
+		if len(addresses) == 0 {
+			addresses = internalAddresses
+		}
+		if len(addresses) > 0 {
+			for _, address := range addresses {
+				seen[address] = struct{}{}
+			}
+			result = append(result, serviceLBNode{name: node.Name, ips: addresses})
+		}
+	}
+	return result
+}
+
+func serviceLBNodeIPs(ctx context.Context, client kubernetes.Interface, service *corev1.Service, nodes []corev1.Node) ([]string, error) {
+	candidates := readyServiceLBNodes(nodes)
+	if service.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyTypeLocal {
+		ready, err := serviceHasReadyEndpoint(ctx, client, service)
+		if err != nil {
+			return nil, err
+		}
+		if !ready {
+			return []string{}, nil
+		}
+		ips := make([]string, 0)
+		for _, node := range candidates {
+			ips = append(ips, node.ips...)
+		}
+		return uniqueStrings(ips), nil
+	}
+	selector := labels.SelectorFromSet(labels.Set{discoveryv1.LabelServiceName: service.Name}).String()
+	endpointSlices, err := client.DiscoveryV1().EndpointSlices(service.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list EndpointSlices: %w", err)
+	}
+	localNodes := map[string]struct{}{}
+	for _, endpointSlice := range endpointSlices.Items {
+		for _, endpoint := range endpointSlice.Endpoints {
+			if endpoint.NodeName == nil || (endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready) {
+				continue
+			}
+			localNodes[*endpoint.NodeName] = struct{}{}
+		}
+	}
+	matchingIPs := func(candidates []serviceLBNode) []string {
+		ips := make([]string, 0)
+		for _, node := range candidates {
+			if _, ok := localNodes[node.name]; !ok {
+				continue
+			}
+			ips = append(ips, node.ips...)
+		}
+		return uniqueStrings(ips)
+	}
+	if workerIPs := matchingIPs(readyNodeAddresses(nodes, false)); len(workerIPs) > 0 {
+		return workerIPs, nil
+	}
+	return nil, nil
+}
+
+func serviceHasReadyEndpoint(ctx context.Context, client kubernetes.Interface, service *corev1.Service) (bool, error) {
+	selector := labels.SelectorFromSet(labels.Set{discoveryv1.LabelServiceName: service.Name}).String()
+	endpointSlices, err := client.DiscoveryV1().EndpointSlices(service.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return false, fmt.Errorf("list EndpointSlices: %w", err)
+	}
+	for _, endpointSlice := range endpointSlices.Items {
+		for _, endpoint := range endpointSlice.Endpoints {
+			if endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func isReadyNode(node corev1.Node) bool {
+	if node.Spec.Unschedulable {
+		return false
+	}
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func cleanupLoadBalancerService(ctx context.Context, client kubernetes.Interface, service *corev1.Service) error {
+	if service == nil || service.DeletionTimestamp != nil {
+		return nil
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := client.CoreV1().Services(service.Namespace).Get(ctx, service.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if current.DeletionTimestamp != nil {
+			return nil
+		}
+		managedIPs, err := serviceLBManagedIPs(current.Annotations)
+		if err != nil {
+			return err
+		}
+		managedSet := make(map[string]struct{}, len(managedIPs))
+		for _, ip := range managedIPs {
+			managedSet[ip] = struct{}{}
+		}
+		status := current.Status.DeepCopy()
+		status.LoadBalancer.Ingress = status.LoadBalancer.Ingress[:0]
+		for _, ingress := range current.Status.LoadBalancer.Ingress {
+			if _, managed := managedSet[ingress.IP]; !managed {
+				status.LoadBalancer.Ingress = append(status.LoadBalancer.Ingress, ingress)
+			}
+		}
+		if !reflect.DeepEqual(current.Status, *status) {
+			statusUpdate := current.DeepCopy()
+			statusUpdate.Status = *status
+			current, err = client.CoreV1().Services(current.Namespace).UpdateStatus(ctx, statusUpdate, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+		}
+		updated := current.DeepCopy()
+		updated.Spec.ExternalIPs = updated.Spec.ExternalIPs[:0]
+		for _, ip := range current.Spec.ExternalIPs {
+			if _, managed := managedSet[ip]; !managed {
+				updated.Spec.ExternalIPs = append(updated.Spec.ExternalIPs, ip)
+			}
+		}
+		delete(updated.Annotations, serviceLBManagedIPsAnnotation)
+		if reflect.DeepEqual(current.Spec.ExternalIPs, updated.Spec.ExternalIPs) && current.Annotations[serviceLBManagedIPsAnnotation] == "" {
+			return nil
+		}
+		_, err = client.CoreV1().Services(current.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func isControlPlaneNode(node corev1.Node) bool {
+	_, controlPlane := node.Labels["node-role.kubernetes.io/control-plane"]
+	_, master := node.Labels["node-role.kubernetes.io/master"]
+	return controlPlane || master
+}
+
+func reconcileLoadBalancerService(ctx context.Context, client kubernetes.Interface, service *corev1.Service, nodeIPs []string) error {
+	if service == nil || service.DeletionTimestamp != nil {
+		return nil
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := client.CoreV1().Services(service.Namespace).Get(ctx, service.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if current.DeletionTimestamp != nil || !serviceLBManages(current) {
+			return nil
+		}
+		return reconcileLoadBalancerServiceOnce(ctx, client, current, nodeIPs)
+	})
+}
+
+func reconcileLoadBalancerServiceOnce(ctx context.Context, client kubernetes.Interface, service *corev1.Service, nodeIPs []string) error {
+	managedIPs, err := serviceLBManagedIPs(service.Annotations)
+	if err != nil {
+		return err
+	}
+	managedSet := make(map[string]struct{}, len(managedIPs))
+	for _, ip := range managedIPs {
+		managedSet[ip] = struct{}{}
+	}
+	userIPs := make([]string, 0, len(service.Spec.ExternalIPs))
+	for _, ip := range service.Spec.ExternalIPs {
+		if _, ok := managedSet[ip]; !ok && !containsString(userIPs, ip) {
+			userIPs = append(userIPs, ip)
+		}
+	}
+	desiredManagedIPs := make([]string, 0, len(nodeIPs))
+	for _, ip := range nodeIPs {
+		if !containsString(userIPs, ip) {
+			desiredManagedIPs = append(desiredManagedIPs, ip)
+		}
+	}
+	desiredExternalIPs := append(append([]string{}, userIPs...), nodeIPs...)
+	desiredExternalIPs = uniqueStrings(desiredExternalIPs)
+	encodedManagedIPs, err := json.Marshal(desiredManagedIPs)
+	if err != nil {
+		return fmt.Errorf("encode managed LoadBalancer IPs: %w", err)
+	}
+	desiredAnnotation := string(encodedManagedIPs)
+
+	updated := service.DeepCopy()
+	if !reflect.DeepEqual(updated.Spec.ExternalIPs, desiredExternalIPs) || updated.Annotations[serviceLBManagedIPsAnnotation] != desiredAnnotation {
+		if updated.Annotations == nil {
+			updated.Annotations = map[string]string{}
+		}
+		updated.Spec.ExternalIPs = desiredExternalIPs
+		updated.Annotations[serviceLBManagedIPsAnnotation] = desiredAnnotation
+		current, err := client.CoreV1().Services(service.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("update LoadBalancer service spec: %w", err)
+		}
+		updated = current
+	}
+
+	desiredStatus := updated.Status.DeepCopy()
+	unmanagedIngress := make([]corev1.LoadBalancerIngress, 0, len(desiredStatus.LoadBalancer.Ingress))
+	for _, ingress := range desiredStatus.LoadBalancer.Ingress {
+		if _, managed := managedSet[ingress.IP]; !managed {
+			unmanagedIngress = append(unmanagedIngress, ingress)
+		}
+	}
+	desiredStatus.LoadBalancer.Ingress = unmanagedIngress
+	for _, ip := range nodeIPs {
+		if !containsLoadBalancerIngress(desiredStatus.LoadBalancer.Ingress, ip) {
+			desiredStatus.LoadBalancer.Ingress = append(desiredStatus.LoadBalancer.Ingress, corev1.LoadBalancerIngress{IP: ip})
+		}
+	}
+	if reflect.DeepEqual(updated.Status, *desiredStatus) {
+		return nil
+	}
+	updated.Status = *desiredStatus
+	if _, err := client.CoreV1().Services(service.Namespace).UpdateStatus(ctx, updated, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("update LoadBalancer service status: %w", err)
+	}
+	return nil
+}
+
+func containsLoadBalancerIngress(ingresses []corev1.LoadBalancerIngress, ip string) bool {
+	for _, ingress := range ingresses {
+		if ingress.IP == ip {
+			return true
+		}
+	}
+	return false
+}
+
+func serviceLBManagedIPs(annotations map[string]string) ([]string, error) {
+	value := annotations[serviceLBManagedIPsAnnotation]
+	if value == "" {
+		return nil, nil
+	}
+	var ips []string
+	if err := json.Unmarshal([]byte(value), &ips); err != nil {
+		return nil, fmt.Errorf("decode managed LoadBalancer IPs: %w", err)
+	}
+	return uniqueStrings(ips), nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func uniqueStrings(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "" && !containsString(result, value) {
+			result = append(result, value)
+		}
+	}
+	return result
+}

--- a/server/servicelb_test.go
+++ b/server/servicelb_test.go
@@ -1,0 +1,226 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestServiceLBSkipsForeignLoadBalancerClass(t *testing.T) {
+	foreignClass := "metallb.io/controller"
+	ready := corev1.ConditionTrue
+	client := fake.NewSimpleClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker"}, Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: ready}},
+			Addresses:  []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "192.0.2.10"}},
+		}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"}, Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer, LoadBalancerClass: &foreignClass,
+		}},
+	)
+	if err := reconcileServiceLB(context.Background(), client); err != nil {
+		t.Fatalf("reconcile service LB: %v", err)
+	}
+	stored, _ := client.CoreV1().Services("default").Get(context.Background(), "app", metav1.GetOptions{})
+	if len(stored.Spec.ExternalIPs) != 0 || len(stored.Status.LoadBalancer.Ingress) != 0 || stored.Annotations[serviceLBManagedIPsAnnotation] != "" {
+		t.Fatalf("foreign LoadBalancer service was modified: annotations=%v spec=%v status=%v", stored.Annotations, stored.Spec.ExternalIPs, stored.Status.LoadBalancer.Ingress)
+	}
+}
+
+func TestServiceLBSkipsUnclassedServiceWithoutOptIn(t *testing.T) {
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"}, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer}}
+	client := fake.NewSimpleClientset(service)
+	if err := reconcileServiceLB(context.Background(), client); err != nil {
+		t.Fatalf("reconcile service LB: %v", err)
+	}
+	stored, _ := client.CoreV1().Services("default").Get(context.Background(), "app", metav1.GetOptions{})
+	if stored.Annotations[serviceLBManagedIPsAnnotation] != "" {
+		t.Fatalf("unclassed Service was claimed without opt-in: %v", stored.Annotations)
+	}
+}
+
+func TestServiceLBDisabledAnnotationCleansManagedState(t *testing.T) {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", Annotations: map[string]string{
+			serviceLBDisabledAnnotation:   "true",
+			serviceLBManagedIPsAnnotation: `["192.0.2.10"]`,
+		}},
+		Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, ExternalIPs: []string{"198.51.100.5", "192.0.2.10"}},
+		Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "192.0.2.10"}}}},
+	}
+	client := fake.NewSimpleClientset(service)
+	if err := reconcileServiceLB(context.Background(), client); err != nil {
+		t.Fatalf("reconcile service LB: %v", err)
+	}
+	stored, _ := client.CoreV1().Services("default").Get(context.Background(), "app", metav1.GetOptions{})
+	if len(stored.Spec.ExternalIPs) != 1 || stored.Spec.ExternalIPs[0] != "198.51.100.5" || stored.Annotations[serviceLBManagedIPsAnnotation] != "" || len(stored.Status.LoadBalancer.Ingress) != 0 {
+		t.Fatalf("managed state was not cleaned: annotations=%v externalIPs=%v status=%v", stored.Annotations, stored.Spec.ExternalIPs, stored.Status.LoadBalancer.Ingress)
+	}
+}
+
+func TestCleanupServiceLBPreservesUserState(t *testing.T) {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", Annotations: map[string]string{
+			serviceLBManagedIPsAnnotation: `["192.0.2.10"]`,
+		}},
+		Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, ExternalIPs: []string{"198.51.100.5", "192.0.2.10"}},
+		Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{
+			{IP: "192.0.2.10"}, {Hostname: "external.example.com"},
+		}}},
+	}
+	client := fake.NewSimpleClientset(service)
+	if err := cleanupServiceLB(context.Background(), client); err != nil {
+		t.Fatalf("cleanup ServiceLB: %v", err)
+	}
+	stored, _ := client.CoreV1().Services("default").Get(context.Background(), "app", metav1.GetOptions{})
+	wantStatus := []corev1.LoadBalancerIngress{{Hostname: "external.example.com"}}
+	if !reflect.DeepEqual(stored.Spec.ExternalIPs, []string{"198.51.100.5"}) || !reflect.DeepEqual(stored.Status.LoadBalancer.Ingress, wantStatus) || stored.Annotations[serviceLBManagedIPsAnnotation] != "" {
+		t.Fatalf("cleanup removed user state: annotations=%v externalIPs=%v status=%v", stored.Annotations, stored.Spec.ExternalIPs, stored.Status.LoadBalancer.Ingress)
+	}
+}
+
+func TestCleanupServiceLBKeepsOwnershipWhenStatusUpdateFails(t *testing.T) {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", Annotations: map[string]string{
+			serviceLBManagedIPsAnnotation: `["192.0.2.10"]`,
+		}},
+		Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, ExternalIPs: []string{"192.0.2.10"}},
+		Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "192.0.2.10"}}}},
+	}
+	client := fake.NewSimpleClientset(service)
+	client.PrependReactor("update", "services", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "status" {
+			return true, nil, errors.New("status update failed")
+		}
+		return false, nil, nil
+	})
+	if err := cleanupLoadBalancerService(context.Background(), client, service); err == nil {
+		t.Fatal("expected status update failure")
+	}
+	stored, _ := client.CoreV1().Services("default").Get(context.Background(), "app", metav1.GetOptions{})
+	if stored.Annotations[serviceLBManagedIPsAnnotation] == "" || len(stored.Spec.ExternalIPs) != 1 {
+		t.Fatalf("cleanup lost ownership after partial failure: annotations=%v externalIPs=%v", stored.Annotations, stored.Spec.ExternalIPs)
+	}
+}
+
+func TestServiceLBDoesNotPublishControlPlaneOnlyNodes(t *testing.T) {
+	ready := corev1.ConditionTrue
+	nodes := []corev1.Node{{
+		ObjectMeta: metav1.ObjectMeta{Name: "control-plane", Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""}},
+		Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: ready}}, Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "192.0.2.20"}}},
+	}}
+	if selected := readyServiceLBNodes(nodes); len(selected) != 0 {
+		t.Fatalf("control-plane nodes were published without explicit support: %v", selected)
+	}
+}
+
+func TestReconcileLoadBalancerServiceRetriesConflict(t *testing.T) {
+	class := serviceLBClass
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"}, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, LoadBalancerClass: &class}}
+	client := fake.NewSimpleClientset(service)
+	conflicts := 0
+	client.PrependReactor("update", "services", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "" && conflicts == 0 {
+			conflicts++
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "services"}, "app", nil)
+		}
+		return false, nil, nil
+	})
+	if err := reconcileLoadBalancerService(context.Background(), client, service, []string{"192.0.2.10"}); err != nil {
+		t.Fatalf("reconcile after conflict: %v", err)
+	}
+	stored, _ := client.CoreV1().Services("default").Get(context.Background(), "app", metav1.GetOptions{})
+	if conflicts != 1 || len(stored.Spec.ExternalIPs) != 1 || stored.Spec.ExternalIPs[0] != "192.0.2.10" {
+		t.Fatalf("conflict was not retried: conflicts=%d externalIPs=%v", conflicts, stored.Spec.ExternalIPs)
+	}
+}
+
+func TestReconcileLoadBalancerServicePreservesUnmanagedStatus(t *testing.T) {
+	class := serviceLBClass
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", Annotations: map[string]string{
+			serviceLBManagedIPsAnnotation: `["192.0.2.9"]`,
+		}},
+		Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, LoadBalancerClass: &class, ExternalIPs: []string{"192.0.2.9"}},
+		Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{
+			{IP: "192.0.2.9"},
+			{Hostname: "external.example.com"},
+		}}},
+	}
+	client := fake.NewSimpleClientset(service)
+	if err := reconcileLoadBalancerService(context.Background(), client, service, []string{"192.0.2.10"}); err != nil {
+		t.Fatalf("reconcile LoadBalancer service: %v", err)
+	}
+	stored, _ := client.CoreV1().Services("default").Get(context.Background(), "app", metav1.GetOptions{})
+	want := []corev1.LoadBalancerIngress{{Hostname: "external.example.com"}, {IP: "192.0.2.10"}}
+	if !reflect.DeepEqual(stored.Status.LoadBalancer.Ingress, want) {
+		t.Fatalf("unmanaged status was not preserved: %v", stored.Status.LoadBalancer.Ingress)
+	}
+}
+
+func TestReconcileLoadBalancerServiceSkipsDeletingService(t *testing.T) {
+	class := serviceLBClass
+	now := metav1.Now()
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", DeletionTimestamp: &now}, Spec: corev1.ServiceSpec{
+		Type: corev1.ServiceTypeLoadBalancer, LoadBalancerClass: &class,
+	}}
+	client := fake.NewSimpleClientset(service)
+	if err := reconcileLoadBalancerService(context.Background(), client, service, []string{"192.0.2.10"}); err != nil {
+		t.Fatalf("reconcile deleting service: %v", err)
+	}
+	stored, _ := client.CoreV1().Services("default").Get(context.Background(), "app", metav1.GetOptions{})
+	if len(stored.Spec.ExternalIPs) != 0 || len(stored.Status.LoadBalancer.Ingress) != 0 {
+		t.Fatalf("deleting service was modified: spec=%v status=%v", stored.Spec.ExternalIPs, stored.Status.LoadBalancer.Ingress)
+	}
+}
+
+func TestReadyServiceLBNodesPreferExternalIPAndSkipCordonedNodes(t *testing.T) {
+	ready := corev1.ConditionTrue
+	nodes := []corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "public-worker"}, Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: ready}},
+			Addresses:  []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.10"}, {Type: corev1.NodeExternalIP, Address: "192.0.2.10"}},
+		}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cordoned-worker"}, Spec: corev1.NodeSpec{Unschedulable: true}, Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: ready}},
+			Addresses:  []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "192.0.2.11"}},
+		}},
+	}
+	selected := readyServiceLBNodes(nodes)
+	if len(selected) != 1 || len(selected[0].ips) != 1 || selected[0].ips[0] != "192.0.2.10" {
+		t.Fatalf("unexpected selected nodes: %v", selected)
+	}
+}
+
+func TestLocalServiceLBPrefersWorkerEndpointOverControlPlane(t *testing.T) {
+	ready := corev1.ConditionTrue
+	workerName, controlPlaneName := "worker", "control-plane"
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"}, Spec: corev1.ServiceSpec{
+		Type: corev1.ServiceTypeLoadBalancer, ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+	}}
+	client := fake.NewSimpleClientset(&discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", Labels: map[string]string{discoveryv1.LabelServiceName: "app"}},
+		Endpoints:  []discoveryv1.Endpoint{{NodeName: &workerName}, {NodeName: &controlPlaneName}},
+	})
+	nodes := []corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: workerName}, Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: ready}}, Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "192.0.2.10"}}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: controlPlaneName, Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""}}, Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: ready}}, Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "192.0.2.20"}}}},
+	}
+	ips, err := serviceLBNodeIPs(context.Background(), client, service, nodes)
+	if err != nil {
+		t.Fatalf("select ServiceLB IPs: %v", err)
+	}
+	if len(ips) != 1 || ips[0] != "192.0.2.10" {
+		t.Fatalf("expected only worker IP, got %v", ips)
+	}
+}

--- a/server/storage_bootstrap.go
+++ b/server/storage_bootstrap.go
@@ -440,7 +440,18 @@ func hashConfigData(data map[string]string) string {
 	return fmt.Sprintf("%x", sum[:])
 }
 
-func createOrUpdateServiceAccount(ctx context.Context, client kubernetes.Interface, sa *corev1.ServiceAccount) error {
+type existingObjectValidator func(metav1.Object) error
+
+func validateExistingObject(object metav1.Object, validators []existingObjectValidator) error {
+	for _, validator := range validators {
+		if err := validator(object); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createOrUpdateServiceAccount(ctx context.Context, client kubernetes.Interface, sa *corev1.ServiceAccount, validators ...existingObjectValidator) error {
 	current, err := client.CoreV1().ServiceAccounts(sa.Namespace).Get(ctx, sa.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err = client.CoreV1().ServiceAccounts(sa.Namespace).Create(ctx, sa, metav1.CreateOptions{})
@@ -451,6 +462,9 @@ func createOrUpdateServiceAccount(ctx context.Context, client kubernetes.Interfa
 	}
 	if err != nil {
 		return fmt.Errorf("get serviceaccount %s/%s: %w", sa.Namespace, sa.Name, err)
+	}
+	if err := validateExistingObject(current, validators); err != nil {
+		return fmt.Errorf("validate serviceaccount %s/%s: %w", sa.Namespace, sa.Name, err)
 	}
 	sa.Labels = mergeStringMap(current.Labels, sa.Labels)
 	sa.Annotations = mergeStringMap(current.Annotations, sa.Annotations)
@@ -471,7 +485,7 @@ func createOrUpdateServiceAccount(ctx context.Context, client kubernetes.Interfa
 	return nil
 }
 
-func createOrUpdateClusterRole(ctx context.Context, client kubernetes.Interface, role *rbacv1.ClusterRole) error {
+func createOrUpdateClusterRole(ctx context.Context, client kubernetes.Interface, role *rbacv1.ClusterRole, validators ...existingObjectValidator) error {
 	current, err := client.RbacV1().ClusterRoles().Get(ctx, role.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err = client.RbacV1().ClusterRoles().Create(ctx, role, metav1.CreateOptions{})
@@ -482,6 +496,9 @@ func createOrUpdateClusterRole(ctx context.Context, client kubernetes.Interface,
 	}
 	if err != nil {
 		return fmt.Errorf("get clusterrole %s: %w", role.Name, err)
+	}
+	if err := validateExistingObject(current, validators); err != nil {
+		return fmt.Errorf("validate clusterrole %s: %w", role.Name, err)
 	}
 	role.Labels = mergeStringMap(current.Labels, role.Labels)
 	role.Annotations = mergeStringMap(current.Annotations, role.Annotations)
@@ -498,7 +515,7 @@ func createOrUpdateClusterRole(ctx context.Context, client kubernetes.Interface,
 	return nil
 }
 
-func createOrUpdateClusterRoleBinding(ctx context.Context, client kubernetes.Interface, binding *rbacv1.ClusterRoleBinding) error {
+func createOrUpdateClusterRoleBinding(ctx context.Context, client kubernetes.Interface, binding *rbacv1.ClusterRoleBinding, validators ...existingObjectValidator) error {
 	current, err := client.RbacV1().ClusterRoleBindings().Get(ctx, binding.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err = client.RbacV1().ClusterRoleBindings().Create(ctx, binding, metav1.CreateOptions{})
@@ -509,6 +526,9 @@ func createOrUpdateClusterRoleBinding(ctx context.Context, client kubernetes.Int
 	}
 	if err != nil {
 		return fmt.Errorf("get clusterrolebinding %s: %w", binding.Name, err)
+	}
+	if err := validateExistingObject(current, validators); err != nil {
+		return fmt.Errorf("validate clusterrolebinding %s: %w", binding.Name, err)
 	}
 	binding.Labels = mergeStringMap(current.Labels, binding.Labels)
 	binding.Annotations = mergeStringMap(current.Annotations, binding.Annotations)
@@ -608,7 +628,7 @@ func createOrUpdateRoleBinding(ctx context.Context, client kubernetes.Interface,
 	return nil
 }
 
-func createOrUpdateDeployment(ctx context.Context, client kubernetes.Interface, deployment *appsv1.Deployment) error {
+func createOrUpdateDeployment(ctx context.Context, client kubernetes.Interface, deployment *appsv1.Deployment, validators ...existingObjectValidator) error {
 	desired := deployment.DeepCopy()
 	appsinternal.SetObjectDefaults_Deployment(desired)
 	current, err := client.AppsV1().Deployments(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
@@ -621,6 +641,9 @@ func createOrUpdateDeployment(ctx context.Context, client kubernetes.Interface, 
 	}
 	if err != nil {
 		return fmt.Errorf("get deployment %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+	if err := validateExistingObject(current, validators); err != nil {
+		return fmt.Errorf("validate deployment %s/%s: %w", desired.Namespace, desired.Name, err)
 	}
 	desired.Labels = mergeStringMap(current.Labels, desired.Labels)
 	desired.Annotations = mergeStringMap(current.Annotations, desired.Annotations)

--- a/server/storage_bootstrap.go
+++ b/server/storage_bootstrap.go
@@ -13,10 +13,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	appsinternal "k8s.io/kubernetes/pkg/apis/apps/v1"
 )
 
 const (
@@ -49,6 +51,12 @@ func ensureDefaultStorageProvisioner(ctx context.Context, client kubernetes.Inte
 		return err
 	}
 	if err := ensureLocalPathServiceAccount(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureLocalPathRole(ctx, client); err != nil {
+		return err
+	}
+	if err := ensureLocalPathRoleBinding(ctx, client); err != nil {
 		return err
 	}
 	if err := ensureLocalPathClusterRole(ctx, client); err != nil {
@@ -89,6 +97,43 @@ func ensureLocalPathServiceAccount(ctx context.Context, client kubernetes.Interf
 	return createOrUpdateServiceAccount(ctx, client, sa)
 }
 
+func ensureLocalPathRole(ctx context.Context, client kubernetes.Interface) error {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "local-path-provisioner-role",
+			Namespace: localPathNamespace,
+			Labels:    localPathLabels(),
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"get", "list", "watch", "create", "patch", "update", "delete"},
+		}},
+	}
+	return createOrUpdateRole(ctx, client, role)
+}
+
+func ensureLocalPathRoleBinding(ctx context.Context, client kubernetes.Interface) error {
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "local-path-provisioner-bind",
+			Namespace: localPathNamespace,
+			Labels:    localPathLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "local-path-provisioner-role",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      "local-path-provisioner-service-account",
+			Namespace: localPathNamespace,
+		}},
+	}
+	return createOrUpdateRoleBinding(ctx, client, binding)
+}
+
 func ensureLocalPathClusterRole(ctx context.Context, client kubernetes.Interface) error {
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
@@ -109,7 +154,7 @@ func ensureLocalPathClusterRole(ctx context.Context, client kubernetes.Interface
 			{
 				APIGroups: []string{""},
 				Resources: []string{"persistentvolumes"},
-				Verbs:     []string{"get", "list", "watch", "create", "patch", "delete"},
+				Verbs:     []string{"get", "list", "watch", "create", "patch", "update", "delete"},
 			},
 			{
 				APIGroups: []string{""},
@@ -174,6 +219,9 @@ spec:
   automountServiceAccountToken: false
   tolerations:
     - key: node.kubernetes.io/disk-pressure
+      operator: Exists
+      effect: NoSchedule
+    - key: casos.io/bootstrap
       operator: Exists
       effect: NoSchedule
   containers:
@@ -259,6 +307,7 @@ func ensureLocalPathDeployment(ctx context.Context, client kubernetes.Interface,
 					Tolerations: []corev1.Toleration{
 						{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
 						{Key: "node-role.kubernetes.io/master", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Key: "casos.io/bootstrap", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
 					},
 					Containers: []corev1.Container{
 						{
@@ -408,6 +457,13 @@ func createOrUpdateServiceAccount(ctx context.Context, client kubernetes.Interfa
 	sa.Secrets = current.Secrets
 	sa.ImagePullSecrets = current.ImagePullSecrets
 	sa.AutomountServiceAccountToken = current.AutomountServiceAccountToken
+	if apiequality.Semantic.DeepEqual(current.Labels, sa.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, sa.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.Secrets, sa.Secrets) &&
+		apiequality.Semantic.DeepEqual(current.ImagePullSecrets, sa.ImagePullSecrets) &&
+		apiequality.Semantic.DeepEqual(current.AutomountServiceAccountToken, sa.AutomountServiceAccountToken) {
+		return nil
+	}
 	sa.ResourceVersion = current.ResourceVersion
 	if _, err := client.CoreV1().ServiceAccounts(sa.Namespace).Update(ctx, sa, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("update serviceaccount %s/%s: %w", sa.Namespace, sa.Name, err)
@@ -429,6 +485,12 @@ func createOrUpdateClusterRole(ctx context.Context, client kubernetes.Interface,
 	}
 	role.Labels = mergeStringMap(current.Labels, role.Labels)
 	role.Annotations = mergeStringMap(current.Annotations, role.Annotations)
+	if apiequality.Semantic.DeepEqual(current.Labels, role.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, role.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.Rules, role.Rules) &&
+		apiequality.Semantic.DeepEqual(current.AggregationRule, role.AggregationRule) {
+		return nil
+	}
 	role.ResourceVersion = current.ResourceVersion
 	if _, err := client.RbacV1().ClusterRoles().Update(ctx, role, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("update clusterrole %s: %w", role.Name, err)
@@ -450,6 +512,12 @@ func createOrUpdateClusterRoleBinding(ctx context.Context, client kubernetes.Int
 	}
 	binding.Labels = mergeStringMap(current.Labels, binding.Labels)
 	binding.Annotations = mergeStringMap(current.Annotations, binding.Annotations)
+	if apiequality.Semantic.DeepEqual(current.Labels, binding.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, binding.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.RoleRef, binding.RoleRef) &&
+		apiequality.Semantic.DeepEqual(current.Subjects, binding.Subjects) {
+		return nil
+	}
 	binding.ResourceVersion = current.ResourceVersion
 	if _, err := client.RbacV1().ClusterRoleBindings().Update(ctx, binding, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("update clusterrolebinding %s: %w", binding.Name, err)
@@ -471,6 +539,13 @@ func createOrUpdateConfigMap(ctx context.Context, client kubernetes.Interface, c
 	}
 	cm.Labels = mergeStringMap(current.Labels, cm.Labels)
 	cm.Annotations = mergeStringMap(current.Annotations, cm.Annotations)
+	if apiequality.Semantic.DeepEqual(current.Labels, cm.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, cm.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.Data, cm.Data) &&
+		apiequality.Semantic.DeepEqual(current.BinaryData, cm.BinaryData) &&
+		apiequality.Semantic.DeepEqual(current.Immutable, cm.Immutable) {
+		return nil
+	}
 	cm.ResourceVersion = current.ResourceVersion
 	if _, err := client.CoreV1().ConfigMaps(cm.Namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("update configmap %s/%s: %w", cm.Namespace, cm.Name, err)
@@ -478,23 +553,86 @@ func createOrUpdateConfigMap(ctx context.Context, client kubernetes.Interface, c
 	return nil
 }
 
-func createOrUpdateDeployment(ctx context.Context, client kubernetes.Interface, deployment *appsv1.Deployment) error {
-	current, err := client.AppsV1().Deployments(deployment.Namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+func createOrUpdateRole(ctx context.Context, client kubernetes.Interface, role *rbacv1.Role) error {
+	roles := client.RbacV1().Roles(role.Namespace)
+	current, err := roles.Get(ctx, role.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err = client.AppsV1().Deployments(deployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("create deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
+		if _, err = roles.Create(ctx, role, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("create role %s/%s: %w", role.Namespace, role.Name, err)
 		}
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("get deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
+		return fmt.Errorf("get role %s/%s: %w", role.Namespace, role.Name, err)
 	}
-	deployment.Labels = mergeStringMap(current.Labels, deployment.Labels)
-	deployment.Annotations = mergeStringMap(current.Annotations, deployment.Annotations)
-	deployment.ResourceVersion = current.ResourceVersion
-	if _, err := client.AppsV1().Deployments(deployment.Namespace).Update(ctx, deployment, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("update deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
+	role.Labels = mergeStringMap(current.Labels, role.Labels)
+	role.Annotations = mergeStringMap(current.Annotations, role.Annotations)
+	if apiequality.Semantic.DeepEqual(current.Labels, role.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, role.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.Rules, role.Rules) {
+		return nil
+	}
+	role.ResourceVersion = current.ResourceVersion
+	if _, err := roles.Update(ctx, role, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update role %s/%s: %w", role.Namespace, role.Name, err)
+	}
+	return nil
+}
+
+func createOrUpdateRoleBinding(ctx context.Context, client kubernetes.Interface, binding *rbacv1.RoleBinding) error {
+	bindings := client.RbacV1().RoleBindings(binding.Namespace)
+	current, err := bindings.Get(ctx, binding.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		if _, err = bindings.Create(ctx, binding, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("create rolebinding %s/%s: %w", binding.Namespace, binding.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get rolebinding %s/%s: %w", binding.Namespace, binding.Name, err)
+	}
+	if !apiequality.Semantic.DeepEqual(current.RoleRef, binding.RoleRef) {
+		return fmt.Errorf("rolebinding %s/%s has immutable roleRef %v", binding.Namespace, binding.Name, current.RoleRef)
+	}
+	binding.Labels = mergeStringMap(current.Labels, binding.Labels)
+	binding.Annotations = mergeStringMap(current.Annotations, binding.Annotations)
+	if apiequality.Semantic.DeepEqual(current.Labels, binding.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, binding.Annotations) &&
+		apiequality.Semantic.DeepEqual(current.Subjects, binding.Subjects) {
+		return nil
+	}
+	binding.ResourceVersion = current.ResourceVersion
+	if _, err := bindings.Update(ctx, binding, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update rolebinding %s/%s: %w", binding.Namespace, binding.Name, err)
+	}
+	return nil
+}
+
+func createOrUpdateDeployment(ctx context.Context, client kubernetes.Interface, deployment *appsv1.Deployment) error {
+	desired := deployment.DeepCopy()
+	appsinternal.SetObjectDefaults_Deployment(desired)
+	current, err := client.AppsV1().Deployments(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = client.AppsV1().Deployments(desired.Namespace).Create(ctx, desired, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create deployment %s/%s: %w", desired.Namespace, desired.Name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get deployment %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+	desired.Labels = mergeStringMap(current.Labels, desired.Labels)
+	desired.Annotations = mergeStringMap(current.Annotations, desired.Annotations)
+	currentSpec := defaultedDeploymentSpec(current.Spec)
+	if apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) &&
+		apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) &&
+		apiequality.Semantic.DeepEqual(currentSpec, desired.Spec) {
+		return nil
+	}
+	desired.ResourceVersion = current.ResourceVersion
+	if _, err := client.AppsV1().Deployments(desired.Namespace).Update(ctx, desired, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update deployment %s/%s: %w", desired.Namespace, desired.Name, err)
 	}
 	return nil
 }
@@ -523,6 +661,10 @@ func reconcileLocalPathDeployment(ctx context.Context, client kubernetes.Interfa
 		updated := current.DeepCopy()
 		updated.Labels = mergeStringMap(updated.Labels, deployment.Labels)
 		updated.Annotations = mergeStringMap(updated.Annotations, deployment.Annotations)
+		if apiequality.Semantic.DeepEqual(current.Labels, updated.Labels) &&
+			apiequality.Semantic.DeepEqual(current.Annotations, updated.Annotations) {
+			return nil
+		}
 		if _, err := client.AppsV1().Deployments(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("patch deployment %s/%s metadata: %w", deployment.Namespace, deployment.Name, err)
 		}
@@ -550,6 +692,7 @@ func reconcileLocalPathDeployment(ctx context.Context, client kubernetes.Interfa
 }
 
 func hashLocalPathDeploymentSpec(spec appsv1.DeploymentSpec) (string, error) {
+	spec = defaultedDeploymentSpec(spec)
 	managed := struct {
 		Replicas *int32
 		Selector *metav1.LabelSelector
@@ -574,6 +717,12 @@ func hashLocalPathDeploymentSpec(spec appsv1.DeploymentSpec) (string, error) {
 	managed.Template.Spec.Containers = spec.Template.Spec.Containers
 	managed.Template.Spec.Volumes = spec.Template.Spec.Volumes
 	return hashJSON(managed)
+}
+
+func defaultedDeploymentSpec(spec appsv1.DeploymentSpec) appsv1.DeploymentSpec {
+	defaulted := &appsv1.Deployment{Spec: *spec.DeepCopy()}
+	appsinternal.SetObjectDefaults_Deployment(defaulted)
+	return defaulted.Spec
 }
 
 func createOrPatchStorageClassDefaultAnnotations(ctx context.Context, client kubernetes.Interface, class *storagev1.StorageClass) error {
@@ -602,6 +751,9 @@ func createOrPatchStorageClassDefaultAnnotations(ctx context.Context, client kub
 	} else {
 		delete(copied.Annotations, "storageclass.kubernetes.io/is-default-class")
 		delete(copied.Annotations, "storageclass.beta.kubernetes.io/is-default-class")
+	}
+	if apiequality.Semantic.DeepEqual(current.Annotations, copied.Annotations) {
+		return nil
 	}
 	if _, err := client.StorageV1().StorageClasses().Update(ctx, copied, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("update storageclass %s: %w", class.Name, err)

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -12,6 +12,10 @@ const e2eDataDir = process.env.E2E_DATA_DIR || path.join(os.tmpdir(), `casos-e2e
 const backendDir = path.resolve(__dirname, "..");
 const browserChannel = process.env.E2E_BROWSER_CHANNEL;
 const videoMode = process.env.E2E_DISABLE_VIDEO ? "off" : "retain-on-failure";
+const isCI = /^true$/i.test(process.env.CI || "");
+const ciCoreDNSImage = "registry.k8s.io/coredns/coredns:v1.12.4";
+const ciFlannelImage = "ghcr.io/flannel-io/flannel:v0.27.4";
+const ciFlannelCNIPluginImage = "ghcr.io/flannel-io/flannel-cni-plugin:v1.8.0-flannel1";
 
 process.env.E2E_TEST_TOKEN = e2eToken;
 
@@ -53,6 +57,9 @@ module.exports = defineConfig({
         apiserverPort: process.env.E2E_APISERVER_PORT || "16443",
         webhookPort: process.env.E2E_WEBHOOK_PORT || "19443",
         socks5Proxy: process.env.socks5Proxy || "",
+        coreDNSImage: isCI ? ciCoreDNSImage : process.env.coreDNSImage || "",
+        flannelImage: isCI ? ciFlannelImage : process.env.flannelImage || "",
+        flannelCNIPluginImage: isCI ? ciFlannelCNIPluginImage : process.env.flannelCNIPluginImage || "",
         e2eTestMode: "true",
         e2eTestToken: e2eToken,
       },

--- a/web/src/DeploymentListPage.js
+++ b/web/src/DeploymentListPage.js
@@ -153,13 +153,22 @@ class DeploymentListPage extends React.Component {
     const {services, ingresses, nodeIP} = this.state;
     const urls = [];
 
-    if (nodeIP) {
-      const svc = services.find(s => s.name === deploy.name && s.namespace === deploy.namespace && s.type === "NodePort");
-      if (svc) {
-        (svc.ports ?? []).filter(p => p.nodePort).forEach(p => {
-          urls.push({url: `http://${nodeIP}:${p.nodePort}`, type: "nodeport"});
-        });
+    const svc = services.find(s => s.name === deploy.name && s.namespace === deploy.namespace && (s.type === "NodePort" || s.type === "LoadBalancer"));
+    if (svc) {
+      let addresses;
+      if (svc.type === "LoadBalancer") {
+        addresses = svc.loadBalancerAddresses ?? [];
+      } else {
+        addresses = nodeIP ? [nodeIP] : [];
       }
+      const ports = svc.type === "LoadBalancer"
+        ? (svc.ports ?? []).filter(p => p.port)
+        : (svc.ports ?? []).filter(p => p.nodePort);
+      addresses.forEach(address => ports.forEach(p => {
+        const port = svc.type === "LoadBalancer" ? p.port : p.nodePort;
+        const host = address.includes(":") ? `[${address}]` : address;
+        urls.push({url: `http://${host}:${port}`, type: svc.type === "LoadBalancer" ? "loadbalancer" : "nodeport"});
+      }));
     }
 
     const deployServiceNames = new Set(
@@ -173,9 +182,19 @@ class DeploymentListPage extends React.Component {
       .filter(ing => ing.namespace === deploy.namespace)
       .forEach(ing => {
         (ing.rules ?? []).forEach(rule => {
-          if (deployServiceNames.has(rule.serviceName) && rule.host) {
-            const path = rule.path && rule.path !== "/" ? rule.path : "";
-            urls.push({url: `http://${rule.host}${path}`, type: "domain"});
+          if (!deployServiceNames.has(rule.serviceName)) {
+            return;
+          }
+          const path = rule.path && rule.path !== "/" ? rule.path : "";
+          const scheme = ing.tlsEnabled ? "https" : "http";
+          if (rule.host) {
+            urls.push({url: `${scheme}://${rule.host}${path}`, type: "domain"});
+          } else {
+            const publishedAddresses = ing.loadBalancerAddresses ?? [];
+            publishedAddresses.forEach(address => {
+              const host = address.includes(":") ? `[${address}]` : address;
+              urls.push({url: `${scheme}://${host}${path}`, type: "ingress"});
+            });
           }
         });
       });

--- a/web/src/MachineEditPage.js
+++ b/web/src/MachineEditPage.js
@@ -11,6 +11,7 @@ const statusColor = {
   Offline: "red",
   Deploying: "processing",
   Deployed: "blue",
+  Operational: "green",
   Failed: "red",
   Unknown: "default",
 };

--- a/web/src/MachineListPage.js
+++ b/web/src/MachineListPage.js
@@ -12,6 +12,7 @@ const statusColor = {
   Offline: "red",
   Deploying: "processing",
   Deployed: "blue",
+  Operational: "green",
   Failed: "red",
   Unknown: "default",
 };

--- a/web/src/ServiceListPage.js
+++ b/web/src/ServiceListPage.js
@@ -238,17 +238,26 @@ class ServiceListPage extends React.Component {
         title: "Access URL",
         key: "accessUrl",
         render: (_, record) => {
-          if (record.type !== "NodePort" || !nodeIP) {
+          if (record.type !== "NodePort" && record.type !== "LoadBalancer") {
             return null;
           }
-          return (record.ports ?? []).filter(p => p.nodePort).map((p, i) => {
-            const url = `http://${nodeIP}:${p.nodePort}`;
-            return (
-              <a key={i} href={url} target="_blank" rel="noopener noreferrer" style={{display: "block"}}>
+          const loadBalancerAddresses = record.loadBalancerAddresses ?? [];
+          const ports = record.type === "LoadBalancer"
+            ? (record.ports ?? []).filter(p => p.port)
+            : (record.ports ?? []).filter(p => p.nodePort);
+          const addresses = record.type === "LoadBalancer" ? loadBalancerAddresses : (nodeIP ? [nodeIP] : []);
+          const links = [];
+          addresses.forEach(address => ports.forEach((p, i) => {
+            const port = record.type === "LoadBalancer" ? p.port : p.nodePort;
+            const host = address.includes(":") ? `[${address}]` : address;
+            const url = `http://${host}:${port}`;
+            links.push(
+              <a key={`${address}-${i}`} href={url} target="_blank" rel="noopener noreferrer" style={{display: "block"}}>
                 {url}
               </a>
             );
-          });
+          }));
+          return links;
         },
       },
       {title: "Created", dataIndex: "createdAt", key: "createdAt", width: 180},

--- a/web/tests/ui/e2e-helpers.js
+++ b/web/tests/ui/e2e-helpers.js
@@ -2,14 +2,28 @@ const {randomUUID} = require("crypto");
 const {expect} = require("@playwright/test");
 
 const API_E2E_SIGNIN = "/api/e2e/signin";
+const API_GET_NODES = "/api/get-nodes";
 const e2eToken = process.env.E2E_TEST_TOKEN;
 const e2eSshPassword = process.env.E2E_SSH_PASSWORD || randomUUID();
 
 async function expectOkJson(response) {
-  expect(response.ok()).toBeTruthy();
+  expect(response.ok(), `${response.status()} ${response.url()}`).toBeTruthy();
   const body = await response.json();
-  expect(body.status).toBe("ok");
+  expect(body.status, JSON.stringify(body)).toBe("ok");
   return body;
+}
+
+async function waitForApiserverReady(page) {
+  await expect.poll(async () => {
+    const response = await page.context().request.get(API_GET_NODES);
+    if (!response.ok()) {
+      return {status: `http-${response.status()}`};
+    }
+    return response.json();
+  }, {
+    message: "wait for the apiserver before starting UI workflows",
+    timeout: 30_000,
+  }).toMatchObject({status: "ok"});
 }
 
 async function signInAsCiUser(page) {
@@ -29,6 +43,7 @@ async function signInAsCiUser(page) {
     name: "ci-user",
     displayName: "CI User",
   });
+  await waitForApiserverReady(page);
 }
 
 module.exports = {

--- a/web/tests/ui/worker-node-helpers.js
+++ b/web/tests/ui/worker-node-helpers.js
@@ -5,6 +5,7 @@ const {e2eSshPassword, expectOkJson} = require("./e2e-helpers");
 const API_ADD_MACHINE = "/api/add-machine";
 const API_DELETE_MACHINE = "/api/delete-machine";
 const API_DEPLOY_MACHINE_NODE = "/api/deploy-machine-node";
+const API_GET_MACHINE_NODE_LOGS = "/api/get-machine-node-logs";
 const API_GET_MACHINE_NODE_TASKS = "/api/get-machine-node-tasks";
 const API_REPAIR_MACHINE_NODE = "/api/repair-machine-node";
 // MachineListPage currently submits new machines with owner "admin".
@@ -143,6 +144,16 @@ async function getMachineNodeTasks(page, machineName) {
   return expectOkJson(tasks);
 }
 
+async function getMachineNodeLogs(page, taskId) {
+  if (!taskId) {
+    throw new Error("taskId is required to load worker node logs");
+  }
+  const logs = await page.context().request.get(
+    `${API_GET_MACHINE_NODE_LOGS}?taskId=${encodeURIComponent(taskId)}`
+  );
+  return expectOkJson(logs);
+}
+
 function workerNodeDialog(page, machineName) {
   return page.getByRole("dialog", {name: `Worker Node - ${machineName}`});
 }
@@ -261,12 +272,14 @@ module.exports = {
   API_ADD_MACHINE,
   API_DELETE_MACHINE,
   API_DEPLOY_MACHINE_NODE,
+  API_GET_MACHINE_NODE_LOGS,
   API_GET_MACHINE_NODE_TASKS,
   API_REPAIR_MACHINE_NODE,
   E2E_MACHINE_OWNER,
   createdMachinesFixture,
   createMachineFromUi,
   findMachineRow,
+  getMachineNodeLogs,
   getMachineNodeTasks,
   makeMachineName,
   openWorkerNodePanel,

--- a/web/tests/ui/worker-node-ready.spec.js
+++ b/web/tests/ui/worker-node-ready.spec.js
@@ -3,6 +3,8 @@ const {e2eSshPassword, signInAsCiUser} = require("./e2e-helpers");
 const {
   createdMachinesFixture,
   createMachineFromUi,
+  getMachineNodeLogs,
+  getMachineNodeTasks,
   makeMachineName,
   startWorkerNodeDeployment,
   workerNodeDialog,
@@ -31,11 +33,63 @@ function nodeRow(page, nodeName) {
   return page.locator(".ant-table-wrapper").filter({hasText: "Nodes"}).locator(`tr[data-row-key="${nodeName}"]`);
 }
 
+function workflowCommandData(value) {
+  return String(value).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+function emitGithubActionsError(title, message) {
+  if (process.env.GITHUB_ACTIONS !== "true") {
+    return;
+  }
+  const property = String(title)
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A")
+    .replace(/:/g, "%3A")
+    .replace(/,/g, "%2C");
+  console.error(`::error title=${property}::${workflowCommandData(message)}`);
+}
+
+async function deploymentDiagnostics(page, machineName, taskId) {
+  const details = [];
+  try {
+    const taskBody = await getMachineNodeTasks(page, machineName);
+    const task = (taskBody.data || []).find(item => String(item.id) === String(taskId));
+    details.push(`Task: ${JSON.stringify(task || null)}`);
+  } catch (error) {
+    details.push(`Task lookup failed: ${error.message}`);
+  }
+  try {
+    const logBody = await getMachineNodeLogs(page, taskId);
+    const logs = (logBody.data || []).slice(-25).map(log =>
+      `${log.createdAt || ""} ${log.level || ""} ${log.message || ""}`.trim()
+    );
+    details.push(`Recent task logs:\n${logs.join("\n") || "(none)"}`);
+  } catch (error) {
+    details.push(`Task log lookup failed: ${error.message}`);
+  }
+  return details.join("\n");
+}
+
 async function waitForDeployTaskToSucceed(page, machineName, taskId) {
   const taskRow = workerNodeTaskTable(page, machineName).locator(`tr[data-row-key="${taskId}"]`);
-  await expect(taskRow.getByRole("cell", {name: "succeeded", exact: true})).toBeVisible({
-    timeout: E2E_WORKER_DEPLOY_TIMEOUT_MS,
-  });
+  const statusTag = taskRow.locator("td .ant-tag");
+  try {
+    await expect.poll(async() => {
+      const status = (await statusTag.textContent())?.trim().toLowerCase();
+      if (status === "failed") {
+        throw new Error(`Deployment task ${taskId} reached failed state`);
+      }
+      return status || "pending";
+    }, {timeout: E2E_WORKER_DEPLOY_TIMEOUT_MS}).toBe("succeeded");
+  } catch (error) {
+    const alert = workerNodeDialog(page, machineName).getByRole("alert");
+    const detail = await alert.isVisible() ? await alert.innerText() : "no deployment error was shown";
+    const diagnostics = await deploymentDiagnostics(page, machineName, taskId);
+    const message = `${error.message}\nDeployment task ${taskId} failed: ${detail}\n${diagnostics}`;
+    emitGithubActionsError("Worker deployment diagnostics", message);
+    throw new Error(message);
+  }
 }
 
 async function waitForNodeReady(page, nodeName) {


### PR DESCRIPTION
## Summary

- enforce policy/image checks on user workload intent, not controller-created Pods
- recognize only exact generated control-plane identities
- extract PodSpecs version-agnostically from supported workloads
- avoid scan side effects during dry-run
- issue dedicated controller-manager and scheduler identities
- keep the broad webhook recoverable with a bounded timeout and `FailurePolicy: Ignore`

## Dependency and merge order

Depends on #106. Platform stack: #110 -> #105 -> #106 -> #107.

GitHub base remains `master` because prerequisite branches exist only in the fork; this head branch carries the prerequisite commits in its history.

## Owner review

1. **Correct:** approved workloads restart/scale without duplicate stale-result blocking; user intent remains checked.
2. **Complete:** rules, identity, decoding, scanning, certificates, kubeconfigs, and RBAC agree.
3. **Focused:** no access-data-plane or Helm behavior is included.
4. **Failure:** malformed objects fail closed; dry-run has no scan side effects; timeout/Ignore preserve recovery.
5. **Compatibility:** decoding is API-version agnostic and legacy component kubeconfigs are replaced.
6. **Concurrency:** admission is request-local and identities are deterministic/restart-safe.
7. **Ownership:** labels and ownerReferences cannot claim controller exemption.
8. **Evidence:** spoofing, malformed input, workload groups, subresources, dry-run, identity, webhook, renewal, and RBAC are tested.

Design boundary: `FailurePolicy: Ignore` is deliberate for single-node recoverability; normal authorization still runs when the webhook is reachable.

## Validation

- `go test ./server -count=1`

Fix: https://github.com/casosorg/casos/issues/101
