### PR TITLE
fix: pin cluster images in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,11 @@ jobs:
       dataSourceName: root:casos-${{ github.run_id }}-${{ github.run_attempt }}@tcp(127.0.0.1:3306)/
       dbName: casos
       socks5Proxy: ""
+      coreDNSImage: registry.k8s.io/coredns/coredns:v1.12.4
+      flannelImage: ghcr.io/flannel-io/flannel:v0.27.4
+      flannelCNIPluginImage: ghcr.io/flannel-io/flannel-cni-plugin:v1.8.0-flannel1
+      localPathProvisionerImage: docker.io/rancher/local-path-provisioner:v0.0.32
+      localPathHelperImage: docker.io/library/busybox:1.37.0
       E2E_DATA_DIR: /tmp/casos-e2e-${{ github.run_id }}-${{ github.run_attempt }}
       E2E_APISERVER_PORT: 16443
       E2E_WEBHOOK_PORT: 19443


### PR DESCRIPTION
## Summary

- pin CoreDNS, Flannel, Flannel CNI, local-path-provisioner, and BusyBox helper images for GitHub Actions UI tests
- keep production defaults on `docker.1ms.run` and leave local Playwright environment handling unchanged
- keep CI-only image selection in `.github/workflows/build.yml` so image versions have one explicit owner