### PR TITLE
fix: retry Helm downloads and extend install timeout

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -29,6 +29,8 @@ imageRegistryMirror = auto
 ; -- Helm images (optional) -------------------------------------------------
 ; Set true only when implicit/latest chart images must use IfNotPresent.
 helmImplicitLatestPullPolicy = false
+; Maximum time Helm waits for an application and its jobs to become ready.
+helmInstallTimeout = 20m
 
 ; -- Control plane ----------------------------------------------------------
 apiserverPort = 6443

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	helm.sh/helm/v3 v3.21.2
 	k8s.io/api v1.36.1-k3s1
 	k8s.io/component-base v1.36.1-k3s1
+	oras.land/oras-go/v2 v2.6.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -338,7 +339,6 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.51.0 // indirect
-	oras.land/oras-go/v2 v2.6.1 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/object/helm_operation.go
+++ b/object/helm_operation.go
@@ -191,6 +191,14 @@ func StartHelmOperationTaskContext(ctx context.Context, id int64, phase string) 
 	return nil
 }
 
+func TouchHelmOperationTaskContext(ctx context.Context, id int64) error {
+	_, err := ormer.Engine.Context(ctx).ID(id).
+		Where("status IN (?, ?)", HelmOperationStatusPending, HelmOperationStatusRunning).
+		Cols("updated_at").
+		Update(&HelmOperationTask{UpdatedAt: time.Now().UTC()})
+	return err
+}
+
 func UpdateHelmOperationTaskPhase(id int64, phase string) error {
 	return UpdateHelmOperationTaskPhaseContext(context.Background(), id, phase)
 }

