### PR TITLE
feat: strengthen Helm compatibility validation

### DIFF
--- a/controllers/helm.go
+++ b/controllers/helm.go
@@ -19,6 +19,28 @@ import (
 
 const helmOperationTaskNotFoundCode = "helm_task_not_found"
 
+func helmErrorResponse(err error) Response {
+	response := Response{Status: "error", Msg: err.Error()}
+	if info, ok := store.HelmCompatibilityErrorInfoFrom(err); ok {
+		response.Data = info
+	}
+	return response
+}
+
+func (c *ApiController) responseHelmError(err error) {
+	c.Data["json"] = helmErrorResponse(err)
+	c.ServeJSON()
+}
+
+func writeHelmInstallStreamEvent(w io.Writer, event store.HelmInstallStreamEvent) error {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal Helm install stream event: %w", err)
+	}
+	_, err = fmt.Fprintf(w, "data: %s\n\n", payload)
+	return err
+}
+
 // ---------- ArtifactHub proxy ----------
 
 type ahSearchResult struct {
@@ -214,7 +236,7 @@ func (c *ApiController) InstallHelmChart() {
 		return
 	}
 	if err := store.InstallHelmChartWithValuesBaseline(cfg, req.ReleaseName, req.Namespace, req.ChartName, req.RepoURL, req.Version, req.ValuesYAML, req.ValuesBaselineYAML); err != nil {
-		c.ResponseError(err.Error())
+		c.responseHelmError(err)
 		return
 	}
 	c.ResponseOk()
@@ -226,32 +248,29 @@ func (c *ApiController) InstallHelmChartStream() {
 	if c.RequireAdmin() {
 		return
 	}
+	w := c.Ctx.ResponseWriter.ResponseWriter
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
 	cfg := getAdminRestConfig()
 	if cfg == nil {
-		c.Ctx.ResponseWriter.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprintf(c.Ctx.ResponseWriter.ResponseWriter, "data: ERROR: cluster not ready\n\n")
+		_ = writeHelmInstallStreamEvent(w, store.HelmInstallStreamEvent{Type: store.HelmInstallStreamEventError, Message: "cluster not ready"})
 		c.StopRun()
 		return
 	}
 	var req helmInstallReq
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &req); err != nil {
-		c.Ctx.ResponseWriter.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprintf(c.Ctx.ResponseWriter.ResponseWriter, "data: ERROR: %s\n\n", err.Error())
+		_ = writeHelmInstallStreamEvent(w, store.HelmInstallStreamEvent{Type: store.HelmInstallStreamEventError, Message: err.Error()})
 		c.StopRun()
 		return
 	}
 	owner := helmOperationOwner(c)
 	if owner == "" {
-		c.Ctx.ResponseWriter.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(c.Ctx.ResponseWriter.ResponseWriter, "data: ERROR: unable to identify Helm operation owner\n\n")
+		_ = writeHelmInstallStreamEvent(w, store.HelmInstallStreamEvent{Type: store.HelmInstallStreamEventError, Message: "unable to identify Helm operation owner"})
 		c.StopRun()
 		return
 	}
 
-	w := c.Ctx.ResponseWriter.ResponseWriter
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 
 	ctx := c.Ctx.Request.Context()
@@ -263,7 +282,7 @@ func (c *ApiController) InstallHelmChartStream() {
 		} else {
 			logs.Error("create Helm operation task: %v", err)
 		}
-		fmt.Fprintf(w, "data: ERROR: %s\n\n", message)
+		_ = writeHelmInstallStreamEvent(w, store.HelmInstallStreamEvent{Type: store.HelmInstallStreamEventError, Message: message})
 		c.StopRun()
 		return
 	}
@@ -274,7 +293,7 @@ func (c *ApiController) InstallHelmChartStream() {
 			logs.Error("finish unstarted Helm operation task %d: %v", task.Id, finishErr)
 		}
 	}
