### PR TITLE
feat: add one-click standalone installers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+scripts/install.sh text eol=lf
+scripts/install.ps1 text eol=crlf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   go-tests:
@@ -37,11 +41,140 @@ jobs:
       - run: yarn install && CI=false yarn run build
         working-directory: ./web
       - name: Upload build artifacts
-        if: github.repository == 'casosorg/casos' && github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: frontend-build-${{ github.run_id }}
           path: ./web/build
+
+  standalone:
+    name: Standalone ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    needs: [ frontend ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            output: casos_linux_amd64
+            smoke: true
+          - goos: linux
+            goarch: arm64
+            output: casos_linux_arm64
+            smoke: false
+          - goos: windows
+            goarch: amd64
+            output: casos_windows_amd64.exe
+            smoke: false
+          - goos: windows
+            goarch: arm64
+            output: casos_windows_arm64.exe
+            smoke: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: ./go.mod
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-build-${{ github.run_id }}
+          path: ./web/build
+      - name: Build standalone release binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          CGO_ENABLED=0 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
+            go build -trimpath -tags embed -o "dist/${{ matrix.output }}" .
+      - name: Upload standalone release binaries
+        if: github.repository == 'casosorg/casos' && github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: standalone-${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.run_id }}
+          path: ./dist/${{ matrix.output }}
+          retention-days: 1
+      - name: Smoke embedded Linux binary
+        if: matrix.smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          probe_dir="$(mktemp -d)"
+          pid=""
+          cleanup() {
+            if [[ -n "$pid" ]]; then
+              kill "$pid" 2>/dev/null || true
+              wait "$pid" 2>/dev/null || true
+            fi
+            rm -rf "$probe_dir"
+          }
+          trap cleanup EXIT
+
+          mkdir -p "$probe_dir/home" "$probe_dir/cwd"
+          (
+            cd "$probe_dir/cwd"
+            exec env HOME="$probe_dir/home" \
+              httpport=9000 \
+              "$GITHUB_WORKSPACE/dist/casos_linux_amd64" >"$probe_dir/casos.log" 2>&1
+          ) &
+          pid=$!
+
+          ready=false
+          for _ in $(seq 1 120); do
+            if curl --noproxy '*' -fsS http://127.0.0.1:9000/ >"$probe_dir/index.html" 2>/dev/null; then
+              ready=true
+              break
+            fi
+            if ! kill -0 "$pid" 2>/dev/null; then
+              cat "$probe_dir/casos.log" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          if [[ "$ready" != true ]]; then
+            cat "$probe_dir/casos.log" >&2
+            exit 1
+          fi
+
+          asset_path="$(grep -oE '/static/js/[^" ]+\.js' "$probe_dir/index.html" | head -n 1)"
+          [[ -n "$asset_path" ]]
+          curl --noproxy '*' -fsS "http://127.0.0.1:9000$asset_path" >/dev/null
+
+          curl --noproxy '*' -fsS -D "$probe_dir/dev.headers" -o /dev/null \
+            -H 'Origin: http://localhost:8001' http://localhost:9000/
+          grep -qi '^Access-Control-Allow-Origin: http://localhost:8001' "$probe_dir/dev.headers"
+
+          cross_status="$(curl --noproxy '*' -sS -o /dev/null -w '%{http_code}' \
+            -H 'Origin: https://attacker.example' http://127.0.0.1:9000/api/get-account)"
+          [[ "$cross_status" == 403 ]]
+
+          data_dir="$probe_dir/home/.local/share/casos"
+          [[ -f "$data_dir/casos.db" ]]
+          [[ -d "$data_dir/kine" ]]
+          [[ -d "$data_dir/tls" ]]
+          [[ -d "$data_dir/sessions" ]]
+          [[ "$(stat -c '%a' "$data_dir")" == 700 ]]
+
+  standalone-bundle:
+    name: Bundle standalone release binaries
+    if: github.repository == 'casosorg/casos' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: [ standalone ]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: standalone-*-${{ github.run_id }}
+          path: ./dist
+          merge-multiple: true
+      - name: Generate release checksums
+        shell: bash
+        run: (cd dist && sha256sum casos_* > SHA256SUMS)
+      - name: Upload standalone release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: standalone-binaries-${{ github.run_id }}
+          path: ./dist
+          retention-days: 1
 
   ui-tests:
     name: UI tests
@@ -414,7 +547,7 @@ jobs:
       contents: write
       issues: write
     if: github.repository == 'casosorg/casos' && github.event_name == 'push'
-    needs: [ frontend, ui-tests, backend, linter ]
+    needs: [ frontend, standalone-bundle, ui-tests, backend, linter ]
     outputs:
       new-release-published: ${{ steps.semantic.outputs.new_release_published }}
       new-release-version: ${{ steps.semantic.outputs.new_release_version }}