--- a/object/helm_operation_recorder.go
+++ b/object/helm_operation_recorder.go
@@ -22,6 +22,7 @@ const (
 	helmOperationFinishTimeout     = HelmOperationPersistenceTimeout
 	helmOperationFinishAttempts    = 3
 	helmOperationFinishRetryDelay  = 100 * time.Millisecond
+	helmOperationHeartbeatInterval = time.Minute
 )
 
 type HelmOperationRecorder struct {
@@ -36,32 +37,36 @@ type HelmOperationRecorder struct {
 	finish    sync.Once
 	finishErr error
 
-	persistLogs      func(context.Context, int64, []*HelmOperationLog) error
-	finishTask       func(context.Context, int64, bool, string) error
-	terminalMatches  func(context.Context, int64, bool, string) (bool, error)
-	persistTimeout   time.Duration
-	shutdownTimeout  time.Duration
-	finishTimeout    time.Duration
-	finishRetryDelay time.Duration
-	persistCtx       context.Context
-	cancelPersist    context.CancelFunc
+	persistLogs       func(context.Context, int64, []*HelmOperationLog) error
+	finishTask        func(context.Context, int64, bool, string) error
+	terminalMatches   func(context.Context, int64, bool, string) (bool, error)
+	touchTask         func(context.Context, int64) error
+	persistTimeout    time.Duration
+	heartbeatInterval time.Duration
+	shutdownTimeout   time.Duration
+	finishTimeout     time.Duration
+	finishRetryDelay  time.Duration
+	persistCtx        context.Context
+	cancelPersist     context.CancelFunc
 }
 
 func NewHelmOperationRecorder(taskID int64) *HelmOperationRecorder {
 	persistCtx, cancelPersist := context.WithCancel(context.Background())
 	recorder := &HelmOperationRecorder{
-		taskID:           taskID,
-		queue:            make(chan *HelmOperationLog, helmOperationLogBatchSize*2),
-		done:             make(chan struct{}),
-		persistLogs:      addHelmOperationLogsContext,
-		finishTask:       FinishHelmOperationTaskContext,
-		terminalMatches:  HelmOperationTaskHasTerminalOutcomeContext,
-		persistTimeout:   helmOperationLogPersistTimeout,
-		shutdownTimeout:  helmOperationRecorderShutdown,
-		finishTimeout:    helmOperationFinishTimeout,
-		finishRetryDelay: helmOperationFinishRetryDelay,
-		persistCtx:       persistCtx,
-		cancelPersist:    cancelPersist,
+		taskID:            taskID,
+		queue:             make(chan *HelmOperationLog, helmOperationLogBatchSize*2),
+		done:              make(chan struct{}),
+		persistLogs:       addHelmOperationLogsContext,
+		finishTask:        FinishHelmOperationTaskContext,
+		terminalMatches:   HelmOperationTaskHasTerminalOutcomeContext,
+		touchTask:         TouchHelmOperationTaskContext,
+		persistTimeout:    helmOperationLogPersistTimeout,
+		heartbeatInterval: helmOperationHeartbeatInterval,
+		shutdownTimeout:   helmOperationRecorderShutdown,
+		finishTimeout:     helmOperationFinishTimeout,
+		finishRetryDelay:  helmOperationFinishRetryDelay,
+		persistCtx:        persistCtx,
+		cancelPersist:     cancelPersist,
 	}
 	go recorder.run()
 	return recorder
@@ -219,6 +224,8 @@ func (r *HelmOperationRecorder) run() {
 	}()
 	ticker := time.NewTicker(helmOperationLogFlushInterval)
 	defer ticker.Stop()
+	heartbeatTicker := time.NewTicker(r.heartbeatInterval)
+	defer heartbeatTicker.Stop()
 	batch := make([]*HelmOperationLog, 0, helmOperationLogBatchSize)
 	flush := func() {
 		if len(batch) == 0 {
@@ -247,6 +254,13 @@ func (r *HelmOperationRecorder) run() {
 			}
 		case <-ticker.C:
 			flush()
+		case <-heartbeatTicker.C:
+			ctx, cancel := context.WithTimeout(r.persistCtx, r.persistTimeout)
+			err := r.touchTask(ctx, r.taskID)
+			cancel()
+			if err != nil && !errors.Is(err, context.Canceled) {
+				logs.Warning("refresh Helm operation task %d heartbeat: %v", r.taskID, err)
+			}
 		}
 	}
 }

--- a/store/helm.go
+++ b/store/helm.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -44,15 +43,13 @@ import (
 )
 
 const (
-	helmOperationTimeout        = 5 * time.Minute
-	helmInstallTimeout          = 10 * time.Minute
-	helmCompatibilityTimeout    = 2 * time.Minute
-	helmChartLoadTimeout        = 2 * time.Minute
-	helmDiagnosticsTimeout      = 15 * time.Second
-	helmInstallOperationTimeout = helmChartLoadTimeout + helmCompatibilityTimeout + helmInstallTimeout + helmDiagnosticsTimeout
-	helmDiagnosticsMaxEvents    = 20
-	helmDiagnosticsMessageLen   = 240
-	helmDiagnosticsEventLen     = 360
+	helmOperationTimeout      = 5 * time.Minute
+	helmCompatibilityTimeout  = 2 * time.Minute
+	helmChartLoadTimeout      = 2 * time.Minute
+	helmDiagnosticsTimeout    = 15 * time.Second
+	helmDiagnosticsMaxEvents  = 20
+	helmDiagnosticsMessageLen = 240
+	helmDiagnosticsEventLen   = 360
 )
 
 // ---------- Types ----------
@@ -283,34 +280,17 @@ func httpClientWithContext(ctx context.Context, base *http.Client) *http.Client 
 	return &client
 }
 
-func helmGet(ctx context.Context, url string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("User-Agent", "Helm/3.21.2")
-	return proxypkg.ProxyHttpClient.Do(req)
-}
-
 // ---------- Repo index ----------
 
 func fetchIndexFile(ctx context.Context, repoURL string) (*repo.IndexFile, error) {
 	indexURL := strings.TrimRight(repoURL, "/") + "/index.yaml"
-	resp, err := helmGet(ctx, indexURL)
+	data, err := downloadHelmRepoIndex(ctx, indexURL)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"fetch index %q: %w",
 			redactURLForError(indexURL),
 			sanitizeErrorMessage(err, indexURL, repoURL),
 		)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("index returned HTTP %d", resp.StatusCode)
-	}
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
 	}
 	// Use sigs.k8s.io/yaml (YAML→JSON→struct) so that embedded pointer fields
 	// like *chart.Metadata inside ChartVersion are properly allocated. Plain
