### PR TITLE
feat: add control plane egress policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,28 @@ clientSecret        = <your-client-secret>
 casdoorOrganization = <your-org>
 casdoorApplication  = <your-app>
 
+; Optional control-plane SOCKS5 proxy
+; Leave blank to use environment proxy settings or direct access.
+; When set, the proxy is required for requests not matched by NO_PROXY.
+socks5Proxy =
+
 ; Kubernetes control plane
 apiserverPort = 6443
 apiserverBind = 127.0.0.1
 dataDir       = /var/lib/casos
 ```
+
+The control-plane proxy accepts `host:port`, `socks5://`, and `socks5h://`
+addresses. When `socks5Proxy` is set, CasOS fails requests that cannot use the
+configured proxy instead of silently falling back to direct access. Destinations
+matched by the CasOS process `NO_PROXY` environment variable continue to use
+direct access. When `socks5Proxy` is blank, CasOS follows `HTTP_PROXY`,
+`HTTPS_PROXY`, and `NO_PROXY`, and uses direct access when no environment proxy
+is configured.
+
+**Upgrade notice:** the previous example default of `127.0.0.1:10808` has been
+removed. Set `socks5Proxy` explicitly before upgrading if that local proxy is a
+required control-plane dependency.
 
 ## Development
 

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -17,7 +17,9 @@ casdoorOrganization = casbin
 casdoorApplication  = app-casibase
 
 ; -- Outbound proxy (optional) ----
-socks5Proxy   = 127.0.0.1:10808
+; Leave blank to use environment proxy settings or direct access.
+; When set, the proxy is required for requests not matched by NO_PROXY.
+socks5Proxy   =
 
 ; -- Built-in image registry mirror -----------------------------------------
 ; auto   = probe each canonical registry from the target worker and enable

--- a/controllers/dockerhub.go
+++ b/controllers/dockerhub.go
@@ -1,14 +1,29 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/casosorg/casos/proxy"
 )
