### PR TITLE
fix: fix failed UI test about "Add Local WSL" button

### DIFF
--- a/web/tests/ui/worker-node-helpers.js
+++ b/web/tests/ui/worker-node-helpers.js
@@ -166,7 +166,7 @@ async function createMachineFromUi(page, machineName, createdMachines, options =
   await page.waitForLoadState("networkidle");
   await expect(page).toHaveURL(/\/machines$/);
 
-  await machineTableTitle(page).getByRole("button", {name: "Add"}).click();
+  await machineTableTitle(page).getByRole("button").filter({hasText: /^Add$/}).click();
   const addDialog = page.getByRole("dialog", {name: "Add Machine"});
   await expect(addDialog).toBeVisible();
   await addDialog.getByPlaceholder("my-machine").fill(machineName);


### PR DESCRIPTION
## Summary

- select the regular machine `Add` button by its exact visible text
- avoid matching the neighboring `Add Local WSL` action
- keep the worker smoke test independent of Ant Design icon accessible names

## Why

The worker smoke test originally used Playwright's substring accessible-name matching, so `Add` matched both `plus Add` and `windows Add Local WSL`. Using `exact: true` on the name was also insufficient because Ant Design includes the icon label in the accessible name. Filtering buttons by the exact visible text `Add` selects the intended action without depending on the icon name.

## Validation

- fork PR CI is green: https://github.com/bugkeep/casos/pull/177
- Playwright DOM selector check: exactly one `Add` button matched
- `node --check tests/ui/worker-node-helpers.js`
- `yarn run ui:test:selector:check`
- `yarn eslint tests/ui/worker-node-helpers.js`
- focused Playwright test discovery with `--list`
- `yarn build`
- independent diff review: no blocking findings

No matching issue was found.