-	if _, err := fmt.Fprintf(w, "data: TASK_ID:%d\n\n", task.Id); err != nil {
+	if err := writeHelmInstallStreamEvent(w, store.HelmInstallStreamEvent{Type: store.HelmInstallStreamEventLog, Message: fmt.Sprintf("TASK_ID:%d", task.Id)}); err != nil {
 		finishUnstartedTask(fmt.Errorf("failed to send Helm operation task id: %w", err))
 		c.StopRun()
 		return
@@ -287,8 +306,8 @@ func (c *ApiController) InstallHelmChartStream() {
 	}
 	recorder := object.NewHelmOperationRecorder(task.Id)
 	logCh := store.InstallHelmChartStreamWithValuesBaseline(ctx, recorder, cfg, req.ReleaseName, req.Namespace, req.ChartName, req.RepoURL, req.Version, req.ValuesYAML, req.ValuesBaselineYAML)
-	for line := range logCh {
-		if _, err := fmt.Fprintf(w, "data: %s\n\n", line); err != nil {
+	for event := range logCh {
+		if err := writeHelmInstallStreamEvent(w, event); err != nil {
 			break
 		}
 		if err := responseController.Flush(); err != nil {
@@ -371,7 +390,7 @@ func (c *ApiController) UpgradeHelmRelease() {
 		return
 	}
 	if err := store.UpgradeHelmReleaseWithValuesBaseline(cfg, req.ReleaseName, req.Namespace, req.ChartName, req.RepoURL, req.Version, req.ValuesYAML, req.ValuesBaselineYAML); err != nil {
-		c.ResponseError(err.Error())
+		c.responseHelmError(err)
 		return
 	}
 	c.ResponseOk()
@@ -400,7 +419,7 @@ func (c *ApiController) RollbackHelmRelease() {
 		return
 	}
 	if err := store.RollbackHelmRelease(cfg, req.ReleaseName, req.Namespace, req.Revision); err != nil {
-		c.ResponseError(err.Error())
+		c.responseHelmError(err)
 		return
 	}
 	c.ResponseOk()

--- a/store/helm.go
+++ b/store/helm.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -1320,54 +1321,93 @@ type HelmInstallLifecycle interface {
 	Finish(installErr error) error
 }
 
+const (
+	HelmInstallStreamEventLog     = "log"
+	HelmInstallStreamEventWarning = "warning"
+	HelmInstallStreamEventError   = "error"
+	HelmInstallStreamEventDone    = "done"
+)
+
+type HelmInstallStreamEvent struct {
+	Type    string                      `json:"type"`
+	Message string                      `json:"message,omitempty"`
+	Error   *HelmCompatibilityErrorInfo `json:"error,omitempty"`
+}
+
+func newHelmErrorEvent(err error) HelmInstallStreamEvent {
+	event := HelmInstallStreamEvent{Type: HelmInstallStreamEventError, Message: err.Error()}
+	if info, ok := HelmCompatibilityErrorInfoFrom(err); ok {
+		event.Error = &info
+	}
+	return event
+}
+
 // InstallHelmChartStream runs a Helm install independently of the browser
 // request. Lifecycle persistence is supplied by the caller so store remains
 // independent of the database layer.
-func InstallHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML string) <-chan string {
+func InstallHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML string) <-chan HelmInstallStreamEvent {
 	return installHelmChartStream(ctx, lifecycle, cfg, releaseName, namespace, chartName, repoURL, version, valuesYAML, "")
 }
 
-func InstallHelmChartStreamWithValuesBaseline(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string) <-chan string {
+func InstallHelmChartStreamWithValuesBaseline(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string) <-chan HelmInstallStreamEvent {
 	return installHelmChartStream(ctx, lifecycle, cfg, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML)
 }
 
-func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string) <-chan string {
-	logCh := make(chan string, 64)
+func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string) <-chan HelmInstallStreamEvent {
+	eventCh := make(chan HelmInstallStreamEvent, 64)
 	if lifecycle == nil {
-		logCh <- "ERROR: Helm install lifecycle is required"
-		close(logCh)
-		return logCh
+		eventCh <- newHelmErrorEvent(errors.New("Helm install lifecycle is required"))
+		close(eventCh)
+		return eventCh
 	}
 	go func() {
-		defer close(logCh)
+		defer close(eventCh)
 		streamCtx := ctx
 		if streamCtx == nil {
 			streamCtx = context.Background()
 		}
-		send := func(line string) bool {
-			if err := lifecycle.RecordLog(line); err != nil {
-				logrus.Warnf("failed to persist Helm operation log: %v", err)
+		send := func(event HelmInstallStreamEvent) bool {
+			persistedMessage := event.Message
+			switch event.Type {
+			case HelmInstallStreamEventError:
+				persistedMessage = "ERROR: " + event.Message
+			case HelmInstallStreamEventWarning:
+				persistedMessage = "WARNING: " + event.Message
+			}
+			if persistedMessage != "" {
+				if err := lifecycle.RecordLog(persistedMessage); err != nil {
+					logrus.Warnf("failed to persist Helm operation log: %v", err)
+				}
 			}
 			select {
-			case logCh <- line:
+			case eventCh <- event:
 				return true
 			case <-streamCtx.Done():
 				return false
 			}
 		}
-		if err := lifecycle.StartLoading(); err != nil {
-			send("ERROR: " + err.Error())
+		sendLog := func(message string) bool {
+			return send(HelmInstallStreamEvent{Type: HelmInstallStreamEventLog, Message: message})
+		}
+		sendWarning := func(message string) bool {
+			return send(HelmInstallStreamEvent{Type: HelmInstallStreamEventWarning, Message: message})
+		}
+		sendError := func(err error) bool {
+			return send(newHelmErrorEvent(err))
+		}
+		finishWithError := func(err error, context string) {
+			sendError(err)
 			if finishErr := lifecycle.Finish(err); finishErr != nil {
-				logrus.Errorf("failed to finish Helm operation after loading error: %v", finishErr)
+				logrus.Errorf("failed to finish Helm operation after %s: %v", context, finishErr)
 			}
+		}
+		if err := lifecycle.StartLoading(); err != nil {
+			finishWithError(err, "loading error")
 			return
 		}
 		installTimeout, err := configuredHelmInstallTimeout()
 		if err != nil {
-			send("ERROR: " + err.Error())
-			if finishErr := lifecycle.Finish(err); finishErr != nil {
-				logrus.Errorf("failed to finish Helm operation after configuration error: %v", finishErr)
-			}
+			finishWithError(err, "configuration error")
 			return
 		}
 		installCtx, cancelInstall := context.WithTimeout(
@@ -1376,65 +1416,46 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 		)
 		defer cancelInstall()
 		logFn := func(format string, args ...interface{}) {
-			send(fmt.Sprintf(format, args...))
+			sendLog(fmt.Sprintf(format, args...))
 		}
 		actionConfig, err := newHelmConfigWithLog(cfg, namespace, logFn)
 		if err != nil {
-			send("ERROR: " + err.Error())
-			if finishErr := lifecycle.Finish(err); finishErr != nil {
-				logrus.Errorf("failed to finish Helm operation after configuration error: %v", finishErr)
-			}
+			finishWithError(err, "configuration error")
 			return
 		}
 		helmChart, err := loadChartWithContext(installCtx, chartName, repoURL, version)
 		if err != nil {
-			send("ERROR: " + err.Error())
-			if finishErr := lifecycle.Finish(err); finishErr != nil {
-				logrus.Errorf("failed to finish Helm operation after chart loading error: %v", finishErr)
-			}
+			finishWithError(err, "chart loading error")
 			return
 		}
 		valuesYAML, inputIsOverrides, err := getHelmValueOverrides(valuesYAML, valuesBaselineYAML)
 		if err != nil {
-			send("ERROR: " + err.Error())
-			if finishErr := lifecycle.Finish(err); finishErr != nil {
-				logrus.Errorf("failed to finish Helm operation after value override parsing error: %v", finishErr)
-			}
+			finishWithError(err, "value override parsing error")
 			return
 		}
 		vals, err := parseValues(valuesYAML)
 		if err != nil {
-			send("ERROR: " + err.Error())
-			if finishErr := lifecycle.Finish(err); finishErr != nil {
-				logrus.Errorf("failed to finish Helm operation after values parsing error: %v", finishErr)
-			}
+			finishWithError(err, "values parsing error")
 			return
 		}
 		vals, adjustments, err := prepareHelmInstallValuesWithMode(helmChart, repoURL, vals, inputIsOverrides)
 		if err != nil {
-			send("ERROR: " + err.Error())
-			if finishErr := lifecycle.Finish(err); finishErr != nil {
-				logrus.Errorf("failed to finish Helm operation after values preparation error: %v", finishErr)
-			}
+			finishWithError(err, "values preparation error")
 			return
 		}
 		for _, warning := range adjustments.warnings() {
-			send("WARNING: " + warning)
+			sendWarning(warning)
 		}
 		compatibilityCtx, cancelCompatibility := context.WithTimeout(installCtx, helmCompatibilityTimeout)
 		attachHelmCapabilities(compatibilityCtx, actionConfig, cfg, logFn)
 		err = validateHelmChartCompatibility(compatibilityCtx, cfg, actionConfig, releaseName, namespace, helmChart, vals)
 		cancelCompatibility()
 		if err != nil {
-			send("ERROR: " + err.Error())
-			_ = lifecycle.Finish(err)
+			finishWithError(err, "compatibility validation error")
 			return
 		}
 		if err := lifecycle.MarkInstalling(); err != nil {
-			send("ERROR: " + err.Error())
-			if finishErr := lifecycle.Finish(err); finishErr != nil {
-				logrus.Errorf("failed to finish Helm operation after phase transition error: %v", finishErr)
-			}
+			finishWithError(err, "phase transition error")
 			return
 		}
 		install := action.NewInstall(actionConfig)
@@ -1445,35 +1466,29 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 				installErr,
 				func(installErr error) error {
 					for _, line := range helmReleaseDiagnostics(installCtx, cfg, releaseName, namespace) {
-						send(line)
+						sendLog(line)
 					}
 					return installErr
 				},
 				func() error { return cleanupFailedHelmRelease(actionConfig, install, failedRelease) },
 			)
-			send("ERROR: " + err.Error())
-			if finishErr := lifecycle.Finish(err); finishErr != nil {
-				logrus.Errorf("failed to finish Helm operation after install error: %v", finishErr)
-			}
+			finishWithError(err, "install error")
 			return
 		}
 		reportHelmReadiness(inspectHelmReleaseResources(installCtx, cfg, releaseName, namespace), func(message string) {
-			send("WARNING: " + message)
+			sendWarning(message)
 		})
 		if err := lifecycle.Finish(nil); err != nil {
 			logrus.Warnf("failed to finish Helm operation: %v", err)
-			select {
-			case logCh <- "ERROR: " + err.Error():
-			case <-streamCtx.Done():
-			}
+			sendError(err)
 			return
 		}
 		select {
-		case logCh <- "DONE":
+		case eventCh <- HelmInstallStreamEvent{Type: HelmInstallStreamEventDone}:
 		case <-streamCtx.Done():
 		}
 	}()
-	return logCh
+	return eventCh
 }
 
 func UpgradeHelmRelease(cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML string) error {

--- a/store/helm_compatibility.go
+++ b/store/helm_compatibility.go
@@ -3,12 +3,15 @@ package store
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -25,6 +28,13 @@ func validateHelmChartCompatibility(ctx context.Context, cfg *rest.Config, actio
 	}
 	ctx, cancel := context.WithTimeout(ctx, helmCompatibilityTimeout)
 	defer cancel()
+	chartCRDs, err := helmChartCRDDefinitions(chartToInstall)
+	if err != nil {
+		return fmt.Errorf("read chart %s CRDs: %w", chartToInstall.Name(), &kubernetesResourceError{
+			Code: kubernetesInvalidManifest,
+			Err:  err,
+		})
+	}
 	namespaceExists, err := helmNamespaceExists(ctx, cfg, namespace)
 	if err != nil {
 		return err
@@ -33,23 +43,29 @@ func validateHelmChartCompatibility(ctx context.Context, cfg *rest.Config, actio
 	// target cluster. Remote template lookups are only safe after the release
 	// namespace exists; the real install remains the source of truth.
 	dryRun := newHelmCompatibilityDryRun(actionConfig, releaseName, namespace, namespaceExists)
-	_, err = dryRun.RunWithContext(ctx, chartToInstall, values)
+	rendered, err := dryRun.RunWithContext(ctx, chartToInstall, values)
 	if err == nil {
-		return nil
+		if namespaceExists {
+			return nil
+		}
+		return validateHelmManifestGVKs(ctx, actionConfig, rendered.Manifest, chartCRDs)
 	}
 	// A server-side dry-run rejects charts that declare a CRD and a custom
 	// resource of that CRD in the same release, because the new kind is not yet
-	// registered when the dry-run runs. Helm applies CRDs before other
-	// resources during a real install, so this is a false positive for the
-	// compatibility gate. Fall back to a client-side dry-run, which still
-	// catches genuine template and structural errors.
+	// registered when the dry-run runs. Only exact GVKs declared by this chart
+	// may use the client-render fallback; external prerequisites must still fail.
 	if namespaceExists && isUnregisteredKindDryRunError(err) {
 		clientDryRun := newHelmCompatibilityDryRun(actionConfig, releaseName, namespace, false)
-		if _, clientErr := clientDryRun.RunWithContext(ctx, chartToInstall, values); clientErr == nil {
-			return nil
+		clientRendered, clientErr := clientDryRun.RunWithContext(ctx, chartToInstall, values)
+		if clientErr != nil {
+			return fmt.Errorf("render chart %s with client dry-run: %w", chartToInstall.Name(), classifyHelmDryRunError(schema.GroupVersionKind{}, clientErr))
 		}
+		if validateErr := validateHelmManifestGVKs(ctx, actionConfig, clientRendered.Manifest, chartCRDs); validateErr != nil {
+			return fmt.Errorf("chart %s is not compatible with the target cluster: %w", chartToInstall.Name(), validateErr)
+		}
+		return nil
 	}
-	return fmt.Errorf("render chart %s for compatibility check: %w", chartToInstall.Name(), err)
+	return fmt.Errorf("render chart %s for compatibility check: %w", chartToInstall.Name(), classifyHelmDryRunError(schema.GroupVersionKind{}, err))
 }
 
 func validateHelmReleaseCompatibility(ctx context.Context, actionConfig *action.Configuration, releaseName, namespace string, chartToInstall *chart.Chart, values map[string]interface{}) error {
@@ -65,22 +81,24 @@ func validateHelmReleaseCompatibility(ctx context.Context, actionConfig *action.
 	ctx, cancel := context.WithTimeout(ctx, helmCompatibilityTimeout)
 	defer cancel()
 
-	err := runHelmUpgradeDryRun(ctx, actionConfig, releaseName, namespace, chartToInstall, values, "server")
+	_, err := runHelmUpgradeDryRun(ctx, actionConfig, releaseName, namespace, chartToInstall, values, "server")
 	if err == nil {
 		return nil
 	}
-	// See validateHelmChartCompatibility: a CRD and a custom resource of that
-	// CRD declared in the same release make a server-side dry-run fail on an
-	// unregistered kind. Fall back to a client-side dry-run before rejecting.
 	if isUnregisteredKindDryRunError(err) {
-		if clientErr := runHelmUpgradeDryRun(ctx, actionConfig, releaseName, namespace, chartToInstall, values, "client"); clientErr == nil {
-			return nil
+		clientRendered, clientErr := runHelmUpgradeDryRun(ctx, actionConfig, releaseName, namespace, chartToInstall, values, "client")
+		if clientErr != nil {
+			return fmt.Errorf("render Helm release %s with client dry-run: %w", releaseName, classifyHelmDryRunError(schema.GroupVersionKind{}, clientErr))
 		}
+		if validateErr := validateHelmManifestGVKs(ctx, actionConfig, clientRendered, nil); validateErr != nil {
+			return fmt.Errorf("Helm release %s is not compatible with the target cluster: %w", releaseName, validateErr)
+		}
+		return nil
 	}
-	return fmt.Errorf("render Helm release %s for compatibility check: %w", releaseName, err)
+	return fmt.Errorf("render Helm release %s for compatibility check: %w", releaseName, classifyHelmDryRunError(schema.GroupVersionKind{}, err))
 }
 
-func runHelmUpgradeDryRun(ctx context.Context, actionConfig *action.Configuration, releaseName, namespace string, chartToInstall *chart.Chart, values map[string]interface{}, dryRunOption string) error {
+func runHelmUpgradeDryRun(ctx context.Context, actionConfig *action.Configuration, releaseName, namespace string, chartToInstall *chart.Chart, values map[string]interface{}, dryRunOption string) (string, error) {
 	dryRun := action.NewUpgrade(actionConfig)
 	dryRun.Namespace = namespace
 	dryRun.DryRun = true
@@ -88,15 +106,15 @@ func runHelmUpgradeDryRun(ctx context.Context, actionConfig *action.Configuratio
 	dryRun.Wait = true
 	dryRun.WaitForJobs = true
 	dryRun.Timeout = helmCompatibilityTimeout
-	_, err := dryRun.RunWithContext(ctx, releaseName, chartToInstall, values)
-	return err
+	rendered, err := dryRun.RunWithContext(ctx, releaseName, chartToInstall, values)
+	if err != nil {
+		return "", err
+	}
+	return rendered.Manifest, nil
 }
 
-// isUnregisteredKindDryRunError reports whether a dry-run failure is caused by a
-// custom resource whose CRD is created by the same release. A server-side
-// dry-run cannot recognize such a kind before the CRD is applied, but a real
-// install/upgrade applies CRDs first, so this specific failure is not a genuine
-// incompatibility and must not block the operation.
+// isUnregisteredKindDryRunError reports whether a server dry-run failed before
+// cluster-aware GVK validation could determine if the resource is served.
 func isUnregisteredKindDryRunError(err error) bool {
 	if err == nil {
 		return false
@@ -113,6 +131,98 @@ func isUnregisteredKindDryRunError(err error) bool {
 		}
 	}
 	return false
+}
+
+func validateHelmManifestGVKs(ctx context.Context, actionConfig *action.Configuration, manifest string, chartCRDs map[schema.GroupVersionKind]crdDefinition) error {
+	if actionConfig == nil {
+		return &kubernetesResourceError{Code: kubernetesAPIUnavailable, Err: fmt.Errorf("Helm action configuration is missing")}
+	}
+	adapter, err := newKubernetesResourceAdapter(actionConfig.RESTClientGetter)
+	if err != nil {
+		return err
+	}
+	return adapter.validateManifest(ctx, manifest, chartCRDs)
+}
+
+type crdDefinition struct {
+	Name           string
+	Group          string
+	Kind           string
+	ServedVersions []string
+}
+
+func helmChartCRDDefinitions(ch *chart.Chart) (map[schema.GroupVersionKind]crdDefinition, error) {
+	definitions := make(map[schema.GroupVersionKind]crdDefinition)
+	if ch == nil {
+		return definitions, nil
+	}
+	for _, crd := range ch.CRDObjects() {
+		if crd.File == nil {
+			return nil, fmt.Errorf("CRD file %s is missing", crd.Name)
+		}
+		decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(string(crd.File.Data)), 4096)
+		for {
+			var document map[string]interface{}
+			if err := decoder.Decode(&document); err != nil {
+				if err == io.EOF {
+					break
+				}
+				return nil, fmt.Errorf("decode CRD file %s: %w", crd.Name, err)
+			}
+			if len(document) == 0 {
+				continue
+			}
+			definition, err := parseCRDDefinition(document)
+			if err != nil {
+				return nil, fmt.Errorf("parse CRD file %s: %w", crd.Name, err)
+			}
+			for _, version := range definition.ServedVersions {
+				gvk := schema.GroupVersion{Group: definition.Group, Version: version}.WithKind(definition.Kind)
+				definitions[gvk] = definition
+			}
+		}
+	}
+	return definitions, nil
+}
+
+func parseCRDDefinition(document map[string]interface{}) (crdDefinition, error) {
+	if kind, _ := document["kind"].(string); kind != "CustomResourceDefinition" {
+		return crdDefinition{}, fmt.Errorf("expected CustomResourceDefinition, got %q", kind)
+	}
+	metadata, _ := document["metadata"].(map[string]interface{})
+	name, _ := metadata["name"].(string)
+	spec, _ := document["spec"].(map[string]interface{})
+	names, _ := spec["names"].(map[string]interface{})
+	kind, _ := names["kind"].(string)
+	group, _ := spec["group"].(string)
+	if strings.TrimSpace(name) == "" || strings.TrimSpace(kind) == "" || strings.TrimSpace(group) == "" {
+		return crdDefinition{}, fmt.Errorf("metadata.name, spec.names.kind, and spec.group are required")
+	}
+	versions := make([]string, 0)
+	if items, ok := spec["versions"].([]interface{}); ok {
+		for _, item := range items {
+			version, _ := item.(map[string]interface{})
+			served, _ := version["served"].(bool)
+			name, _ := version["name"].(string)
+			if strings.TrimSpace(name) != "" && served {
+				versions = append(versions, name)
+			}
+		}
+	}
+	if len(versions) == 0 {
+		if version, _ := spec["version"].(string); strings.TrimSpace(version) != "" {
+			versions = append(versions, version)
+		}
+	}
+	if len(versions) == 0 {
+		return crdDefinition{}, fmt.Errorf("at least one served spec version is required")
+	}
+	return crdDefinition{
+		Name:           name,
+		Group:          group,
+		Kind:           kind,
+		ServedVersions: versions,
+	}, nil
 }
 
 func validateHelmRollbackCompatibility(ctx context.Context, actionConfig *action.Configuration, releaseName, namespace string, revision int) error {

--- a/store/kubernetes_resource_adapter.go
+++ b/store/kubernetes_resource_adapter.go
@@ -1,0 +1,308 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"slices"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/action"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+)
+
+type HelmCompatibilityErrorCode string
+
+type kubernetesResourceErrorCode = HelmCompatibilityErrorCode
+
+const (
+	HelmCompatibilityInvalidManifest   HelmCompatibilityErrorCode = "INVALID_MANIFEST"
+	HelmCompatibilityResourceNotServed HelmCompatibilityErrorCode = "RESOURCE_NOT_SERVED"
+	HelmCompatibilityResourceNotFound  HelmCompatibilityErrorCode = "RESOURCE_NOT_FOUND"
+	HelmCompatibilityForbiddenByRBAC   HelmCompatibilityErrorCode = "FORBIDDEN_BY_RBAC"
+	HelmCompatibilityConflict          HelmCompatibilityErrorCode = "CONFLICT"
+	HelmCompatibilityDiscoveryFailed   HelmCompatibilityErrorCode = "DISCOVERY_FAILED"
+	HelmCompatibilityAPIUnavailable    HelmCompatibilityErrorCode = "API_UNAVAILABLE"
+	HelmCompatibilityDryRunFailed      HelmCompatibilityErrorCode = "HELM_DRY_RUN_FAILED"
+
+	kubernetesInvalidManifest   = HelmCompatibilityInvalidManifest
+	kubernetesResourceNotServed = HelmCompatibilityResourceNotServed
+	kubernetesResourceNotFound  = HelmCompatibilityResourceNotFound
+	kubernetesForbidden         = HelmCompatibilityForbiddenByRBAC
+	kubernetesConflict          = HelmCompatibilityConflict
+	kubernetesDiscoveryFailed   = HelmCompatibilityDiscoveryFailed
+	kubernetesAPIUnavailable    = HelmCompatibilityAPIUnavailable
+	kubernetesHelmDryRunFailed  = HelmCompatibilityDryRunFailed
+)
+
+type HelmCompatibilityErrorInfo struct {
+	Code HelmCompatibilityErrorCode `json:"code"`
+	GVK  string                     `json:"gvk,omitempty"`
+}
+
+type HelmCompatibilityError struct {
+	Code kubernetesResourceErrorCode
+	GVK  schema.GroupVersionKind
+	Err  error
+}
+
+type kubernetesResourceError = HelmCompatibilityError
+
+func (e *HelmCompatibilityError) Error() string {
+	if e.GVK.Empty() {
+		return fmt.Sprintf("%s: %v", e.Code, e.Err)
+	}
+	return fmt.Sprintf("%s for %s: %v", e.Code, e.GVK.String(), e.Err)
+}
+
+func (e *HelmCompatibilityError) Unwrap() error {
+	return e.Err
+}
+
+func HelmCompatibilityErrorInfoFrom(err error) (HelmCompatibilityErrorInfo, bool) {
+	var compatibilityErr *HelmCompatibilityError
+	if !errors.As(err, &compatibilityErr) {
+		return HelmCompatibilityErrorInfo{}, false
+	}
+	info := HelmCompatibilityErrorInfo{Code: compatibilityErr.Code}
+	if !compatibilityErr.GVK.Empty() {
+		info.GVK = compatibilityErr.GVK.String()
+	}
+	return info, true
+}
+
+// kubernetesResourceAdapter validates rendered Helm resources against the
+// target cluster. Helm remains responsible for release dry-runs and writes.
+type kubernetesResourceAdapter struct {
+	mapper  meta.RESTMapper
+	refresh func()
+	getCRD  func(context.Context, string) (*unstructured.Unstructured, error)
+}
+
+func newKubernetesResourceAdapter(getter action.RESTClientGetter) (*kubernetesResourceAdapter, error) {
+	if getter == nil {
+		return nil, &kubernetesResourceError{
+			Code: kubernetesAPIUnavailable,
+			Err:  fmt.Errorf("Helm REST client getter is missing"),
+		}
+	}
+	discoveryClient, err := getter.ToDiscoveryClient()
+	if err != nil {
+		return nil, classifyKubernetesResourceError(schema.GroupVersionKind{}, err)
+	}
+	restConfig, err := getter.ToRESTConfig()
+	if err != nil {
+		return nil, classifyKubernetesResourceError(schema.GroupVersionKind{}, err)
+	}
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, classifyKubernetesResourceError(schema.GroupVersionKind{}, err)
+	}
+	crds := dynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	})
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+	return &kubernetesResourceAdapter{
+		mapper:  mapper,
+		refresh: mapper.Reset,
+		getCRD: func(ctx context.Context, name string) (*unstructured.Unstructured, error) {
+			return crds.Get(ctx, name, metav1.GetOptions{})
+		},
+	}, nil
+}
+
+func (a *kubernetesResourceAdapter) validateManifest(ctx context.Context, manifest string, chartCRDs map[schema.GroupVersionKind]crdDefinition) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if a == nil || a.mapper == nil {
+		return &kubernetesResourceError{
+			Code: kubernetesAPIUnavailable,
+			Err:  fmt.Errorf("Kubernetes REST mapper is missing"),
+		}
+	}
+
+	decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 4096)
+	for {
+		if err := ctx.Err(); err != nil {
+			return classifyKubernetesResourceError(schema.GroupVersionKind{}, err)
+		}
+		var document map[string]interface{}
+		if err := decoder.Decode(&document); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return &kubernetesResourceError{Code: kubernetesInvalidManifest, Err: fmt.Errorf("decode rendered Helm manifest: %w", err)}
+		}
+		if len(document) == 0 {
+			continue
+		}
+		if err := a.validateDocument(ctx, document, chartCRDs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *kubernetesResourceAdapter) validateDocument(ctx context.Context, document map[string]interface{}, chartCRDs map[schema.GroupVersionKind]crdDefinition) error {
+	if err := ctx.Err(); err != nil {
+		return classifyKubernetesResourceError(schema.GroupVersionKind{}, err)
+	}
+	kind, _, err := unstructured.NestedString(document, "kind")
+	if err != nil {
+		return &kubernetesResourceError{Code: kubernetesInvalidManifest, Err: fmt.Errorf("read kind: %w", err)}
+	}
+	kind = strings.TrimSpace(kind)
+	if kind == "List" {
+		items, _, err := unstructured.NestedSlice(document, "items")
+		if err != nil {
+			return &kubernetesResourceError{Code: kubernetesInvalidManifest, Err: fmt.Errorf("decode List items: %w", err)}
+		}
+		for _, item := range items {
+			object, ok := item.(map[string]interface{})
+			if !ok {
+				return &kubernetesResourceError{Code: kubernetesInvalidManifest, Err: fmt.Errorf("List item is not a Kubernetes object")}
+			}
+			if err := a.validateDocument(ctx, object, chartCRDs); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	apiVersion, _, err := unstructured.NestedString(document, "apiVersion")
+	if err != nil {
+		return &kubernetesResourceError{Code: kubernetesInvalidManifest, Err: fmt.Errorf("read apiVersion: %w", err)}
+	}
+	apiVersion = strings.TrimSpace(apiVersion)
+	if apiVersion == "" || kind == "" {
+		return &kubernetesResourceError{Code: kubernetesInvalidManifest, Err: fmt.Errorf("apiVersion and kind are required")}
+	}
+	groupVersion, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return &kubernetesResourceError{Code: kubernetesInvalidManifest, Err: fmt.Errorf("parse apiVersion %q: %w", apiVersion, err)}
+	}
+	gvk := groupVersion.WithKind(kind)
+
+	_, err = a.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if meta.IsNoMatchError(err) && a.refresh != nil {
+		a.refresh()
+		if err := ctx.Err(); err != nil {
+			return classifyKubernetesResourceError(gvk, err)
+		}
+		_, err = a.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	}
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			definition, declaredByChart := chartCRDs[gvk]
+			if !declaredByChart {
+				return &kubernetesResourceError{Code: kubernetesResourceNotServed, GVK: gvk, Err: err}
+			}
+			return a.validateChartCRD(ctx, gvk, definition)
+		}
+		return classifyKubernetesResourceError(gvk, err)
+	}
+	return nil
+}
+
+func (a *kubernetesResourceAdapter) validateChartCRD(ctx context.Context, gvk schema.GroupVersionKind, definition crdDefinition) error {
+	if a.getCRD == nil {
+		return &kubernetesResourceError{
+			Code: kubernetesAPIUnavailable,
+			GVK:  gvk,
+			Err:  fmt.Errorf("CustomResourceDefinition client is missing"),
+		}
+	}
+	existing, err := a.getCRD(ctx, definition.Name)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return classifyKubernetesResourceError(gvk, err)
+	}
+	return validateExistingCRD(gvk, existing)
+}
+
+func validateExistingCRD(gvk schema.GroupVersionKind, crd *unstructured.Unstructured) error {
+	if crd == nil {
+		return crdDoesNotServeError(gvk, "existing CustomResourceDefinition is empty")
+	}
+	definition, err := parseCRDDefinition(crd.Object)
+	if err != nil {
+		return &kubernetesResourceError{
+			Code: kubernetesInvalidManifest,
+			GVK:  gvk,
+			Err:  fmt.Errorf("parse existing CRD %s: %w", crd.GetName(), err),
+		}
+	}
+	if definition.Group != gvk.Group {
+		return crdDoesNotServeError(gvk, "existing CustomResourceDefinition has group %q", definition.Group)
+	}
+	if definition.Kind != gvk.Kind {
+		return crdDoesNotServeError(gvk, "existing CustomResourceDefinition has kind %q", definition.Kind)
+	}
+	if !slices.Contains(definition.ServedVersions, gvk.Version) {
+		return crdDoesNotServeError(gvk, "existing CustomResourceDefinition does not serve version %s", gvk.Version)
+	}
+	return nil
+}
+
+func crdDoesNotServeError(gvk schema.GroupVersionKind, format string, args ...interface{}) error {
+	return &kubernetesResourceError{
+		Code: kubernetesResourceNotServed,
+		GVK:  gvk,
+		Err:  fmt.Errorf(format, args...),
+	}
+}
+
+func classifyKubernetesResourceError(gvk schema.GroupVersionKind, err error) error {
+	return classifyKubernetesErrorWithDefault(gvk, err, kubernetesAPIUnavailable)
+}
+
+func classifyHelmDryRunError(gvk schema.GroupVersionKind, err error) error {
+	if err != nil && isUnregisteredKindDryRunError(err) {
+		return &kubernetesResourceError{Code: kubernetesResourceNotServed, GVK: gvk, Err: err}
+	}
+	return classifyKubernetesErrorWithDefault(gvk, err, kubernetesHelmDryRunFailed)
+}
+
+func classifyKubernetesErrorWithDefault(gvk schema.GroupVersionKind, err error, defaultCode kubernetesResourceErrorCode) error {
+	if err == nil {
+		return nil
+	}
+	code := defaultCode
+	switch {
+	case meta.IsNoMatchError(err):
+		code = kubernetesResourceNotServed
+	case apierrors.IsForbidden(err), apierrors.IsUnauthorized(err):
+		code = kubernetesForbidden
+	case apierrors.IsAlreadyExists(err), apierrors.IsConflict(err):
+		code = kubernetesConflict
+	case apierrors.IsNotFound(err):
+		code = kubernetesResourceNotFound
+	case apierrors.IsTimeout(err), apierrors.IsServerTimeout(err), apierrors.IsServiceUnavailable(err), apierrors.IsInternalError(err), apierrors.IsTooManyRequests(err), errors.Is(err, io.EOF), errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		code = kubernetesAPIUnavailable
+	default:
+		var networkError net.Error
+		if errors.As(err, &networkError) {
+			code = kubernetesAPIUnavailable
+		}
+		var discoveryError *discovery.ErrGroupDiscoveryFailed
+		if errors.As(err, &discoveryError) {
+			code = kubernetesDiscoveryFailed
+		}
+	}
+	return &kubernetesResourceError{Code: code, GVK: gvk, Err: err}
+}

--- a/web/src/HelmCompatibilityErrorAlert.js
+++ b/web/src/HelmCompatibilityErrorAlert.js
@@ -1,0 +1,35 @@
+import React from "react";
+import {Alert, Typography} from "antd";
+
+const {Text} = Typography;
+
+export default function HelmCompatibilityErrorAlert({error, onClose, t}) {
+  if (!error) {return null;}
+  const structured = typeof error === "object";
+  return (
+    <Alert
+      type="error"
+      message={structured ? error.message : error}
+      description={structured && (error.gvk || error.detail) ? (
+        <div>
+          {error.gvk && (
+            <div>
+              <Text strong>{t("helm:Missing resource")}</Text><br />
+              <Text code>{error.gvk}</Text>
+            </div>
+          )}
+          {error.detail && (
+            <div style={{marginTop: error.gvk ? 8 : 0}}>
+              <Text strong>{t("helm:Compatibility details")}</Text><br />
+              {error.detail}
+            </div>
+          )}
+        </div>
+      ) : undefined}
+      showIcon
+      style={{marginBottom: 16}}
+      closable
+      onClose={onClose}
+    />
+  );
+}

--- a/web/src/HelmCompatibilityErrorAlert.test.js
+++ b/web/src/HelmCompatibilityErrorAlert.test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+
+import React from "react";
+import {renderToStaticMarkup} from "react-dom/server";
+import HelmCompatibilityErrorAlert from "./HelmCompatibilityErrorAlert";
+
+jest.mock("antd", () => {
+  const React = require("react");
+  const Text = ({children}) => React.createElement("span", null, children);
+  return {
+    Alert: ({message, description}) => React.createElement("div", null, message, description),
+    Typography: {Text},
+  };
+});
+
+test("renders a friendly Helm compatibility message with GVK and details", () => {
+  const html = renderToStaticMarkup(
+    <HelmCompatibilityErrorAlert
+      error={{
+        message: "当前集群不支持 Chart 所需的资源类型",
+        gvk: "cert-manager.io/v1, Kind=Certificate",
+        detail: "no matches for kind Certificate",
+      }}
+      onClose={() => {}}
+      t={key => ({
+        "helm:Missing resource": "缺少资源",
+        "helm:Compatibility details": "兼容性详情",
+      })[key]}
+    />
+  );
+
+  expect(html).toContain("当前集群不支持 Chart 所需的资源类型");
+  expect(html).toContain("缺少资源");
+  expect(html).toContain("cert-manager.io/v1, Kind=Certificate");
+  expect(html).toContain("兼容性详情");
+  expect(html).toContain("no matches for kind Certificate");
+});

--- a/web/src/HelmInstallModal.js
+++ b/web/src/HelmInstallModal.js
@@ -11,6 +11,8 @@ import {
   helmTaskStorageSchemaVersion,
   removeStoredHelmTask
 } from "./helmTaskStorage";
+import {resolveHelmCompatibilityError} from "./helmCompatibilityErrors";
+import HelmCompatibilityErrorAlert from "./HelmCompatibilityErrorAlert";
 
 const {Text} = Typography;
 const helmOperationTaskNotFoundCode = "helm_task_not_found";
@@ -364,11 +366,19 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
           if (!mountedRef.current || streamAbortRef.current !== streamController) {return;}
           stopStreamIdleTimer(streamController);
           if (streamController.signal.aborted) {return;}
+          if (e.code) {
+            setError(resolveHelmCompatibilityError(e, t));
+            setInstalling(false);
+            setPollingPaused(false);
+            submittingRef.current = false;
+            forgetTask();
+            return;
+          }
           if (taskIdRef.current) {
             monitorTask(taskIdRef.current, taskStorageKeyRef.current, taskIdentityRef.current);
             return;
           }
-          setError(e.message);
+          setError(resolveHelmCompatibilityError(e, t));
           setInstalling(false);
           setPollingPaused(false);
           submittingRef.current = false;
@@ -447,7 +457,7 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
       destroyOnHidden
     >
       {error && (
-        <Alert type="error" message={error} showIcon style={{marginBottom: 16}} closable onClose={() => setError(null)} />
+        <HelmCompatibilityErrorAlert error={error} t={t} onClose={() => setError(null)} />
       )}
 
       {storageWarning && (

--- a/web/src/backend/HelmBackend.js
+++ b/web/src/backend/HelmBackend.js
@@ -56,8 +56,8 @@ export function installHelmChart(payload) {
   }).then(r => r.json());
 }
 
-// installHelmChartStream posts the payload then reads the SSE response line-by-line.
-// onLine(line) is called for each log line; returns "DONE" and rejects on "ERROR: ...".
+// installHelmChartStream posts the payload then reads structured SSE events.
+// onLine(line) is called for each displayable message; returns "DONE" on completion.
 // Closing the browser stream does not cancel a submitted install.
 export async function installHelmChartStream(payload, onLine, signal) {
   const resp = await fetch(`${Setting.ServerUrl}/api/install-helm-chart-stream`, {
@@ -73,11 +73,21 @@ export async function installHelmChartStream(payload, onLine, signal) {
     const parts = buf.split("\n\n");
     buf = parts.pop();
     for (const part of parts) {
-      const line = part.replace(/^data: /, "");
-      if (line) {
-        onLine(line);
-        if (line.startsWith("ERROR: ")) {throw new Error(line.slice(7));}
-        if (line === "DONE") {return line;}
+      const dataLine = part.split("\n").find(line => line.startsWith("data: "));
+      if (!dataLine) {continue;}
+      const event = JSON.parse(dataLine.slice(6));
+      if (event.message) {
+        onLine(event.type === "warning" ? `WARNING: ${event.message}` : event.message);
+      }
+      if (event.type === "error") {
+        const installError = new Error(event.message || "Helm install failed");
+        installError.code = event.error?.code;
+        installError.gvk = event.error?.gvk;
+        throw installError;
+      }
+      if (event.type === "done") {
+        onLine("DONE");
+        return "DONE";
       }
     }
   }

--- a/web/src/backend/HelmBackend.test.js
+++ b/web/src/backend/HelmBackend.test.js
@@ -37,25 +37,29 @@ describe("installHelmChartStream", () => {
     jest.resetAllMocks();
   });
 
-  test("rejects when the server reports an install failure", async() => {
+  test("rejects with a compatibility code from a structured error event", async() => {
     global.fetch = jest.fn().mockResolvedValue(mockStreamResponse([
-      "data: creating 1 resource(s)\n\n",
-      "data: ERROR: install failed\n\n",
+      "data: {\"type\":\"log\",\"message\":\"creating 1 resource(s)\"}\n\n",
+      "data: {\"type\":\"error\",\"message\":\"install failed\",\"error\":{\"code\":\"RESOURCE_NOT_SERVED\",\"gvk\":\"cert-manager.io/v1, Kind=Certificate\"}}\n\n",
     ]));
 
     const onLine = jest.fn();
     await expect(installHelmChartStream({releaseName: "demo"}, onLine))
-      .rejects.toThrow("install failed");
+      .rejects.toMatchObject({
+        message: "install failed",
+        code: "RESOURCE_NOT_SERVED",
+        gvk: "cert-manager.io/v1, Kind=Certificate",
+      });
 
     expect(onLine).toHaveBeenCalledTimes(2);
     expect(onLine).toHaveBeenNthCalledWith(1, "creating 1 resource(s)");
-    expect(onLine).toHaveBeenNthCalledWith(2, "ERROR: install failed");
+    expect(onLine).toHaveBeenNthCalledWith(2, "install failed");
   });
 
   test("returns DONE when the server completes the install stream", async() => {
     global.fetch = jest.fn().mockResolvedValue(mockStreamResponse([
-      "data: creating 1 resource(s)\n\n",
-      "data: DONE\n\n",
+      "data: {\"type\":\"log\",\"message\":\"creating 1 resource(s)\"}\n\n",
+      "data: {\"type\":\"done\"}\n\n",
     ]));
 
     const onLine = jest.fn();
@@ -68,8 +72,8 @@ describe("installHelmChartStream", () => {
 
   test("forwards the task id and abort signal", async() => {
     global.fetch = jest.fn().mockResolvedValue(mockStreamResponse([
-      "data: TASK_ID:42\n\n",
-      "data: DONE\n\n",
+      "data: {\"type\":\"log\",\"message\":\"TASK_ID:42\"}\n\n",
+      "data: {\"type\":\"done\"}\n\n",
     ]));
     const signal = {aborted: false};
     const onLine = jest.fn();

--- a/web/src/helmCompatibilityErrors.js
+++ b/web/src/helmCompatibilityErrors.js
@@ -1,0 +1,22 @@
+export const helmCompatibilityMessageKeys = {
+  INVALID_MANIFEST: "helm:Invalid Helm manifest",
+  RESOURCE_NOT_SERVED: "helm:Helm resource not served",
+  RESOURCE_NOT_FOUND: "helm:Helm resource not found",
+  FORBIDDEN_BY_RBAC: "helm:Helm compatibility check forbidden",
+  CONFLICT: "helm:Helm resource conflict",
+  DISCOVERY_FAILED: "helm:Kubernetes discovery failed",
+  API_UNAVAILABLE: "helm:Kubernetes API unavailable",
+  HELM_DRY_RUN_FAILED: "helm:Helm dry run failed",
+};
+
+export function resolveHelmCompatibilityError(error, t) {
+  const messageKey = helmCompatibilityMessageKeys[error?.code];
+  if (!messageKey) {
+    return {message: error?.message || "Helm install failed", gvk: "", detail: ""};
+  }
+  return {
+    message: t(messageKey),
+    gvk: error?.gvk || "",
+    detail: error?.message || "",
+  };
+}

--- a/web/src/helmCompatibilityErrors.test.js
+++ b/web/src/helmCompatibilityErrors.test.js
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+
+import {helmCompatibilityMessageKeys, resolveHelmCompatibilityError} from "./helmCompatibilityErrors";
+
+describe("resolveHelmCompatibilityError", () => {
+  test.each([
+    "INVALID_MANIFEST",
+    "RESOURCE_NOT_SERVED",
+    "RESOURCE_NOT_FOUND",
+    "FORBIDDEN_BY_RBAC",
+    "CONFLICT",
+    "DISCOVERY_FAILED",
+    "API_UNAVAILABLE",
+    "HELM_DRY_RUN_FAILED",
+  ])("maps %s to a friendly message without parsing the backend message", code => {
+    const t = jest.fn(key => `translated:${key}`);
+    const result = resolveHelmCompatibilityError({
+      message: "opaque backend details",
+      code,
+      gvk: "cert-manager.io/v1, Kind=Certificate",
+    }, t);
+
+    expect(result.message).toBe(`translated:${helmCompatibilityMessageKeys[code]}`);
+    expect(result.gvk).toBe("cert-manager.io/v1, Kind=Certificate");
+    expect(result.detail).toBe("opaque backend details");
+  });
+
+  test("falls back to the backend message for an unknown code", () => {
+    expect(resolveHelmCompatibilityError({message: "install failed", code: "UNKNOWN"}, key => key))
+      .toEqual({message: "install failed", gvk: "", detail: ""});
+  });
+});

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -109,7 +109,17 @@
     "Unable to refresh installation status": "Unable to refresh installation status: {{error}}",
     "Unable to refresh installation status: invalid response": "Unable to refresh installation status: invalid response",
     "The saved installation task no longer matches this chart and was discarded": "The saved installation task no longer matches this chart and was discarded.",
-    "Helm operation failed": "Helm operation failed"
+    "Helm operation failed": "Helm operation failed",
+    "Invalid Helm manifest": "The chart rendered an invalid Kubernetes manifest.",
+    "Helm resource not served": "The target cluster does not serve a resource required by this chart. A CRD may be missing or the API version may be incompatible.",
+    "Helm resource not found": "A Kubernetes resource required for the compatibility check was not found.",
+    "Helm compatibility check forbidden": "CasOS does not have permission to complete the Helm compatibility check. Check Kubernetes RBAC.",
+    "Helm resource conflict": "A conflicting resource exists in the target cluster, so the Helm preflight check cannot continue.",
+    "Kubernetes discovery failed": "Kubernetes API discovery failed, so the required resource types could not be verified.",
+    "Kubernetes API unavailable": "The Kubernetes API is unavailable. Check the control plane and network connection.",
+    "Helm dry run failed": "The Helm preflight check failed. Check the chart templates, values, and error details.",
+    "Missing resource": "Missing resource",
+    "Compatibility details": "Details"
   },
   "monitor": {
     "Abnormal Pods": "Abnormal Pods",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -109,7 +109,17 @@
     "Unable to refresh installation status": "无法刷新安装状态：{{error}}",
     "Unable to refresh installation status: invalid response": "无法刷新安装状态：响应无效",
     "The saved installation task no longer matches this chart and was discarded": "已保存的安装任务与当前 chart 不再匹配，已丢弃。",
-    "Helm operation failed": "Helm 操作失败"
+    "Helm operation failed": "Helm 操作失败",
+    "Invalid Helm manifest": "Chart 渲染结果不是有效的 Kubernetes 资源清单。",
+    "Helm resource not served": "当前集群不支持 Chart 所需的资源类型，可能缺少对应 CRD，或 API 版本不兼容。",
+    "Helm resource not found": "兼容性检查所需的 Kubernetes 资源不存在。",
+    "Helm compatibility check forbidden": "CasOS 没有足够权限完成 Helm 兼容性检查，请检查 Kubernetes RBAC。",
+    "Helm resource conflict": "目标集群中存在冲突资源，Helm 预检无法继续。",
+    "Kubernetes discovery failed": "Kubernetes API Discovery 失败，无法确认目标资源类型是否可用。",
+    "Kubernetes API unavailable": "Kubernetes API 当前不可用，请检查控制面状态和网络连接。",
+    "Helm dry run failed": "Helm 预检失败，请检查 Chart 模板、values 和错误详情。",
+    "Missing resource": "缺少资源",
+    "Compatibility details": "详细信息"
   },
   "monitor": {
     "Abnormal Pods": "异常 Pod",


### PR DESCRIPTION
## Background

Helm compatibility checks rely on dry-run behavior. A successful server-side dry-run already proves that the API server accepts the rendered resources, while a client-side dry-run still needs cluster-aware validation to determine whether each rendered GVK is served.

Install and upgrade have different CRD semantics. Helm installs missing CRDs from a chart during installation, but Helm upgrade and rollback do not install or upgrade chart CRDs. Compatibility validation must preserve that distinction and expose failures as a stable interface instead of requiring clients to parse error strings.

## Summary

- treat successful server-side Helm dry-runs as authoritative; fall back to client dry-run plus explicit GVK validation only for unregistered kinds
- allow install validation to use exact GVKs declared by chart CRDs, while upgrade and rollback always validate against resources currently served by the cluster
- replace resolved-resource and pending-CRD state with an error-only manifest validation path
- expose eight stable Helm compatibility error codes and preserve them through wrapped errors with `errors.As`
- return compatibility code and GVK as independent data from normal install, upgrade, and rollback APIs
- stream structured `log`, `warning`, `error`, and `done` events; compatibility error events include independent `code` and optional `gvk` fields
- map every stable code to a user-facing English and Chinese message without parsing backend error strings
- reuse one CRD parser for chart CRDs and existing cluster CRDs, including `spec.versions[].served`

## Compatibility and risk

- validation performs read-only Discovery and CRD GET operations; Helm remains the only component that writes release resources
- existing CRDs are never modified or assumed to be upgraded by Helm
- the legacy single-version CRD field remains supported for install validation
- Kubernetes API, Discovery, timeout, RBAC, conflict, missing resource, invalid manifest, and Helm dry-run failures remain blocking and are reported with stable codes
- the install timeout, background lifecycle, retry, diagnostics, and failed-release cleanup behavior from #114 and #115 is preserved

## Validation

```text
go test ./store ./controllers -count=1
go test ./... -count=1
go test ./... -tags skipCi -count=1
go vet ./...
node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false --runInBand src/backend/HelmBackend.test.js src/helmCompatibilityErrors.test.js src/HelmCompatibilityErrorAlert.test.js
node node_modules/eslint/bin/eslint.js src/backend/HelmBackend.js src/backend/HelmBackend.test.js src/HelmInstallModal.js src/HelmCompatibilityErrorAlert.js src/HelmCompatibilityErrorAlert.test.js src/helmCompatibilityErrors.js src/helmCompatibilityErrors.test.js
node node_modules/react-scripts/bin/react-scripts.js build
```