+
+const dockerHubRequestTimeout = 15 * time.Second
+
+func newDockerHubRequest(ctx context.Context, apiURL string) (*http.Request, context.CancelFunc, error) {
+	requestCtx, cancel := context.WithTimeout(ctx, dockerHubRequestTimeout)
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+	return req, cancel, nil
+}
 
 type dockerHubSearchResult struct {
 	Count   int              `json:"count"`
@@ -44,7 +59,14 @@ func (c *ApiController) SearchDockerHubImages() {
 		url.QueryEscape(q),
 	)
 
-	resp, err := proxy.GetHttpClient(apiURL).Get(apiURL)
+	req, cancel, err := newDockerHubRequest(c.Ctx.Request.Context(), apiURL)
+	if err != nil {
+		c.ResponseError(fmt.Sprintf("failed to create Docker Hub request: %v", err))
+		return
+	}
+	defer cancel()
+
+	resp, err := proxy.HTTPClient().Do(req)
 	if err != nil {
 		c.ResponseError(fmt.Sprintf("failed to reach Docker Hub: %v", err))
 		return
@@ -67,7 +89,7 @@ func (c *ApiController) SearchDockerHubImages() {
 	for i, r := range result.Results {
 		names[i] = r.Name
 	}
-	nsLogos := FetchNamespaceLogos(uniqueNamespaces(names))
+	nsLogos := fetchNamespaceLogos(c.Ctx.Request.Context(), uniqueNamespaces(names))
 
 	items := make([]ImageSearchItem, len(result.Results))
 	for i, r := range result.Results {
@@ -115,7 +137,14 @@ func (c *ApiController) GetDockerHubImageTags() {
 		url.PathEscape(namespace), url.PathEscape(name),
 	)
 
-	resp, err := proxy.GetHttpClient(apiURL).Get(apiURL)
+	req, cancel, err := newDockerHubRequest(c.Ctx.Request.Context(), apiURL)
+	if err != nil {
+		c.ResponseError(fmt.Sprintf("failed to create Docker Hub request: %v", err))
+		return
+	}
+	defer cancel()
+
+	resp, err := proxy.HTTPClient().Do(req)
 	if err != nil {
 		c.ResponseError(fmt.Sprintf("failed to reach Docker Hub: %v", err))
 		return

--- a/controllers/dockerhub_logo.go
+++ b/controllers/dockerhub_logo.go
@@ -1,9 +1,11 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"sync"
 
@@ -16,16 +18,22 @@ type namespaceInfo struct {
 
 // fetchNamespaceGravatar tries the orgs then users endpoint for a Docker Hub namespace.
 // Returns the gravatar_url with d=404 so callers can detect missing avatars via HTTP 404.
-func fetchNamespaceGravatar(namespace string) string {
+func fetchNamespaceGravatar(ctx context.Context, namespace string) string {
 	for _, kind := range []string{"orgs", "users"} {
 		apiURL := fmt.Sprintf("https://hub.docker.com/v2/%s/%s/", kind, namespace)
-		resp, err := proxy.GetHttpClient(apiURL).Get(apiURL)
+		req, cancel, err := newDockerHubRequest(ctx, apiURL)
 		if err != nil {
+			continue
+		}
+		resp, err := proxy.HTTPClient().Do(req)
+		if err != nil {
+			cancel()
 			continue
 		}
 		body, readErr := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		if readErr != nil || resp.StatusCode != 200 {
+		cancel()
+		if readErr != nil || resp.StatusCode != http.StatusOK {
 			continue
 		}
 		var info namespaceInfo
@@ -39,6 +47,10 @@ func fetchNamespaceGravatar(namespace string) string {
 // FetchNamespaceLogos concurrently fetches gravatar URLs for a set of Docker Hub namespaces.
 // Returns a map of namespace -> gravatar URL (empty string if not found).
 func FetchNamespaceLogos(namespaces []string) map[string]string {
+	return fetchNamespaceLogos(context.Background(), namespaces)
+}
+
+func fetchNamespaceLogos(ctx context.Context, namespaces []string) map[string]string {
 	result := make(map[string]string, len(namespaces))
 	if len(namespaces) == 0 {
 		return result
@@ -50,7 +62,7 @@ func FetchNamespaceLogos(namespaces []string) map[string]string {
 		wg.Add(1)
 		go func(ns string) {
 			defer wg.Done()
-			logo := fetchNamespaceGravatar(ns)
+			logo := fetchNamespaceGravatar(ctx, ns)
 			mu.Lock()
 			result[ns] = logo
 			mu.Unlock()

--- a/controllers/helm.go
+++ b/controllers/helm.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/beego/beego/logs"
 	"github.com/casosorg/casos/object"
+	proxypkg "github.com/casosorg/casos/proxy"
 	"github.com/casosorg/casos/store"
 )
 
@@ -66,8 +67,14 @@ func (c *ApiController) SearchArtifactHub() {
 		url += "&ts_query_web=" + q
 	}
 
-	client := &http.Client{Timeout: 15 * time.Second}
-	req, _ := http.NewRequest("GET", url, nil)
+	client := proxypkg.HTTPClient()
+	ctx, cancel := context.WithTimeout(c.Ctx.Request.Context(), 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := client.Do(req)

--- a/proxy/egress_policy.go
+++ b/proxy/egress_policy.go
@@ -1,0 +1,115 @@
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/http/httpproxy"
+)
+
+// EgressPolicy selects the control-plane proxy for each outbound request.
+type EgressPolicy struct {
+	proxyForURL func(*url.URL) (*url.URL, error)
+}
+
+// NewEgressPolicy builds a request-level proxy policy. A blank proxy address
+// preserves the standard library's environment proxy behavior.
+func NewEgressPolicy(proxyAddress, noProxy string) (*EgressPolicy, error) {
+	proxyAddress = strings.TrimSpace(proxyAddress)
+	if proxyAddress == "" {
+		return &EgressPolicy{
+			proxyForURL: func(requestURL *url.URL) (*url.URL, error) {
+				return http.ProxyFromEnvironment(&http.Request{URL: requestURL})
+			},
+		}, nil
+	}
+
+	normalized, err := normalizeSocks5ProxyAddress(proxyAddress)
+	if err != nil {
+		return nil, err
+	}
+	proxyConfig := &httpproxy.Config{
+		HTTPProxy:  normalized,
+		HTTPSProxy: normalized,
+		NoProxy:    noProxy,
+	}
+	return &EgressPolicy{proxyForURL: proxyConfig.ProxyFunc()}, nil
+}
+
+// Proxy implements the proxy callback used by http.Transport.
+func (p *EgressPolicy) Proxy(req *http.Request) (*url.URL, error) {
+	if p == nil || p.proxyForURL == nil {
+		return nil, nil
+	}
+	if req == nil || req.URL == nil {
+		return nil, fmt.Errorf("cannot select proxy for a request without a URL")
+	}
+	return p.proxyForURL(req.URL)
+}
+
+// HTTPClient returns a client whose transport retains the standard defaults
+// while applying this policy independently to every request and redirect.
+func (p *EgressPolicy) HTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = p.Proxy
+	return &http.Client{Transport: transport}
+}
+
+func normalizeSocks5ProxyAddress(raw string) (string, error) {
+	candidate := strings.TrimSpace(raw)
+	if !strings.Contains(candidate, "://") {
+		candidate = "socks5h://" + candidate
+	}
+
+	parsed, err := url.Parse(candidate)
+	if err != nil {
+		return "", invalidProxyAddressError(raw)
+	}
+	if parsed.Scheme != "socks5" && parsed.Scheme != "socks5h" {
+		return "", invalidProxyAddressError(raw)
+	}
+	if parsed.Hostname() == "" || parsed.Port() == "" {
+		return "", invalidProxyAddressError(raw)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil || port < 1 || port > 65535 {
+		return "", invalidProxyAddressError(raw)
+	}
+	if (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", invalidProxyAddressError(raw)
+	}
+
+	normalized := &url.URL{
+		Scheme: "socks5h",
+		User:   parsed.User,
+		Host:   net.JoinHostPort(parsed.Hostname(), parsed.Port()),
+	}
+	return normalized.String(), nil
+}
+
+func invalidProxyAddressError(raw string) error {
+	return fmt.Errorf("invalid SOCKS5 proxy address %q", RedactProxyAddress(raw))
+}
+
+// RedactProxyAddress retains only scheme, host, and port for diagnostics.
+// Paths, queries, fragments, and credentials are never included in errors.
+func RedactProxyAddress(raw string) string {
+	candidate := strings.TrimSpace(raw)
+	hadScheme := strings.Contains(candidate, "://")
+	if !hadScheme {
+		candidate = "redact://" + candidate
+	}
+	parsed, err := url.Parse(candidate)
+	if err != nil || parsed.Hostname() == "" || parsed.Port() == "" {
+		return "REDACTED"
+	}
+	endpoint := net.JoinHostPort(parsed.Hostname(), parsed.Port())
+	if !hadScheme {
+		return endpoint
+	}
+	return (&url.URL{Scheme: parsed.Scheme, Host: endpoint}).String()
+}

--- a/proxy/socks5.go
+++ b/proxy/socks5.go
@@ -1,85 +1,43 @@
 package proxy
 
 import (
-	"crypto/tls"
-	"net"
 	"net/http"
-	"strings"
-	"time"
+	"net/url"
 
 	"github.com/beego/beego/logs"
 	"github.com/casosorg/casos/conf"
-	"golang.org/x/net/proxy"
+	"golang.org/x/net/http/httpproxy"
 )
 
 var (
-	DefaultHttpClient *http.Client
-	ProxyHttpClient   *http.Client
+	DefaultHttpClient = http.DefaultClient
+	ProxyHttpClient   = http.DefaultClient
 )
 
 func InitHttpClient() {
-	// not use proxy
-	DefaultHttpClient = http.DefaultClient
-
-	// use proxy
-	ProxyHttpClient = getProxyHttpClient()
-}
-
-func isAddressOpen(address string) bool {
-	timeout := time.Millisecond * 100
-	conn, err := net.DialTimeout("tcp", address, timeout)
+	policy, err := NewEgressPolicy(GetSocks5ProxyAddress(), httpproxy.FromEnvironment().NoProxy)
 	if err != nil {
-		// cannot connect to address, proxy is not active
-		return false
+		logs.Error("Control-plane egress blocked by invalid proxy configuration: %v", err)
+		policy = &EgressPolicy{
+			proxyForURL: func(*url.URL) (*url.URL, error) {
+				return nil, err
+			},
+		}
 	}
-
-	if conn != nil {
-		defer conn.Close()
-		logs.Info("Socks5 proxy enabled: %s", address)
-		return true
-	}
-
-	return false
-}
-
-func getProxyHttpClient() *http.Client {
-	socks5Proxy := conf.GetConfigString("socks5Proxy")
-	if socks5Proxy == "" {
-		return &http.Client{}
-	}
-
-	if !isAddressOpen(socks5Proxy) {
-		return &http.Client{}
-	}
-
-	// https://stackoverflow.com/questions/33585587/creating-a-go-socks5-client
-	dialer, err := proxy.SOCKS5("tcp", socks5Proxy, nil, proxy.Direct)
-	if err != nil {
-		panic(err)
-	}
-
-	tr := &http.Transport{Dial: dialer.Dial, TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	return &http.Client{
-		Transport: tr,
-	}
+	client := policy.HTTPClient()
+	DefaultHttpClient = client
+	ProxyHttpClient = client
 }
 
 func GetSocks5ProxyAddress() string {
 	return conf.GetConfigString("socks5Proxy")
 }
 
-func GetActiveSocks5ProxyAddress() string {
-	socks5Proxy := GetSocks5ProxyAddress()
-	if socks5Proxy == "" || !isAddressOpen(socks5Proxy) {
-		return ""
-	}
-	return socks5Proxy
+func HTTPClient() *http.Client {
+	return ProxyHttpClient
 }
 
-func GetHttpClient(url string) *http.Client {
-	if strings.Contains(url, "hub.docker.com") {
-		return ProxyHttpClient
-	} else {
-		return DefaultHttpClient
-	}
+// Deprecated: use HTTPClient. The URL parameter never affected client selection.
+func GetHttpClient(_ string) *http.Client {
+	return HTTPClient()
 }


### PR DESCRIPTION
## Summary
- Add a shared control-plane egress policy for SOCKS5/SOCKS5H, NO_PROXY, environment proxy handling, timeouts, and redacted configuration errors.
- Route Helm and Docker Hub control-plane requests through the policy while preserving standard TLS behavior.

## Validation
- go test ./proxy ./controllers
- GitHub Build checks passed on the reviewed source commit.

No corresponding issue is known for this feature.