@@ -426,7 +406,8 @@ func isOCIChartTag(tag string) bool {
 }
 
 func newOCIRegistryClient(ctx context.Context) (*registry.Client, error) {
-	return registry.NewClient(registry.ClientOptHTTPClient(httpClientWithContext(ctx, proxypkg.ProxyHttpClient)))
+	client := newOCIRegistryHTTPClient(proxypkg.ProxyHttpClient)
+	return registry.NewClient(registry.ClientOptHTTPClient(httpClientWithContext(ctx, client)))
 }
 
 // pullOCIChart pulls the chart hosted at repoURL, resolving to the newest published
@@ -441,7 +422,12 @@ func pullOCIChart(ctx context.Context, repoURL, version string) (*registry.PullR
 
 	if resolvedVersion == "" {
 		if !strings.Contains(ref, "@") {
-			tags, err := rc.Tags(ref)
+			var tags []string
+			err = retryOCIRegistryOperation(ctx, func() error {
+				var tagsErr error
+				tags, tagsErr = rc.Tags(ref)
+				return tagsErr
+			})
 			if err != nil {
 				return nil, fmt.Errorf(
 					"list oci tags for %q: %w",
@@ -466,8 +452,18 @@ func pullOCIChart(ctx context.Context, repoURL, version string) (*registry.PullR
 		}
 		pullRef = fmt.Sprintf("%s:%s", ref, resolvedVersion)
 	}
+	if cached, ok, err := cachedOCIChartPull(pullRef); err != nil {
+		return nil, err
+	} else if ok {
+		return cached, nil
+	}
 
-	pull, err := rc.Pull(pullRef, registry.PullOptWithChart(true))
+	var pull *registry.PullResult
+	err = retryOCIRegistryOperation(ctx, func() error {
+		var pullErr error
+		pull, pullErr = rc.Pull(pullRef, registry.PullOptWithChart(true))
+		return pullErr
+	})
 	if err != nil {
 		return nil, fmt.Errorf(
 			"pull oci chart %q: %w",
@@ -475,7 +471,33 @@ func pullOCIChart(ctx context.Context, repoURL, version string) (*registry.PullR
 			sanitizeErrorMessage(err, repoURL, ref, pullRef),
 		)
 	}
+	cacheOCIChartPull(pullRef, pull)
 	return pull, nil
+}
+
+func cachedOCIChartPull(pullRef string) (*registry.PullResult, bool, error) {
+	data, ok := defaultHelmArtifactCache.get("oci-chart:" + pullRef)
+	if !ok {
+		return nil, false, nil
+	}
+	loaded, err := loader.LoadArchive(bytes.NewReader(data))
+	if err != nil {
+		return nil, true, fmt.Errorf("load cached oci chart %q: %w", redactURLForError(pullRef), err)
+	}
+	return &registry.PullResult{
+		Chart: &registry.DescriptorPullSummaryWithMeta{
+			DescriptorPullSummary: registry.DescriptorPullSummary{Data: data, Size: int64(len(data))},
+			Meta:                  loaded.Metadata,
+		},
+		Ref: pullRef,
+	}, true, nil
+}
+
+func cacheOCIChartPull(pullRef string, pull *registry.PullResult) {
+	if pull == nil || pull.Chart == nil || len(pull.Chart.Data) == 0 {
+		return
+	}
+	defaultHelmArtifactCache.put("oci-chart:"+pullRef, pull.Chart.Data)
 }
 
 func latestOCISemverTag(tags []string) string {
@@ -790,7 +812,7 @@ func loadChartWithContext(parent context.Context, chartName, repoURL, version st
 		chartURL = strings.TrimRight(repoURL, "/") + "/" + strings.TrimLeft(chartURL, "/")
 	}
 
-	resp, err := helmGet(ctx, chartURL)
+	data, err := downloadHelmArtifact(ctx, chartURL)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"load chart %q from repo %q version %q: download chart archive %q failed: %w",
@@ -799,29 +821,6 @@ func loadChartWithContext(parent context.Context, chartName, repoURL, version st
 			entry.Version,
 			redactURLForError(chartURL),
 			sanitizeErrorMessage(err, chartURL, repoURL),
-		)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf(
-			"load chart %q from repo %q version %q: chart archive %q returned HTTP %d",
-			chartName,
-			redactURLForError(repoURL),
-			entry.Version,
-			redactURLForError(chartURL),
-			resp.StatusCode,
-		)
-	}
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"load chart %q from repo %q version %q: read chart archive %q failed: %w",
-			chartName,
-			redactURLForError(repoURL),
-			entry.Version,
-			redactURLForError(chartURL),
-			err,
 		)
 	}
 	ch, err := loader.LoadArchive(bytes.NewReader(data))
@@ -1260,6 +1259,10 @@ func InstallHelmChartWithValuesBaseline(cfg *rest.Config, releaseName, namespace
 }
 
 func installHelmChart(cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string) error {
+	installTimeout, err := configuredHelmInstallTimeout()
+	if err != nil {
+		return err
+	}
 	actionConfig, err := newHelmConfig(cfg, namespace)
 	if err != nil {
 		return err
@@ -1292,17 +1295,17 @@ func installHelmChart(cfg *rest.Config, releaseName, namespace, chartName, repoU
 		return err
 	}
 	install := action.NewInstall(actionConfig)
-	install.ReleaseName = releaseName
-	install.Namespace = namespace
-	install.CreateNamespace = true
-	install.Wait = true
-	install.WaitForJobs = true
-	install.Timeout = helmInstallTimeout
-	install.PostRenderer = configuredLocalImagePullPolicyPostRenderer()
+	configureHelmInstall(install, releaseName, namespace, installTimeout)
 
-	_, err = install.Run(ch, vals)
+	failedRelease, err := install.Run(ch, vals)
 	if err != nil {
-		return withHelmReleaseDiagnostics(context.Background(), cfg, releaseName, namespace, err)
+		return finishFailedHelmInstall(
+			err,
+			func(installErr error) error {
+				return withHelmReleaseDiagnostics(context.Background(), cfg, releaseName, namespace, installErr)
+			},
+			func() error { return cleanupFailedHelmRelease(actionConfig, install, failedRelease) },
+		)
 	}
 	reportHelmReadiness(inspectHelmReleaseResources(context.Background(), cfg, releaseName, namespace), func(message string) {
 		logrus.Warn(message)
@@ -1341,8 +1344,6 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 		if streamCtx == nil {
 			streamCtx = context.Background()
 		}
-		installCtx, cancelInstall := context.WithTimeout(context.WithoutCancel(streamCtx), helmInstallOperationTimeout)
-		defer cancelInstall()
 		send := func(line string) bool {
 			if err := lifecycle.RecordLog(line); err != nil {
 				logrus.Warnf("failed to persist Helm operation log: %v", err)
@@ -1361,6 +1362,19 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 			}
 			return
 		}
+		installTimeout, err := configuredHelmInstallTimeout()
+		if err != nil {
+			send("ERROR: " + err.Error())
+			if finishErr := lifecycle.Finish(err); finishErr != nil {
+				logrus.Errorf("failed to finish Helm operation after configuration error: %v", finishErr)
+			}
+			return
+		}
+		installCtx, cancelInstall := context.WithTimeout(
+			context.WithoutCancel(streamCtx),
+			helmInstallOperationDeadline(installTimeout),
+		)
+		defer cancelInstall()
 		logFn := func(format string, args ...interface{}) {
 			send(fmt.Sprintf(format, args...))
 		}
@@ -1424,17 +1438,19 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 			return
 		}
 		install := action.NewInstall(actionConfig)
-		install.ReleaseName = releaseName
-		install.Namespace = namespace
-		install.CreateNamespace = true
-		install.Wait = true
-		install.WaitForJobs = true
-		install.Timeout = helmInstallTimeout
-		install.PostRenderer = configuredLocalImagePullPolicyPostRenderer()
-		if _, err = install.RunWithContext(installCtx, helmChart, vals); err != nil {
-			for _, line := range helmReleaseDiagnostics(installCtx, cfg, releaseName, namespace) {
-				send(line)
-			}
+		configureHelmInstall(install, releaseName, namespace, installTimeout)
+		failedRelease, installErr := install.RunWithContext(installCtx, helmChart, vals)
+		if installErr != nil {
+			err = finishFailedHelmInstall(
+				installErr,
+				func(installErr error) error {
+					for _, line := range helmReleaseDiagnostics(installCtx, cfg, releaseName, namespace) {
+						send(line)
+					}
+					return installErr
+				},
+				func() error { return cleanupFailedHelmRelease(actionConfig, install, failedRelease) },
+			)
 			send("ERROR: " + err.Error())
 			if finishErr := lifecycle.Finish(err); finishErr != nil {
 				logrus.Errorf("failed to finish Helm operation after install error: %v", finishErr)

--- a/store/helm_download.go
+++ b/store/helm_download.go
@@ -1,0 +1,434 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	proxypkg "github.com/casosorg/casos/proxy"
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+const (
+	helmDownloadAttemptTimeout      = 2 * time.Minute
+	helmRegistryConnectTimeout      = 30 * time.Second
+	helmRegistryTLSHandshakeTimeout = 30 * time.Second
+	helmDownloadCacheTTL            = 15 * time.Minute
+	helmDownloadCacheEntries        = 32
+	helmDownloadCacheBytes          = 128 << 20
+)
+
+var defaultHelmArtifactCache = newHelmArtifactCache(helmDownloadCacheTTL, helmDownloadCacheEntries, helmDownloadCacheBytes)
+
+func newOCIRegistryHTTPClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	clonedClient := *client
+	clonedClient.Timeout = 0
+
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	if httpTransport, ok := transport.(*http.Transport); ok {
+		clonedTransport := httpTransport.Clone()
+		configureOCIRegistryDialTimeout(clonedTransport, helmRegistryConnectTimeout)
+		clonedTransport.TLSHandshakeTimeout = helmRegistryTLSHandshakeTimeout
+		clonedTransport.ResponseHeaderTimeout = helmDownloadAttemptTimeout
+		clonedClient.Transport = clonedTransport
+	}
+	return &clonedClient
+}
+
+func configureOCIRegistryDialTimeout(transport *http.Transport, timeout time.Duration) {
+	if transport == nil || timeout <= 0 {
+		return
+	}
+	if transport.DialContext != nil {
+		dialContext := transport.DialContext
+		transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			return dialContext(dialCtx, network, address)
+		}
+		return
+	}
+	if transport.Dial != nil {
+		dial := transport.Dial
+		transport.Dial = nil
+		transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			type dialResult struct {
+				conn net.Conn
+				err  error
+			}
+			resultCh := make(chan dialResult)
+			go func() {
+				result := dialResult{}
+				result.conn, result.err = dial(network, address)
+				select {
+				case resultCh <- result:
+				case <-dialCtx.Done():
+					if result.conn != nil {
+						_ = result.conn.Close()
+					}
+				}
+			}()
+			select {
+			case result := <-resultCh:
+				return result.conn, result.err
+			case <-dialCtx.Done():
+				return nil, dialCtx.Err()
+			}
+		}
+		return
+	}
+	dialer := &net.Dialer{Timeout: timeout, KeepAlive: 30 * time.Second}
+	transport.DialContext = dialer.DialContext
+}
+
+func downloadHelmArtifact(ctx context.Context, rawURL string) ([]byte, error) {
+	downloader := newHelmArtifactDownloader(
+		proxypkg.ProxyHttpClient,
+		helmDownloadAttemptTimeout,
+		[]time.Duration{time.Second, 3 * time.Second},
+		defaultHelmArtifactCache,
+	)
+	return downloader.download(ctx, rawURL)
+}
+
+func downloadHelmRepoIndex(ctx context.Context, rawURL string) ([]byte, error) {
+	downloader := newHelmArtifactDownloader(
+		proxypkg.ProxyHttpClient,
+		helmDownloadAttemptTimeout,
+		[]time.Duration{time.Second, 3 * time.Second},
+		defaultHelmArtifactCache,
+	)
+	downloader.revalidate = true
+	return downloader.download(ctx, rawURL)
+}
+
+type helmHTTPStatusError struct {
+	statusCode int
+}
+
+func (e *helmHTTPStatusError) Error() string {
+	return fmt.Sprintf("HTTP %d", e.statusCode)
+}
+
+type helmArtifactDownloader struct {
+	client         *http.Client
+	attemptTimeout time.Duration
+	retryDelays    []time.Duration
+	cache          *helmArtifactCache
+	revalidate     bool
+}
+
+type helmArtifactDownload struct {
+	data         []byte
+	etag         string
+	lastModified string
+	notModified  bool
+}
+
+func newHelmArtifactDownloader(client *http.Client, attemptTimeout time.Duration, retryDelays []time.Duration, cache *helmArtifactCache) *helmArtifactDownloader {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &helmArtifactDownloader{
+		client:         client,
+		attemptTimeout: attemptTimeout,
+		retryDelays:    append([]time.Duration(nil), retryDelays...),
+		cache:          cache,
+	}
+}
+
+func (d *helmArtifactDownloader) download(ctx context.Context, rawURL string) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var cached *helmArtifactCacheEntry
+	if d.cache != nil {
+		if entry, ok := d.cache.getEntry(rawURL); ok {
+			if !d.revalidate {
+				return entry.data, nil
+			}
+			cached = &entry
+		}
+	}
+
+	for attempt := 0; ; attempt++ {
+		result, err := d.downloadOnce(ctx, rawURL, cached)
+		if err == nil {
+			if result.notModified {
+				if cached == nil {
+					return nil, fmt.Errorf("HTTP %d without cached data", http.StatusNotModified)
+				}
+				if d.cache != nil {
+					d.cache.refresh(rawURL)
+				}
+				return cached.data, nil
+			}
+			if d.cache != nil {
+				d.cache.putWithMetadata(rawURL, result.data, result.etag, result.lastModified)
+			}
+			return result.data, nil
+		}
+		if ctx.Err() != nil || attempt >= len(d.retryDelays) || !isRetryableHelmDownloadError(err) {
+			return nil, err
+		}
+		if err := waitForHelmDownloadRetry(ctx, d.retryDelays[attempt]); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (d *helmArtifactDownloader) downloadOnce(ctx context.Context, rawURL string, cached *helmArtifactCacheEntry) (*helmArtifactDownload, error) {
+	attemptCtx := ctx
+	cancel := func() {}
+	if d.attemptTimeout > 0 {
+		attemptCtx, cancel = context.WithTimeout(ctx, d.attemptTimeout)
+	}
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Helm/3.21.2")
+	if cached != nil {
+		if cached.etag != "" {
+			req.Header.Set("If-None-Match", cached.etag)
+		}
+		if cached.lastModified != "" {
+			req.Header.Set("If-Modified-Since", cached.lastModified)
+		}
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotModified {
+		return &helmArtifactDownload{notModified: true}, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &helmHTTPStatusError{statusCode: resp.StatusCode}
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &helmArtifactDownload{
+		data:         data,
+		etag:         resp.Header.Get("ETag"),
+		lastModified: resp.Header.Get("Last-Modified"),
+	}, nil
+}
+
+func isRetryableHelmDownloadError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) && (networkError.Timeout() || networkError.Temporary()) {
+		return true
+	}
+	var statusError *helmHTTPStatusError
+	if errors.As(err, &statusError) {
+		return statusError.statusCode == http.StatusRequestTimeout ||
+			statusError.statusCode == http.StatusTooManyRequests ||
+			(statusError.statusCode >= http.StatusInternalServerError && statusError.statusCode < 600)
+	}
+	return false
+}
+
+func waitForHelmDownloadRetry(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func retryOCIRegistryOperation(ctx context.Context, operation func() error) error {
+	return retryOCIRegistryOperationWithDelays(ctx, operation, []time.Duration{
+		500 * time.Millisecond,
+		1500 * time.Millisecond,
+	})
+}
+
+func retryOCIRegistryOperationWithDelays(ctx context.Context, operation func() error, delays []time.Duration) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for attempt := 0; ; attempt++ {
+		err := operation()
+		if err == nil {
+			return nil
+		}
+		if attempt >= len(delays) || !isRetryableOCIRegistryError(err) {
+			return err
+		}
+		if err := waitForHelmDownloadRetry(ctx, delays[attempt]); err != nil {
+			return err
+		}
+	}
+}
+
+func isRetryableOCIRegistryError(err error) bool {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) && (networkError.Timeout() || networkError.Temporary()) {
+		return true
+	}
+	var operationError *net.OpError
+	if errors.As(err, &operationError) {
+		return true
+	}
+	var responseError *errcode.ErrorResponse
+	if errors.As(err, &responseError) {
+		return responseError.StatusCode == http.StatusRequestTimeout ||
+			responseError.StatusCode == http.StatusTooManyRequests ||
+			(responseError.StatusCode >= http.StatusInternalServerError && responseError.StatusCode < 600)
+	}
+	return false
+}
+
+type helmArtifactCacheEntry struct {
+	data         []byte
+	etag         string
+	lastModified string
+	lastAccess   uint64
+	expiresAt    time.Time
+}
+
+type helmArtifactCache struct {
+	mu         sync.Mutex
+	entries    map[string]helmArtifactCacheEntry
+	ttl        time.Duration
+	maxEntries int
+	maxBytes   int
+	usedBytes  int
+	accessSeq  uint64
+}
+
+func newHelmArtifactCache(ttl time.Duration, maxEntries, maxBytes int) *helmArtifactCache {
+	return &helmArtifactCache{
+		entries:    make(map[string]helmArtifactCacheEntry),
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		maxBytes:   maxBytes,
+	}
+}
+
+func (c *helmArtifactCache) get(key string) ([]byte, bool) {
+	entry, ok := c.getEntry(key)
+	if !ok {
+		return nil, false
+	}
+	return entry.data, true
+}
+
+func (c *helmArtifactCache) getEntry(key string) (helmArtifactCacheEntry, bool) {
+	if c == nil || c.ttl <= 0 || c.maxEntries <= 0 || c.maxBytes <= 0 {
+		return helmArtifactCacheEntry{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return helmArtifactCacheEntry{}, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		c.deleteLocked(key, entry)
+		return helmArtifactCacheEntry{}, false
+	}
+	c.accessSeq++
+	entry.lastAccess = c.accessSeq
+	c.entries[key] = entry
+	// Cache entries are immutable after insertion; callers must treat this
+	// shared slice as read-only so large indexes and charts are not copied.
+	return entry, true
+}
+
+func (c *helmArtifactCache) put(key string, data []byte) {
+	c.putWithMetadata(key, data, "", "")
+}
+
+func (c *helmArtifactCache) putWithMetadata(key string, data []byte, etag, lastModified string) {
+	if c == nil || c.ttl <= 0 || c.maxEntries <= 0 || c.maxBytes <= 0 || len(data) > c.maxBytes {
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for existingKey, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			c.deleteLocked(existingKey, entry)
+		}
+	}
+	if entry, ok := c.entries[key]; ok {
+		c.deleteLocked(key, entry)
+	}
+	for len(c.entries) >= c.maxEntries || c.usedBytes+len(data) > c.maxBytes {
+		leastRecentlyUsedKey := ""
+		var leastRecentlyUsedEntry helmArtifactCacheEntry
+		for existingKey, entry := range c.entries {
+			if leastRecentlyUsedKey == "" || entry.lastAccess < leastRecentlyUsedEntry.lastAccess {
+				leastRecentlyUsedKey = existingKey
+				leastRecentlyUsedEntry = entry
+			}
+		}
+		if leastRecentlyUsedKey == "" {
+			break
+		}
+		c.deleteLocked(leastRecentlyUsedKey, leastRecentlyUsedEntry)
+	}
+	cloned := append([]byte(nil), data...)
+	c.accessSeq++
+	c.entries[key] = helmArtifactCacheEntry{
+		data:         cloned,
+		etag:         etag,
+		lastModified: lastModified,
+		lastAccess:   c.accessSeq,
+		expiresAt:    now.Add(c.ttl),
+	}
+	c.usedBytes += len(cloned)
+}
+
+func (c *helmArtifactCache) refresh(key string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return
+	}
+	c.accessSeq++
+	entry.lastAccess = c.accessSeq
+	entry.expiresAt = time.Now().Add(c.ttl)
+	c.entries[key] = entry
+}
+
+func (c *helmArtifactCache) deleteLocked(key string, entry helmArtifactCacheEntry) {
+	delete(c.entries, key)
+	c.usedBytes -= len(entry.data)
+}

--- a/store/helm_install.go
+++ b/store/helm_install.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
+
+	"github.com/casosorg/casos/conf"
+)
+
+const defaultHelmInstallTimeout = 20 * time.Minute
+
+func helmInstallOperationDeadline(installTimeout time.Duration) time.Duration {
+	return helmChartLoadTimeout + helmCompatibilityTimeout + installTimeout + helmDiagnosticsTimeout
+}
+
+func configuredHelmInstallTimeout() (time.Duration, error) {
+	return parseHelmInstallTimeout(conf.GetConfigString("helmInstallTimeout"))
+}
+
+func parseHelmInstallTimeout(raw string) (time.Duration, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultHelmInstallTimeout, nil
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid helmInstallTimeout %q: %w", raw, err)
+	}
+	if timeout <= 0 {
+		return 0, fmt.Errorf("helmInstallTimeout must be greater than zero")
+	}
+	return timeout, nil
+}
+
+func configureHelmInstall(install *action.Install, releaseName, namespace string, timeout time.Duration) {
+	install.ReleaseName = releaseName
+	install.Namespace = namespace
+	install.CreateNamespace = true
+	install.Wait = true
+	install.WaitForJobs = true
+	install.Timeout = timeout
+	install.PostRenderer = configuredLocalImagePullPolicyPostRenderer()
+}
+
+func finishFailedHelmInstall(installErr error, diagnose func(error) error, cleanup func() error) error {
+	if diagnose != nil {
+		installErr = diagnose(installErr)
+	}
+	if cleanupErr := cleanup(); cleanupErr != nil {
+		return errors.Join(installErr, fmt.Errorf("clean up failed Helm release: %w", cleanupErr))
+	}
+	return installErr
+}
+
+func cleanupFailedHelmRelease(actionConfig *action.Configuration, install *action.Install, failedRelease *release.Release) error {
+	if failedRelease == nil || failedRelease.Info == nil || failedRelease.Info.Status != release.StatusFailed {
+		return nil
+	}
+	currentRelease, err := actionConfig.Releases.Last(install.ReleaseName)
+	if errors.Is(err, driver.ErrReleaseNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("verify failed Helm release before cleanup: %w", err)
+	}
+	if !shouldCleanupFailedHelmRelease(failedRelease, currentRelease) {
+		return nil
+	}
+
+	uninstall := action.NewUninstall(actionConfig)
+	uninstall.DisableHooks = install.DisableHooks
+	uninstall.KeepHistory = false
+	uninstall.Timeout = install.Timeout
+	_, err = uninstall.Run(install.ReleaseName)
+	if errors.Is(err, driver.ErrReleaseNotFound) {
+		return nil
+	}
+	return err
+}
+
+func shouldCleanupFailedHelmRelease(failedRelease, currentRelease *release.Release) bool {
+	if failedRelease == nil || failedRelease.Info == nil || failedRelease.Info.Status != release.StatusFailed ||
+		currentRelease == nil || currentRelease.Info == nil ||
+		failedRelease.Name != currentRelease.Name || failedRelease.Version != currentRelease.Version {
+		return false
+	}
+	return currentRelease.Info.Status == release.StatusFailed || currentRelease.Info.Status == release.StatusPendingInstall
+}


### PR DESCRIPTION
## Summary

- retry transient classic-repository and OCI downloads and reuse chart artifacts through a bounded in-process cache
- add a configurable `helmInstallTimeout` with a 20-minute default and refresh active task timestamps during long installs
- collect diagnostics before cleaning up a failed release, and clean up only when the failed revision is still current
- apply bounded connection, TLS, response-header, retry, and detached-operation timing

## Compatibility and failure behavior

The new timeout is backward compatible when omitted and rejects invalid values before installation. Retries are finite and exclude permanent errors. The cache is synchronized, time-limited, memory-bounded, and process-local; no API, database schema, application values, or image source changes.

## Validation

- `go test ./store ./object -tags skipCi -count=1`
- `go test ./... -tags skipCi -count=1`
- `go vet ./...`
- `git diff --check`
- local timeout, task-heartbeat, cache, OCI, install, diagnostics, and cleanup checks
