### PR TITLE
fix: open CasOS after Windows double-click

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,9 +7,11 @@ import (
 	"os/signal"
 	"runtime"
 	"syscall"
+	"time"
 
 	"github.com/beego/beego"
 	"github.com/beego/beego/logs"
+	"github.com/spf13/cobra"
 	logsapi "k8s.io/component-base/logs/api/v1"
 
 	"github.com/casosorg/casos/casdoor"
@@ -20,6 +22,7 @@ import (
 	"github.com/casosorg/casos/proxy"
 	"github.com/casosorg/casos/routers"
 	"github.com/casosorg/casos/server"
+	"github.com/casosorg/casos/util"
 )
 
 // Build metadata, set through -ldflags "-X main.version=..." when GoReleaser
@@ -37,6 +40,13 @@ func versionString() string {
 }
 
 func main() {
+	doubleClicked := util.IsDoubleClicked()
+	if doubleClicked {
+		// CasOS embeds Cobra-based Kubernetes commands. Cobra's Windows
+		// mousetrap would otherwise terminate the whole process after startup.
+		cobra.MousetrapHelpText = ""
+	}
+
 	// Allow multiple in-process Kubernetes components to reinitialise the global
 	// logging singleton without killing the process.
 	logsapi.ReapplyHandling = logsapi.ReapplyHandlingIgnoreUnchanged
@@ -126,6 +136,19 @@ func main() {
 	beego.BConfig.WebConfig.Session.SessionGCMaxLifetime = 3600 * 24 * 365
 
 	port := conf.GetConfigIntDefault("httpport", 9000)
+	url := fmt.Sprintf("http://localhost:%v/", port)
 	logs.Info("casos listening on :%d", port)
+	if doubleClicked {
+		go func() {
+			if err := util.WaitForCasOS(url, 30*time.Second); err != nil {
+				logs.Warning("CasOS startup: %v", err)
+				return
+			}
+			logs.Info("CasOS started successfully. Open %s in your browser.", url)
+			if err := util.ShowStartupNotice(url); err != nil {
+				logs.Warning("show startup notice: %v", err)
+			}
+		}()
+	}
 	beego.Run(fmt.Sprintf(":%v", port))
 }

--- a/util/launch_detect_unix.go
+++ b/util/launch_detect_unix.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package util
+
+// IsDoubleClicked is intentionally Windows-only for CasOS. Unix launches keep
+// their existing server behavior and never open a browser automatically.
+func IsDoubleClicked() bool {
+	return false
+}
+
+// ShowStartupNotice is a no-op because double-click handling is Windows-only.
+func ShowStartupNotice(string) error {
+	return nil
+}

--- a/util/launch_detect_windows.go
+++ b/util/launch_detect_windows.go
@@ -1,0 +1,150 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package util
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// IsDoubleClicked reports whether the process was launched by double-clicking
+// its executable in Explorer, rather than from a terminal or another program.
+func IsDoubleClicked() bool {
+	exe, err := os.Executable()
+	if err == nil && isGoBuildTemp(exe) {
+		return false
+	}
+
+	parentName, err := getParentProcessName()
+	if err != nil {
+		return false
+	}
+
+	return strings.EqualFold(parentName, "explorer.exe")
+}
+
+// ShowStartupNotice opens a separate console containing only the successful
+// startup status and URL, so Kubernetes logs cannot immediately bury it.
+func ShowStartupNotice(url string) error {
+	systemDirectory, err := windows.GetSystemDirectory()
+	if err != nil {
+		return err
+	}
+	cmdPath := filepath.Join(systemDirectory, "cmd.exe")
+	commandLine, err := windows.UTF16PtrFromString(windows.ComposeCommandLine([]string{
+		cmdPath, "/d", "/q", "/c", startupNoticeCommand(url),
+	}))
+	if err != nil {
+		return err
+	}
+
+	startupInfo := &windows.StartupInfo{Cb: uint32(unsafe.Sizeof(windows.StartupInfo{}))}
+	var processInfo windows.ProcessInformation
+	if err := windows.CreateProcess(
+		nil,
+		commandLine,
+		nil,
+		nil,
+		false,
+		windows.CREATE_NEW_CONSOLE,
+		nil,
+		nil,
+		startupInfo,
+		&processInfo,
+	); err != nil {
+		return err
+	}
+	_ = windows.CloseHandle(processInfo.Thread)
+	_ = windows.CloseHandle(processInfo.Process)
+	return nil
+}
+
+func startupNoticeCommand(url string) string {
+	return strings.Join([]string{
+		"title CasOS Started",
+		"cls",
+		"echo.",
+		"echo CasOS started successfully.",
+		"echo.",
+		"echo Open " + url + " in your browser.",
+		"echo.",
+		"echo Keep the original CasOS window open while using CasOS.",
+		"echo Press any key to close this message window.",
+		"pause >nul",
+	}, " & ")
+}
+
+func isGoBuildTemp(exe string) bool {
+	for _, part := range strings.Split(strings.ToLower(strings.ReplaceAll(exe, `\`, "/")), "/") {
+		const prefix = "go-build"
+		if strings.HasPrefix(part, prefix) {
+			if _, err := strconv.ParseUint(strings.TrimPrefix(part, prefix), 10, 64); err == nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func getParentProcessName() (string, error) {
+	currentPID := windows.GetCurrentProcessId()
+
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return "", err
+	}
+	defer windows.CloseHandle(snapshot)
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return "", err
+	}
+
+	// Collect all processes in one pass so we can look up parent by PID.
+	processes := make(map[uint32]windows.ProcessEntry32)
+	for {
+		processes[entry.ProcessID] = entry
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				break
+			}
+			return "", err
+		}
+	}
+
+	current, ok := processes[currentPID]
+	if !ok {
+		return "", fmt.Errorf("current process %d not found in snapshot", currentPID)
+	}
+
+	parent, ok := processes[current.ParentProcessID]
+	if !ok {
+		return "", fmt.Errorf("parent process %d not found in snapshot", current.ParentProcessID)
+	}
+
+	return windows.UTF16ToString(parent.ExeFile[:]), nil
+}

--- a/util/startup.go
+++ b/util/startup.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	startupPollInterval   = 200 * time.Millisecond
+	startupRequestTimeout = 5 * time.Second
+	startupResponseLimit  = 64 << 10
+	casOSPageMarker       = "<title>CasOS</title>"
+)
+
+// WaitForCasOS waits until the HTTP endpoint serves the CasOS homepage.
+func WaitForCasOS(url string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	client := &http.Client{Timeout: startupRequestTimeout}
+	ticker := time.NewTicker(startupPollInterval)
+	defer ticker.Stop()
+
+	for {
+		if casOSReady(ctx, client, url) {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for CasOS at %s", url)
+		case <-ticker.C:
+		}
+	}
+}
+
+func casOSReady(ctx context.Context, client *http.Client, url string) bool {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return false
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return false
+	}
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, startupResponseLimit))
+	return err == nil && bytes.Contains(body, []byte(casOSPageMarker))
+}


### PR DESCRIPTION
## Summary
- detect Windows Explorer double-click launches without changing normal CLI behavior
- wait for CasOS readiness and show startup success in a separate CMD window
- keep the original CasOS console available for service logs

## Verification
- `go test ./...`
- GoReleaser Windows amd64 build
- Windows runtime smoke test confirmed the separate notice window, URL, keep-open text, and running server

No corresponding issue exists; this is a focused fix for the Windows double-click startup flow.