### PR TITLE
feat: add one-click installers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.ps1 text eol=crlf

--- a/README.md
+++ b/README.md
@@ -73,6 +73,33 @@ casos/
 
 Supported platforms: **Linux**, **macOS**, **Windows**
 
+## Install
+
+Linux (amd64 or arm64):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/casosorg/casos/master/scripts/install.sh | bash
+```
+
+Windows PowerShell (x64 or arm64):
+
+```powershell
+irm https://raw.githubusercontent.com/casosorg/casos/master/scripts/install.ps1 | iex
+```
+
+The installer downloads the matching binary from the latest GitHub release,
+verifies it against `SHA256SUMS`, and adds CasOS to your user `PATH`. On Linux,
+open a new shell or run the `source` command printed by the installer before
+running `casos`; the installer also prints the absolute executable path. On
+Windows, the current PowerShell session is updated immediately. Open
+`http://localhost:9000` after starting CasOS. Rerun the command to upgrade. Set
+`CASOS_VERSION` to a release tag such as `v1.32.0` to install that version.
+For a piped Linux install, pass installer variables to `bash`, not to `curl`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/casosorg/casos/master/scripts/install.sh | CASOS_VERSION=v1.32.0 INSTALL_DIR="$HOME/.local/bin" bash
+```
+
 ## Configuration
 
 Edit `conf/app.conf` with your values:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,89 @@
+# CasOS one-step installer, adapted from OpenAgent's Apache-2.0 installer.
+# Usage:
+#   irm https://raw.githubusercontent.com/casosorg/casos/master/scripts/install.ps1 | iex
+#
+# Optional environment variables:
+#   CASOS_VERSION  release tag such as v1.32.0 (default: latest)
+#   CASOS_REPOSITORY GitHub release repository (default: casosorg/casos)
+#   INSTALL_DIR    binary directory (default: $env:LOCALAPPDATA\CasOS\bin)
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = if ($env:CASOS_REPOSITORY) { $env:CASOS_REPOSITORY } else { 'casosorg/casos' }
+$Version = if ($env:CASOS_VERSION) { $env:CASOS_VERSION } else { 'latest' }
+$InstallDir = if ($env:INSTALL_DIR) {
+    if ($env:INSTALL_DIR.Contains([System.IO.Path]::PathSeparator)) {
+        throw 'INSTALL_DIR must not contain a PATH separator.'
+    }
+    [System.IO.Path]::GetFullPath($env:INSTALL_DIR)
+} else {
+    Join-Path $env:LOCALAPPDATA 'CasOS\bin'
+}
+
+if ($Repo -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') { throw "Invalid GitHub repository: $Repo" }
+
+if ($Version -eq 'latest') {
+    $ReleaseUrl = "https://github.com/$Repo/releases/latest/download"
+} else {
+    if ($Version -notmatch '^v[0-9A-Za-z._-]+$') { throw "Invalid release version: $Version" }
+    $ReleaseUrl = "https://github.com/$Repo/releases/download/$Version"
+}
+
+$Architecture = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+$ArchName = switch ($Architecture) {
+    'AMD64' { 'amd64' }
+    'ARM64' { 'arm64' }
+    default { throw "Unsupported architecture: $Architecture" }
+}
+
+$Filename = "casos_windows_${ArchName}.exe"
+$TempDir = Join-Path $env:TEMP "casos_install_$([guid]::NewGuid().ToString('N'))"
+$PendingExe = $null
+New-Item -ItemType Directory -Path $TempDir | Out-Null
+
+try {
+    $ExePath = Join-Path $TempDir $Filename
+    $ChecksumsPath = Join-Path $TempDir 'SHA256SUMS'
+    Write-Host "Downloading CasOS $Version..."
+    Invoke-WebRequest -Uri "$ReleaseUrl/$Filename" -OutFile $ExePath -UseBasicParsing
+    Invoke-WebRequest -Uri "$ReleaseUrl/SHA256SUMS" -OutFile $ChecksumsPath -UseBasicParsing
+
+    $ChecksumLine = Get-Content $ChecksumsPath |
+        Where-Object { $_ -match "^[0-9a-fA-F]{64}\s+\*?$([regex]::Escape($Filename))$" } |
+        Select-Object -First 1
+    if (-not $ChecksumLine) { throw "Release checksum for $Filename was not found." }
+    $Expected = ($ChecksumLine -split '\s+')[0].ToLowerInvariant()
+    $Actual = (Get-FileHash -Algorithm SHA256 -Path $ExePath).Hash.ToLowerInvariant()
+    if ($Actual -ne $Expected) { throw 'Download checksum verification failed.' }
+
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    $InstallDir = [System.IO.Path]::GetFullPath($InstallDir)
+    $InstalledExe = Join-Path $InstallDir 'casos.exe'
+    $PendingExe = Join-Path $InstallDir 'casos.new.exe'
+
+    if (Test-Path $InstalledExe) {
+        $RunningCasOS = Get-CimInstance Win32_Process -Filter "Name = 'casos.exe'" -ErrorAction SilentlyContinue |
+            Where-Object { $_.ExecutablePath -and ([System.IO.Path]::GetFullPath($_.ExecutablePath) -eq $InstalledExe) }
+        if ($RunningCasOS) {
+            throw 'CasOS is currently running. Exit CasOS, then run the installer again to upgrade.'
+        }
+    }
+
+    Copy-Item -Path $ExePath -Destination $PendingExe -Force
+    Move-Item -Path $PendingExe -Destination $InstalledExe -Force
+}
+finally {
+    Remove-Item -Recurse -Force $TempDir -ErrorAction SilentlyContinue
+    if ($PendingExe) { Remove-Item -Force $PendingExe -ErrorAction SilentlyContinue }
+}
+
+$UserPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+$PathEntries = @($UserPath -split ';' | Where-Object { $_ })
+if ($PathEntries -notcontains $InstallDir) {
+    [Environment]::SetEnvironmentVariable('PATH', (@($PathEntries) + $InstallDir) -join ';', 'User')
+    Write-Host "Added $InstallDir to your user PATH."
+}
+$env:PATH = "$env:PATH;$InstallDir"
+
+Write-Host "CasOS $Version installed at $InstalledExe"
+Write-Host "Run 'casos' and open http://localhost:9000"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# CasOS one-step installer, adapted from OpenAgent's Apache-2.0 installer.
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/casosorg/casos/master/scripts/install.sh | bash
+#
+# Optional environment variables:
+#   CASOS_VERSION  release tag such as v1.32.0 (default: latest)
+#   CASOS_REPOSITORY GitHub release repository (default: casosorg/casos)
+#   INSTALL_DIR    binary directory (default: $HOME/.local/bin)
+
+set -euo pipefail
+
+REPO="${CASOS_REPOSITORY:-casosorg/casos}"
+CASOS_VERSION="${CASOS_VERSION:-latest}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+info() { printf '%s\n' "$*"; }
+die() { printf '[casos] %s\n' "$*" >&2; exit 1; }
+
+[[ "$REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || die "invalid GitHub repository: $REPO"
+
+need_cmd() {
+	command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+need_cmd curl
+
+[[ "$INSTALL_DIR" != *:* ]] || die "INSTALL_DIR must not contain a PATH separator (:)"
+
+if [[ "$CASOS_VERSION" == "latest" ]]; then
+	RELEASE_URL="https://github.com/${REPO}/releases/latest/download"
+else
+	[[ "$CASOS_VERSION" =~ ^v[0-9A-Za-z._-]+$ ]] || die "invalid release version: $CASOS_VERSION"
+	RELEASE_URL="https://github.com/${REPO}/releases/download/${CASOS_VERSION}"
+fi
+
+case "$(uname -s)" in
+	Linux) OS_NAME="linux" ;;
+	*) die "unsupported operating system; download manually from https://github.com/${REPO}/releases" ;;
+esac
+
+case "$(uname -m)" in
+	x86_64|amd64) ARCH_NAME="amd64" ;;
+	aarch64|arm64) ARCH_NAME="arm64" ;;
+	*) die "unsupported architecture; download manually from https://github.com/${REPO}/releases" ;;
+esac
+
+FILENAME="casos_${OS_NAME}_${ARCH_NAME}"
+TEMP_DIR="$(mktemp -d)"
+PENDING=""
+cleanup() {
+	rm -rf "$TEMP_DIR"
+	[[ -z "$PENDING" ]] || rm -f "$PENDING"
+}
+trap cleanup EXIT
+
+info "Downloading CasOS ${CASOS_VERSION}..."
+curl -fsSL -o "$TEMP_DIR/$FILENAME" "$RELEASE_URL/$FILENAME"
+curl -fsSL -o "$TEMP_DIR/SHA256SUMS" "$RELEASE_URL/SHA256SUMS"
+
+EXPECTED="$(grep -E "^[0-9a-fA-F]{64}[[:space:]]+\\*?${FILENAME}$" "$TEMP_DIR/SHA256SUMS" | head -1 | awk '{print tolower($1)}' || true)"
+[[ -n "$EXPECTED" ]] || die "release checksum for $FILENAME was not found"
+if command -v sha256sum >/dev/null 2>&1; then
+	ACTUAL="$(sha256sum "$TEMP_DIR/$FILENAME" | awk '{print tolower($1)}')"
+elif command -v shasum >/dev/null 2>&1; then
+	ACTUAL="$(shasum -a 256 "$TEMP_DIR/$FILENAME" | awk '{print tolower($1)}')"
+else
+	die "required command not found: sha256sum or shasum"
+fi
+[[ "$ACTUAL" == "$EXPECTED" ]] || die "download checksum verification failed"
+
+mkdir -p "$INSTALL_DIR"
+INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd -P)"
+[[ -w "$INSTALL_DIR" ]] || die "installation directory is not writable: $INSTALL_DIR"
+
+PENDING="$INSTALL_DIR/.casos.new.$$"
+cp "$TEMP_DIR/$FILENAME" "$PENDING"
+chmod 755 "$PENDING"
+mv -f "$PENDING" "$INSTALL_DIR/casos"
+PENDING=""
+
+SHELL_RC=""
+LOGIN_SHELL="${SHELL:-}"
+if command -v getent >/dev/null 2>&1; then
+	DETECTED_LOGIN_SHELL="$(getent passwd "$(id -un)" | cut -d: -f7 || true)"
+	[[ -z "$DETECTED_LOGIN_SHELL" ]] || LOGIN_SHELL="$DETECTED_LOGIN_SHELL"
+fi
+case "$LOGIN_SHELL" in
+	*/zsh) SHELL_RC="$HOME/.zshrc" ;;
+	*/bash) SHELL_RC="$HOME/.bashrc" ;;
+esac
+PATH_LINE="$(printf 'export PATH=%q:"$PATH"' "$INSTALL_DIR")"
+if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]] && [[ -n "$SHELL_RC" ]] && \
+	! grep -Fq "$PATH_LINE" "$SHELL_RC" 2>/dev/null; then
+	printf '\n%s\n' "$PATH_LINE" >> "$SHELL_RC"
+	info "Added $INSTALL_DIR to PATH in $SHELL_RC."
+fi
+
+info "CasOS ${CASOS_VERSION} installed at $INSTALL_DIR/casos"
+if [[ ":$PATH:" == *":$INSTALL_DIR:"* ]]; then
+	info "Run 'casos' and open http://localhost:9000"
+elif [[ -n "$SHELL_RC" ]]; then
+	SOURCE_COMMAND="$(printf 'source %q' "$SHELL_RC")"
+	info "Open a new shell or run: $SOURCE_COMMAND"
+	info "Then run 'casos' and open http://localhost:9000"
+	info "You can also run '$INSTALL_DIR/casos' directly."
+else
+	info "Add $INSTALL_DIR to PATH for your shell, or run '$INSTALL_DIR/casos' directly."
+	info "Then open http://localhost:9000"
+fi


### PR DESCRIPTION
## Summary

Add one-click installers for released standalone binaries on Linux and Windows.

- Detect the host OS and architecture and download the matching release asset.
- Verify the binary against `SHA256SUMS` before installation.
- Install atomically into a user-writable directory and update the user PATH.
- Support `CASOS_VERSION` for pinned installs and `CASOS_REPOSITORY` for fork/test releases; the production default is `casosorg/casos`.
- Document the upstream `master` raw installer commands and correct piped Bash variable usage.

## Verification

- `wsl.exe bash -n scripts/install.sh` passed.
- Invalid Bash repository input exits before download with the expected error.
- PowerShell AST parsing passed.
- `git diff --check` passed.
- No Go tests, dependency files, or unrelated paths were changed.

This PR is based on `51c96539dbefff2f6a6d4a3aa814d2470c33a2b3` and keeps the fork-only test override out of the production default.