@@ -437,7 +570,14 @@ jobs:
     if: github.repository == 'casosorg/casos' && github.event_name == 'push' && needs.tag-release.outputs.new-release-published == 'true'
     needs: [ tag-release ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: standalone-binaries-${{ github.run_id }}
+          path: ./dist
+      - name: Upload standalone binaries
+        run: gh release upload "v${{ needs.tag-release.outputs.new-release-version }}" ./dist/* --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish release
         run: gh release edit "v${{ needs.tag-release.outputs.new-release-version }}" --draft=false
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,6 +2,11 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "draftRelease": true
+      }
+    ]
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Release](https://img.shields.io/github/v/release/casosorg/casos?style=flat-square&color=4f46e5)](https://github.com/casosorg/casos/releases/latest)
 [![Go Report](https://goreportcard.com/badge/github.com/casosorg/casos?style=flat-square)](https://goreportcard.com/report/github.com/casosorg/casos)
 [![License](https://img.shields.io/github/license/casosorg/casos?style=flat-square&color=22c55e)](https://github.com/casosorg/casos/blob/master/LICENSE)
-[![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-blue?style=flat-square)](https://github.com/casosorg/casos/releases/latest)
+[![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Windows-blue?style=flat-square)](https://github.com/casosorg/casos/releases/latest)
 [![Discord](https://img.shields.io/discord/1022748306096537660?logo=discord&label=discord&color=5865F2&style=flat-square)](https://discord.gg/6ma4BAmV7P)
 
 **Official Website: [https://www.casos.net](https://www.casos.net)**
@@ -71,7 +71,49 @@ casos/
 - **Frontend**: [Node.js](https://nodejs.org/) 20+ and [Yarn](https://classic.yarnpkg.com/) 1.x
 - A [Casdoor](https://casdoor.org) instance (for authentication)
 
-Supported platforms: **Linux**, **macOS**, **Windows**
+Standalone releases are currently supported on **Linux** and **Windows** for
+amd64 and arm64.
+
+## Install
+
+Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/casosorg/casos/master/scripts/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/casosorg/casos/master/scripts/install.ps1 | iex
+```
+
+The installers select the release binary for the current OS and architecture,
+verify it against the published `SHA256SUMS`, install it for the current user,
+and start CasOS at `http://127.0.0.1:9000`. On Linux, the default binary
+location is `~/.local/bin/casos`, separate from the data directory.
+On Windows, exit a running CasOS process before rerunning the installer to
+upgrade it; the installer refuses to replace an executable that is in use.
+
+Set `CASOS_VERSION` to an explicit release tag to select the downloaded binary
+version. The installer script itself still comes from the branch or commit in
+the script URL, so pin that URL as well when a fully reproducible historical
+installation is required. `SHA256SUMS` detects download corruption; it is not a
+substitute for release signing, provenance, or artifact attestation.
+
+A standalone installation without `conf/app.conf` stores its persistent data in
+the platform user-data directory:
+
+| Platform | Default data directory |
+|----------|------------------------|
+| Linux | `$XDG_DATA_HOME/casos`, or `~/.local/share/casos` when `XDG_DATA_HOME` is unset |
+| Windows | `%LOCALAPPDATA%\CasOS` |
+
+Set `CASOS_DATA_DIR` before starting CasOS to use a different standalone data
+directory. Keep that value stable across restarts so CasOS continues to use the
+same database, Kubernetes state, TLS material, and sessions. A newly created
+standalone data root and its managed subdirectories use mode `0700` on Unix;
+existing explicitly managed directory permissions are preserved.
 
 ## Configuration
 
@@ -80,6 +122,7 @@ Edit `conf/app.conf` with your values:
 ```ini
 appname       = casos
 httpport      = 9000
+httpBind      =
 runmode       = dev
 
 ; Database
@@ -104,15 +147,36 @@ socks5Proxy =
 apiserverPort = 6443
 apiserverBind = 127.0.0.1
 dataDir       = ./data
+storageProvisionerEnabled = true
+localPathRoot =
 ```
 
-SQLite is the default and stores CasOS business data in `data/casos.db` and
-Kubernetes state in `data/kine/state.db`. The `data` directory is ignored by
-Git and is writable when running the development command from the repository
-root.
+Source and configured builds keep the historical empty `httpBind` default and
+listen on all interfaces. Standalone binaries built with `-tags embed` default
+to `127.0.0.1`. Set `httpBind` explicitly to override the default for either
+build type. The supported frontend development origin
+`http://localhost:8001` may access the backend at `http://localhost:9000`;
+other browser origins must match the effective backend origin.
+
+When running from the repository, the checked-in `conf/app.conf` explicitly
+sets `dataDir=./data`. SQLite therefore stores CasOS business data in
+`data/casos.db` and Kubernetes state in `data/kine/state.db`. The `data`
+directory is ignored by Git and is writable when running the development
+command from the repository root. This configured development behavior is
+separate from the standalone defaults documented above.
+
+The built-in local-path provisioner defaults to disabled on Windows standalone
+binaries because `%LOCALAPPDATA%\CasOS` is a Windows control-plane path, not a
+valid storage root on Linux worker nodes. To enable it explicitly, set
+`storageProvisionerEnabled=true` and set `localPathRoot` to an absolute POSIX
+path available on the Linux workers, for example
+`/var/lib/casos/local-path-provisioner`. Linux and configured/source builds keep
+the existing enabled default; when `localPathRoot` is blank, they derive it from
+`dataDir` as before.
 
 > **Breaking change:** `dataDir` used to default to `/var/lib/casos`. It now
-> defaults to `./data`, which is resolved against the working directory of the
+> defaults to `./data` for deployments that use `conf/app.conf`. That relative
+> path is resolved against the working directory of the
 > CasOS process, so starting CasOS from a different directory points it at a
 > different — and most likely empty — data directory. Besides the two SQLite
 > databases, `dataDir` also holds the control-plane TLS material and the key

--- a/casdoor/init.go
+++ b/casdoor/init.go
@@ -3,18 +3,18 @@ package casdoor
 import (
 	_ "embed"
 
-	"github.com/beego/beego"
 	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
+	"github.com/casosorg/casos/conf"
 )
 
 //go:embed token_jwt_key.pem
 var JwtPublicKey string
 
 func InitCasdoorConfig() {
-	casdoorEndpoint := beego.AppConfig.String("casdoorEndpoint")
-	clientId := beego.AppConfig.String("clientId")
-	clientSecret := beego.AppConfig.String("clientSecret")
-	casdoorOrganization := beego.AppConfig.String("casdoorOrganization")
-	casdoorApplication := beego.AppConfig.String("casdoorApplication")
+	casdoorEndpoint := conf.GetConfigString("casdoorEndpoint")
+	clientId := conf.GetConfigString("clientId")
+	clientSecret := conf.GetConfigString("clientSecret")
+	casdoorOrganization := conf.GetConfigString("casdoorOrganization")
+	casdoorApplication := conf.GetConfigString("casdoorApplication")
 	casdoorsdk.InitConfig(casdoorEndpoint, clientId, clientSecret, JwtPublicKey, casdoorOrganization, casdoorApplication)
 }

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -1,5 +1,6 @@
 appname       = casos
 httpport      = 9000
+httpBind      =
 runmode       = dev
 SessionOn     = true
 copyrequestbody = true
@@ -39,5 +40,7 @@ helmInstallTimeout = 20m
 apiserverPort = 6443
 apiserverBind = 127.0.0.1
 dataDir       = ./data
+storageProvisionerEnabled = true
+localPathRoot =
 ingressControllerEnabled = true
 serviceLBEnabled = true

--- a/conf/build_disk.go
+++ b/conf/build_disk.go
@@ -1,0 +1,9 @@
+//go:build !embed
+
+package conf
+
+const standaloneBuild = false
+
+func standaloneConfigValue(string) string {
+	return ""
+}

--- a/conf/build_embed.go
+++ b/conf/build_embed.go
@@ -1,0 +1,31 @@
+//go:build embed
+
+package conf
+
+import (
+	_ "embed"
+
+	beegoconfig "github.com/beego/beego/config"
+)
+
+const standaloneBuild = true
+
+//go:embed app.conf
+var standaloneAppConfig []byte
+
+var standaloneDefaults beegoconfig.Configer
+
+func init() {
+	config, err := beegoconfig.NewConfigData("ini", standaloneAppConfig)
+	if err != nil {
+		panic(err)
+	}
+	standaloneDefaults = config
+}
+
+func standaloneConfigValue(key string) string {
+	if standaloneDefaults == nil {
+		return ""
+	}
+	return standaloneDefaults.String(key)
+}

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -16,6 +16,7 @@ package conf
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -28,6 +29,16 @@ import (
 )
 
 const DefaultDataDir = "./data"
+
+var builtInDefaults = map[string]string{
+	"appname":             "casos",
+	"driverName":          "sqlite",
+	"casdoorEndpoint":     "https://door.casdoor.com",
+	"clientId":            "af6b5aa958822fb9dc33",
+	"clientSecret":        "8bc3010c1c951c8d876b1f311a901ff8deeb93bc",
+	"casdoorOrganization": "casbin",
+	"casdoorApplication":  "app-casibase",
+}
 
 var (
 	dataDirOnce     sync.Once
@@ -55,10 +66,15 @@ func GetConfigString(key string) string {
 	// the only place in the codebase that reads beego's app.conf directly
 	res := beego.AppConfig.String(key)
 	if res == "" {
-		if key == "staticBaseUrl" {
+		res = standaloneConfigValue(key)
+	}
+	if res == "" {
+		if value, ok := builtInDefaults[key]; ok {
+			res = value
+		} else if key == "staticBaseUrl" {
 			res = "https://cdn.casbin.org"
 		} else if key == "logConfig" {
-			res = fmt.Sprintf("{\"filename\": \"logs/%s.log\", \"maxdays\":99999, \"perm\":\"0770\"}", GetConfigString("appname"))
+			res = fmt.Sprintf("{\"filename\": %q, \"maxdays\":99999, \"perm\":\"0600\"}", filepath.Join(GetDataDir(), "logs", GetConfigString("appname")+".log"))
 		}
 	}
 
@@ -128,6 +144,20 @@ func GetConfigIntDefault(key string, defaultValue int) int {
 	return res
 }
 
+// GetHTTPListenAddress preserves the all-interface source-build listener while
+// defaulting standalone binaries to loopback. httpBind overrides either default.
+func GetHTTPListenAddress(port int) string {
+	bind := strings.TrimSpace(GetConfigString("httpBind"))
+	if bind == "" && standaloneBuild {
+		bind = "127.0.0.1"
+	}
+	return net.JoinHostPort(bind, strconv.Itoa(port))
+}
+
+func IsStandaloneBuild() bool {
+	return standaloneBuild
+}
+
 func GetConfigInt64(key string) (int64, error) {
 	value := GetConfigString(key)
 	num, err := strconv.ParseInt(value, 10, 64)
@@ -172,7 +202,20 @@ func GetDatabaseDataSourceName() string {
 // key if anything ever changed the working directory.
 func GetDataDir() string {
 	dataDirOnce.Do(func() {
-		dataDir := GetConfigStringDefault("dataDir", DefaultDataDir)
+		userDataDir := ""
+		if standaloneBuild {
+			userDataDir = defaultUserDataDir()
+		}
+		configuredDataDir := strings.TrimSpace(os.Getenv("dataDir"))
+		if configuredDataDir == "" {
+			configuredDataDir = strings.TrimSpace(beego.AppConfig.String("dataDir"))
+		}
+		dataDir := resolveDataDir(
+			standaloneBuild,
+			os.Getenv("CASOS_DATA_DIR"),
+			configuredDataDir,
+			userDataDir,
+		)
 		resolvedDataDir = dataDir
 		if absolutePath, err := filepath.Abs(dataDir); err == nil {
 			resolvedDataDir = absolutePath
@@ -180,6 +223,73 @@ func GetDataDir() string {
 		logs.Info("casos data directory: %s", resolvedDataDir)
 	})
 	return resolvedDataDir
+}
+
+func resolveDataDir(standalone bool, casosDataDir, configuredDataDir, userDataDir string) string {
+	if dataDir := strings.TrimSpace(casosDataDir); dataDir != "" {
+		return dataDir
+	}
+	if dataDir := strings.TrimSpace(configuredDataDir); dataDir != "" {
+		return dataDir
+	}
+	if standalone {
+		return userDataDir
+	}
+	return DefaultDataDir
+}
+
+func defaultUserDataDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+	return defaultDataDir(runtime.GOOS, home, os.Getenv("XDG_DATA_HOME"), os.Getenv("LOCALAPPDATA"))
+}
+
+func defaultDataDir(goos, home, xdgDataHome, localAppData string) string {
+	switch goos {
+	case "windows":
+		if localAppData != "" {
+			return filepath.Join(localAppData, "CasOS")
+		}
+	case "darwin":
+		if home != "" {
+			return filepath.Join(home, "Library", "Application Support", "CasOS")
+		}
+	default:
+		if xdgDataHome != "" {
+			return filepath.Join(xdgDataHome, "casos")
+		}
+		if home != "" {
+			return filepath.Join(home, ".local", "share", "casos")
+		}
+	}
+	return DefaultDataDir
+}
+
+func EnsureDataDir() error {
+	dataDir := GetDataDir()
+	for _, dir := range []string{dataDir, filepath.Join(dataDir, "logs"), GetSessionDir()} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("create data directory %q: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func GetSessionDir() string {
+	configuredDataDir := strings.TrimSpace(os.Getenv("dataDir"))
+	if configuredDataDir == "" {
+		configuredDataDir = strings.TrimSpace(beego.AppConfig.String("dataDir"))
+	}
+	return resolveSessionDir(standaloneBuild, os.Getenv("CASOS_DATA_DIR"), configuredDataDir, GetDataDir())
+}
+
+func resolveSessionDir(standalone bool, casosDataDir, configuredDataDir, dataDir string) string {
+	if strings.TrimSpace(casosDataDir) == "" && (!standalone || strings.TrimSpace(configuredDataDir) != "") {
+		return "./tmp"
+	}
+	return filepath.Join(dataDir, "sessions")
 }
 
 func resolveDatabaseDataSourceName(driverName, dataSourceName, dataDir string) string {

--- a/main.go
+++ b/main.go
@@ -24,6 +24,9 @@ func main() {
 	// Allow multiple in-process Kubernetes components to reinitialise the global
 	// logging singleton without killing the process.
 	logsapi.ReapplyHandling = logsapi.ReapplyHandlingIgnoreUnchanged
+	if err := conf.EnsureDataDir(); err != nil {
+		panic(err)
+	}
 
 	object.InitFlag()
 	object.InitAdapter()
@@ -95,10 +98,11 @@ func main() {
 	beego.BConfig.CopyRequestBody = true
 	beego.BConfig.WebConfig.Session.SessionOn = true
 	beego.BConfig.WebConfig.Session.SessionProvider = "file"
-	beego.BConfig.WebConfig.Session.SessionProviderConfig = "./tmp"
+	beego.BConfig.WebConfig.Session.SessionProviderConfig = conf.GetSessionDir()
 	beego.BConfig.WebConfig.Session.SessionGCMaxLifetime = 3600 * 24 * 365
 
 	port := conf.GetConfigIntDefault("httpport", 9000)
-	logs.Info("casos listening on :%d", port)
-	beego.Run(fmt.Sprintf(":%v", port))
+	listenAddress := conf.GetHTTPListenAddress(port)
+	logs.Info("casos listening on %s", listenAddress)
+	beego.Run(listenAddress)
 }

--- a/routers/cors_filter.go
+++ b/routers/cors_filter.go
@@ -1,7 +1,11 @@
 package routers
 
 import (
+	"net"
 	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/beego/beego/context"
 )
@@ -9,13 +13,169 @@ import (
 func CorsFilter(ctx *context.Context) {
 	origin := ctx.Request.Header.Get("Origin")
 	if origin == "" {
-		origin = "*"
+		return
 	}
+	if !isAllowedOriginRequest(origin, ctx.Request) {
+		ctx.Abort(http.StatusForbidden, "")
+		return
+	}
+
+	ctx.ResponseWriter.Header().Add("Vary", "Origin")
 	ctx.ResponseWriter.Header().Set("Access-Control-Allow-Origin", origin)
 	ctx.ResponseWriter.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, PATCH, OPTIONS")
 	ctx.ResponseWriter.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
 	ctx.ResponseWriter.Header().Set("Access-Control-Allow-Credentials", "true")
 	if ctx.Request.Method == http.MethodOptions {
-		ctx.ResponseWriter.WriteHeader(http.StatusOK)
+		ctx.Abort(http.StatusNoContent, "")
 	}
+}
+
+func isAllowedOriginRequest(origin string, request *http.Request) bool {
+	parsedOrigin, err := url.Parse(origin)
+	if err != nil || parsedOrigin.Scheme == "" || parsedOrigin.Host == "" ||
+		parsedOrigin.User != nil || (parsedOrigin.Path != "" && parsedOrigin.Path != "/") ||
+		parsedOrigin.RawQuery != "" || parsedOrigin.Fragment != "" {
+		return false
+	}
+
+	requestScheme, requestHost, ok := requestOrigin(request)
+	if !ok {
+		return false
+	}
+	if sameOrigin(parsedOrigin.Scheme, parsedOrigin.Host, requestScheme, requestHost) {
+		return true
+	}
+
+	return strings.EqualFold(parsedOrigin.Scheme, "http") &&
+		strings.EqualFold(requestScheme, "http") &&
+		isLoopbackDevelopmentPair(parsedOrigin.Host, requestHost)
+}
+
+func sameOrigin(leftScheme, leftHost, rightScheme, rightHost string) bool {
+	leftHostname, leftPort, leftOK := canonicalOriginHost(leftScheme, leftHost)
+	rightHostname, rightPort, rightOK := canonicalOriginHost(rightScheme, rightHost)
+	return leftOK && rightOK && strings.EqualFold(leftScheme, rightScheme) &&
+		strings.EqualFold(leftHostname, rightHostname) && leftPort == rightPort
+}
+
+func canonicalOriginHost(scheme, host string) (string, string, bool) {
+	parsed, err := url.Parse("//" + host)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.Path != "" ||
+		parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", "", false
+	}
+	port := parsed.Port()
+	if port == "" {
+		switch strings.ToLower(scheme) {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		default:
+			return "", "", false
+		}
+	}
+	return parsed.Hostname(), port, parsed.Hostname() != ""
+}
+
+func isLoopbackDevelopmentPair(originHost, requestHost string) bool {
+	return isLoopbackHostPort(originHost, "8001") && isLoopbackHostPort(requestHost, "9000") ||
+		isLoopbackHostPort(originHost, "9000") && isLoopbackHostPort(requestHost, "8001")
+}
+
+func isLoopbackHostPort(hostPort, expectedPort string) bool {
+	parsed, err := url.Parse("//" + hostPort)
+	if err != nil || parsed.Port() != expectedPort {
+		return false
+	}
+	hostname := parsed.Hostname()
+	if strings.EqualFold(hostname, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	return ip != nil && ip.IsLoopback()
+}
+
+func requestOrigin(request *http.Request) (string, string, bool) {
+	requestScheme := request.URL.Scheme
+	if requestScheme == "" {
+		requestScheme = "http"
+		if request.TLS != nil {
+			requestScheme = "https"
+		}
+	}
+	requestHost := request.Host
+
+	if forwarded := strings.TrimSpace(request.Header.Get("Forwarded")); forwarded != "" {
+		proto, host, ok := parseForwardedOrigin(forwarded)
+		if !ok {
+			return "", "", false
+		}
+		if proto != "" {
+			requestScheme = proto
+		}
+		if host != "" {
+			requestHost = host
+		}
+	} else {
+		proto := strings.ToLower(strings.TrimSpace(request.Header.Get("X-Forwarded-Proto")))
+		host := strings.TrimSpace(request.Header.Get("X-Forwarded-Host"))
+		if strings.Contains(proto, ",") || strings.Contains(host, ",") {
+			return "", "", false
+		}
+		if proto != "" {
+			requestScheme = proto
+		}
+		if host != "" {
+			requestHost = host
+		}
+	}
+
+	if requestScheme != "http" && requestScheme != "https" {
+		return "", "", false
+	}
+	if !validOriginHost(requestHost) {
+		return "", "", false
+	}
+	return requestScheme, requestHost, true
+}
+
+func parseForwardedOrigin(value string) (string, string, bool) {
+	if strings.Contains(value, ",") {
+		return "", "", false
+	}
+	var proto, host string
+	for _, parameter := range strings.Split(value, ";") {
+		key, rawValue, found := strings.Cut(strings.TrimSpace(parameter), "=")
+		if !found {
+			return "", "", false
+		}
+		parsedValue := strings.TrimSpace(rawValue)
+		if strings.HasPrefix(parsedValue, `"`) {
+			unquoted, err := strconv.Unquote(parsedValue)
+			if err != nil {
+				return "", "", false
+			}
+			parsedValue = unquoted
+		}
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "proto":
+			if proto != "" {
+				return "", "", false
+			}
+			proto = strings.ToLower(parsedValue)
+		case "host":
+			if host != "" {
+				return "", "", false
+			}
+			host = parsedValue
+		}
+	}
+	return proto, host, true
+}
+
+func validOriginHost(host string) bool {
+	parsed, err := url.Parse("//" + host)
+	return err == nil && parsed.Host != "" && parsed.User == nil && parsed.Path == "" &&
+		parsed.RawQuery == "" && parsed.Fragment == ""
 }

--- a/routers/static_filter.go
+++ b/routers/static_filter.go
@@ -1,12 +1,19 @@
 package routers
 
 import (
+	"bytes"
+	"io/fs"
+	"mime"
 	"net/http"
-	"path/filepath"
+	"path"
 	"strings"
+	"time"
 
 	"github.com/beego/beego/context"
+	webassets "github.com/casosorg/casos/web"
 )
+
+var staticAssets = webassets.Files()
 
 func StaticFilter(ctx *context.Context) {
 	urlPath := ctx.Request.URL.Path
@@ -17,26 +24,20 @@ func StaticFilter(ctx *context.Context) {
 		return
 	}
 
-	path := "web/build"
-	if urlPath == "/" {
-		path += "/index.html"
-	} else {
-		path += urlPath
+	assetPath := strings.TrimPrefix(path.Clean(urlPath), "/")
+	if assetPath == "." || assetPath == "" {
+		assetPath = "index.html"
 	}
-
-	if fileExists(path) {
-		http.ServeFile(ctx.ResponseWriter, ctx.Request, path)
-	} else if filepath.Ext(urlPath) == "" {
-		// Unknown path without extension — let React router handle it.
-		http.ServeFile(ctx.ResponseWriter, ctx.Request, "web/build/index.html")
+	content, err := fs.ReadFile(staticAssets, assetPath)
+	if err != nil && path.Ext(assetPath) == "" {
+		assetPath = "index.html"
+		content, err = fs.ReadFile(staticAssets, assetPath)
 	}
-}
-
-func fileExists(path string) bool {
-	f, err := http.Dir(".").Open(path)
 	if err != nil {
-		return false
+		return
 	}
-	f.Close()
-	return true
+	if contentType := mime.TypeByExtension(path.Ext(assetPath)); contentType != "" {
+		ctx.ResponseWriter.Header().Set("Content-Type", contentType)
+	}
+	http.ServeContent(ctx.ResponseWriter, ctx.Request, assetPath, time.Time{}, bytes.NewReader(content))
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,66 @@
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'casosorg/casos'
+$Version = if ($env:CASOS_VERSION) { $env:CASOS_VERSION } else { 'latest' }
+$InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA 'CasOS\bin' }
+
+if ($Version -eq 'latest') {
+    Write-Host 'Fetching latest CasOS release...'
+    $Version = (Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest").tag_name
+    if (-not $Version) { throw 'Could not resolve the latest release.' }
+}
+if ($Version -notmatch '^v[0-9A-Za-z._-]+$') { throw "Invalid release version: $Version" }
+
+$Architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+$ArchName = switch ($Architecture) {
+    'X64' { 'amd64' }
+    'Arm64' { 'arm64' }
+    default { throw "Unsupported architecture: $Architecture" }
+}
+
+$Filename = "casos_windows_${ArchName}.exe"
+$ReleaseUrl = "https://github.com/$Repo/releases/download/$Version"
+$TempDir = Join-Path $env:TEMP "casos_install_$([guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $TempDir | Out-Null
+
+try {
+    $ExePath = Join-Path $TempDir $Filename
+    $ChecksumsPath = Join-Path $TempDir 'SHA256SUMS'
+    Write-Host "Downloading CasOS $Version..."
+    Invoke-WebRequest -Uri "$ReleaseUrl/$Filename" -OutFile $ExePath -UseBasicParsing
+    Invoke-WebRequest -Uri "$ReleaseUrl/SHA256SUMS" -OutFile $ChecksumsPath -UseBasicParsing
+
+    $ChecksumLine = Get-Content $ChecksumsPath | Where-Object { $_ -match "^[0-9a-fA-F]{64}\s+\*?$([regex]::Escape($Filename))$" } | Select-Object -First 1
+    if (-not $ChecksumLine) { throw "Release checksum for $Filename was not found." }
+    $Expected = ($ChecksumLine -split '\s+')[0].ToLowerInvariant()
+    $Actual = (Get-FileHash -Algorithm SHA256 -Path $ExePath).Hash.ToLowerInvariant()
+    if ($Actual -ne $Expected) { throw 'Download checksum verification failed.' }
+
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    $InstalledExe = Join-Path $InstallDir 'casos.exe'
+    $PendingExe = Join-Path $InstallDir 'casos.new.exe'
+    if (Test-Path $InstalledExe) {
+        $RunningCasOS = Get-CimInstance Win32_Process -Filter "Name = 'casos.exe'" -ErrorAction SilentlyContinue |
+            Where-Object { $_.ExecutablePath -and ([System.IO.Path]::GetFullPath($_.ExecutablePath) -eq [System.IO.Path]::GetFullPath($InstalledExe)) }
+        if ($RunningCasOS) {
+            throw 'CasOS is currently running. Exit CasOS, then run the installer again to upgrade.'
+        }
+    }
+    Copy-Item -Path $ExePath -Destination $PendingExe -Force
+    Move-Item -Path $PendingExe -Destination $InstalledExe -Force
+} finally {
+    Remove-Item -Recurse -Force $TempDir -ErrorAction SilentlyContinue
+}
+
+$UserPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+$PathEntries = @($UserPath -split ';' | Where-Object { $_ })
+if ($PathEntries -notcontains $InstallDir) {
+    $NewUserPath = (@($PathEntries) + $InstallDir) -join ';'
+    [Environment]::SetEnvironmentVariable('PATH', $NewUserPath, 'User')
+    Write-Host "Added $InstallDir to your user PATH."
+}
+$env:PATH = "$env:PATH;$InstallDir"
+
+Write-Host "CasOS $Version installed at $InstalledExe"
+Write-Host 'Starting CasOS at http://127.0.0.1:9000 ...'
+& $InstalledExe

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERSION="${CASOS_VERSION:-latest}"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+INSTALL_DIR="${INSTALL_DIR:-$BIN_DIR}"
+REPO="casosorg/casos"
+
+info() { printf '%s\n' "$*"; }
+die() { printf '[casos] %s\n' "$*" >&2; exit 1; }
+
+command -v curl >/dev/null 2>&1 || die "required command not found: curl"
+
+if [[ "$VERSION" == "latest" ]]; then
+  info "Fetching latest CasOS release..."
+  VERSION="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" |
+    sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  [[ -n "$VERSION" ]] || die "could not resolve the latest release"
+fi
+
+[[ "$VERSION" =~ ^v[0-9A-Za-z._-]+$ ]] || die "invalid release version: $VERSION"
+
+case "$(uname -s)" in
+  Linux) os_name="linux" ;;
+  *) die "unsupported operating system: $(uname -s)" ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64) arch_name="amd64" ;;
+  arm64|aarch64) arch_name="arm64" ;;
+  *) die "unsupported architecture: $(uname -m)" ;;
+esac
+
+filename="casos_${os_name}_${arch_name}"
+release_url="https://github.com/$REPO/releases/download/$VERSION"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "$temp_dir"' EXIT
+
+info "Downloading CasOS $VERSION..."
+curl -fsSL --retry 3 -o "$temp_dir/$filename" "$release_url/$filename"
+curl -fsSL --retry 3 -o "$temp_dir/SHA256SUMS" "$release_url/SHA256SUMS"
+
+expected="$(sed -n "s/^\([[:xdigit:]]\{64\}\)[[:space:]]\+\*\{0,1\}${filename}$/\1/p" "$temp_dir/SHA256SUMS")"
+[[ -n "$expected" ]] || die "release checksum for $filename was not found"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$temp_dir/$filename" | cut -d ' ' -f 1)"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$temp_dir/$filename" | cut -d ' ' -f 1)"
+else
+  die "sha256sum or shasum is required to verify the download"
+fi
+[[ "$actual" == "$expected" ]] || die "download checksum verification failed"
+
+mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd -P)"
+BIN_DIR="$(cd "$BIN_DIR" && pwd -P)"
+install -m 0755 "$temp_dir/$filename" "$INSTALL_DIR/casos.new"
+mv -f "$INSTALL_DIR/casos.new" "$INSTALL_DIR/casos"
+if [[ "$BIN_DIR/casos" != "$INSTALL_DIR/casos" ]]; then
+  ln -sfn "$INSTALL_DIR/casos" "$BIN_DIR/casos"
+fi
+
+if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+  info "$BIN_DIR is not on PATH; add it to your shell profile to run 'casos' later."
+fi
+
+info "CasOS $VERSION installed at $INSTALL_DIR/casos"
+info "Starting CasOS at http://127.0.0.1:9000 ..."
+export PATH="$BIN_DIR:$PATH"
+exec "$INSTALL_DIR/casos"

--- a/server/cobra_windows.go
+++ b/server/cobra_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package server
+
+import "github.com/spf13/cobra"
+
+func init() {
+	// CasOS embeds Cobra-based Kubernetes components and supports Explorer startup.
+	cobra.MousetrapHelpText = ""
+}

--- a/server/config.go
+++ b/server/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/casosorg/casos/conf"
@@ -23,6 +24,7 @@ type Config struct {
 	CoreDNSImage              string             // CoreDNS image used by the built-in DNS bootstrap
 	LocalPathProvisionerImage string             // local-path-provisioner controller image
 	LocalPathHelperImage      string             // helper pod image used by local-path-provisioner
+	LocalPathRoot             string             // POSIX path on Linux worker nodes used for local volumes
 	FlannelImage              string             // Flannel daemon image used by the built-in network bootstrap
 	FlannelCNIPluginImage     string             // Flannel CNI plugin image installed on worker hosts
 	IngressControllerImage    string             // Traefik image used by the built-in Ingress controller
@@ -36,7 +38,11 @@ type Config struct {
 // ConfigFromAppConf reads server config from the beego app.conf.
 func ConfigFromAppConf() (Config, error) {
 	dataDir := conf.GetDataDir()
-	bind := conf.GetConfigStringDefault("apiserverBind", outboundIP())
+	standalone := conf.IsStandaloneBuild()
+	bind := strings.TrimSpace(conf.GetConfigString("apiserverBind"))
+	if bind == "" {
+		bind = outboundIP()
+	}
 	port := conf.GetConfigIntDefault("apiserverPort", 6443)
 	driverName := conf.GetDatabaseDriverName()
 	dataSourceName := conf.GetDatabaseDataSourceName()
@@ -61,7 +67,9 @@ func ConfigFromAppConf() (Config, error) {
 
 	sandboxImage := conf.GetConfigStringDefault("sandboxImage", "registry.k8s.io/pause:3.10.1")
 
-	storageProvisionerEnabled := conf.GetConfigBoolDefault("storageProvisionerEnabled", true)
+	defaultStorageEnabled, defaultLocalPathRoot := storageProvisionerDefaults(runtime.GOOS, standalone, dataDir)
+	storageProvisionerEnabled := conf.GetConfigBoolDefault("storageProvisionerEnabled", defaultStorageEnabled)
+	localPathRoot := conf.GetConfigStringDefault("localPathRoot", defaultLocalPathRoot)
 	coreDNSImage := conf.GetConfigStringDefault("coreDNSImage", "docker.io/coredns/coredns:1.12.4")
 	localPathProvisionerImage := conf.GetConfigStringDefault("localPathProvisionerImage", "docker.io/rancher/local-path-provisioner:v0.0.32")
 	localPathHelperImage := conf.GetConfigStringDefault("localPathHelperImage", "docker.io/library/busybox:1.37.0")
@@ -86,6 +94,7 @@ func ConfigFromAppConf() (Config, error) {
 		CoreDNSImage:              coreDNSImage,
 		LocalPathProvisionerImage: localPathProvisionerImage,
 		LocalPathHelperImage:      localPathHelperImage,
+		LocalPathRoot:             localPathRoot,
 		FlannelImage:              flannelImage,
 		FlannelCNIPluginImage:     flannelCNIPluginImage,
 		IngressControllerImage:    ingressControllerImage,
@@ -97,6 +106,13 @@ func ConfigFromAppConf() (Config, error) {
 	}
 	normalizeApplicationAccessConfig(&config)
 	return config, nil
+}
+
+func storageProvisionerDefaults(goos string, standalone bool, dataDir string) (bool, string) {
+	if goos == "windows" && standalone {
+		return false, ""
+	}
+	return true, filepath.ToSlash(filepath.Join(dataDir, "local-path-provisioner"))
 }
 
 func resolveDatastoreEndpoint(driverName, dataSourceName, dbName, dataDir, configuredEndpoint string) (string, error) {

--- a/server/storage_bootstrap.go
+++ b/server/storage_bootstrap.go
@@ -37,11 +37,10 @@ type localPathNodePathMap struct {
 }
 
 func ensureDefaultStorageProvisioner(ctx context.Context, client kubernetes.Interface, cfg Config) error {
-	if !path.IsAbs(cfg.DataDir) {
-		return fmt.Errorf("dataDir must be absolute to enable local-path storage: %s", cfg.DataDir)
+	if !path.IsAbs(cfg.LocalPathRoot) {
+		return fmt.Errorf("localPathRoot must be an absolute POSIX path to enable local-path storage: %s", cfg.LocalPathRoot)
 	}
-	rootDir := path.Join(cfg.DataDir, "local-path-provisioner")
-	configData, err := localPathConfigData(rootDir, cfg.LocalPathHelperImage)
+	configData, err := localPathConfigData(cfg.LocalPathRoot, cfg.LocalPathHelperImage)
 	if err != nil {
 		return err
 	}

--- a/web/assets_disk.go
+++ b/web/assets_disk.go
@@ -1,0 +1,12 @@
+//go:build !embed
+
+package webassets
+
+import (
+	"io/fs"
+	"os"
+)
+
+func Files() fs.FS {
+	return os.DirFS("web/build")
+}

--- a/web/assets_embed.go
+++ b/web/assets_embed.go
@@ -1,0 +1,19 @@
+//go:build embed
+
+package webassets
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed build
+var embedded embed.FS
+
+func Files() fs.FS {
+	files, err := fs.Sub(embedded, "build")
+	if err != nil {
+		panic(err)
+	}
+	return files
+}


### PR DESCRIPTION
## Summary

This pull request adds checksum-verified one-click standalone installers and release binaries for Linux and Windows amd64/arm64. Standalone binaries embed the production frontend, persist data outside the launch directory, bind to loopback by default, and preserve source/configured deployment compatibility. Release binaries are built before tag creation and published from verified artifacts.

## Verification

- `go test ./...`
- `go vet ./...`
- Bash and PowerShell installer parser checks
- Structured workflow validation
- Embedded/source runtime smoke checks
- Four-platform `CGO_ENABLED=0 -tags embed` builds
- UI and backend CI checks passed on the reviewed head

## Related PR

This upstream PR is associated with the validated fork PR: https://github.com/bugkeep/casos/pull/181

macOS standalone publication, local authentication, and Casdoor downgrade remain out of scope.