### PR TITLE
feat: add local sign-in backend

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -11,11 +11,11 @@ dbName        = casos
 kineEndpoint  =
 
 ; -- Casdoor -------------------------------------------------------------------
-casdoorEndpoint     = https://door.casdoor.com
-clientId            = af6b5aa958822fb9dc33
-clientSecret        = 8bc3010c1c951c8d876b1f311a901ff8deeb93bc
-casdoorOrganization = casbin
-casdoorApplication  = app-casibase
+casdoorEndpoint     =
+clientId            =
+clientSecret        =
+casdoorOrganization =
+casdoorApplication  =
 
 ; -- Outbound proxy (optional) ----
 ; Leave blank to use environment proxy settings or direct access.

--- a/controllers/account.go
+++ b/controllers/account.go
@@ -1,14 +1,155 @@
 package controllers
 
 import (
+	"encoding/json"
+	"errors"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
+	"strings"
+	"sync"
 
+	"github.com/beego/beego"
 	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
+	"github.com/casosorg/casos/casdoor"
+	"github.com/casosorg/casos/conf"
+	"github.com/casosorg/casos/object"
 )
+
+type localSigninForm struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type localAdminSetupForm struct {
+	Password string `json:"password"`
+}
+
+type signinOptions struct {
+	LocalSigninAvailable  bool              `json:"localSigninAvailable"`
+	LocalAdminInitialized bool              `json:"localAdminInitialized"`
+	CasdoorConfigured     bool              `json:"casdoorConfigured"`
+	AuthConfig            map[string]string `json:"authConfig,omitempty"`
+}
+
+const localSessionTokenType = "casos-local"
+
+var casdoorConfigOnce sync.Once
+
+func (c *ApiController) Prepare() {
+	claims := c.GetSessionClaims()
+	if claims == nil {
+		return
+	}
+	if !sessionMatchesAuthMode(claims, object.IsLocalSigninEnabled(), object.IsCasdoorConfigured(), conf.GetConfigBool("e2eTestMode")) {
+		c.SetSessionClaims(nil)
+	}
+}
+
+func sessionMatchesAuthMode(claims *casdoorsdk.Claims, localSignin, casdoorConfigured, e2eMode bool) bool {
+	if claims == nil {
+		return false
+	}
+	e2eIdentity := claims.User.Owner == "built-in" && claims.User.Name == "ci-user"
+	if e2eIdentity {
+		return e2eMode
+	}
+	localIdentity := claims.User.Owner == object.LocalUserOwner && claims.User.Type == "local"
+	localSession := localIdentity && claims.TokenType == localSessionTokenType
+	if localSignin {
+		return localSession
+	}
+	if casdoorConfigured {
+		return !localIdentity
+	}
+	return false
+}
+
+func newLocalSessionClaims(user *object.LocalUser) *casdoorsdk.Claims {
+	return &casdoorsdk.Claims{
+		User:      user.ToSessionUser(),
+		TokenType: localSessionTokenType,
+	}
+}
+
+func buildSigninOptions(localSignin, localAdminInitialized, casdoorConfigured bool) signinOptions {
+	options := signinOptions{
+		LocalSigninAvailable:  localSignin,
+		LocalAdminInitialized: localAdminInitialized,
+		CasdoorConfigured:     casdoorConfigured,
+	}
+	if casdoorConfigured {
+		options.AuthConfig = map[string]string{
+			"serverUrl":        conf.GetConfigString("casdoorEndpoint"),
+			"clientId":         conf.GetConfigString("clientId"),
+			"appName":          conf.GetConfigString("casdoorApplication"),
+			"organizationName": conf.GetConfigString("casdoorOrganization"),
+			"redirectPath":     "/callback",
+		}
+	}
+	return options
+}
+
+func (c *ApiController) GetSigninOptions() {
+	localAdminInitialized, err := object.IsLocalAdminInitialized()
+	if err != nil {
+		beego.Error("get local administrator status: %v", err)
+		c.ResponseError("failed to load sign-in options")
+		return
+	}
+	c.ResponseOk(buildSigninOptions(object.IsLocalSigninEnabled(), localAdminInitialized, object.IsCasdoorConfigured()))
+}
+
+func (c *ApiController) InitializeLocalAdmin() {
+	if !object.IsLocalSigninEnabled() {
+		c.ResponseError("local sign-in is unavailable")
+		return
+	}
+	if !isLocalSetupRequest(c.Ctx.Request) {
+		c.ResponseError("local administrator setup is only available on this device")
+		return
+	}
+	form := localAdminSetupForm{}
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &form); err != nil {
+		c.ResponseError("invalid administrator setup request")
+		return
+	}
+	if sanitized, err := json.Marshal(localAdminSetupForm{Password: "***"}); err == nil {
+		c.Ctx.Input.RequestBody = sanitized
+	}
+	if err := object.ValidateLocalPassword(form.Password); err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	user, err := object.InitializeLocalAdmin(form.Password)
+	if errors.Is(err, object.ErrLocalAdminAlreadyInitialized) {
+		c.ResponseError(err.Error())
+		return
+	}
+	if err != nil {
+		beego.Error("initialize local administrator: %v", err)
+		c.ResponseError("failed to initialize local administrator")
+		return
+	}
+	claims := newLocalSessionClaims(user)
+	c.SetSessionClaims(claims)
+	c.ResponseOk(claims)
+}
 
 func (c *ApiController) Signin() {
 	code := c.Input().Get("code")
 	state := c.Input().Get("state")
+	if code == "" && state == "" && object.IsLocalSigninEnabled() {
+		c.signinLocalUser()
+		return
+	}
+	if !object.IsCasdoorConfigured() {
+		c.ResponseError("Casdoor sign-in is not configured")
+		return
+	}
+	ensureCasdoorConfig()
 
 	token, err := casdoorsdk.GetOAuthToken(code, state)
 	if err != nil {
@@ -26,6 +167,98 @@ func (c *ApiController) Signin() {
 	c.SetSessionClaims(claims)
 
 	c.ResponseOk(claims)
+}
+
+func ensureCasdoorConfig() {
+	casdoorConfigOnce.Do(func() {
+		casdoorsdk.InitConfig(
+			conf.GetConfigString("casdoorEndpoint"),
+			conf.GetConfigString("clientId"),
+			conf.GetConfigString("clientSecret"),
+			casdoor.JwtPublicKey,
+			conf.GetConfigString("casdoorOrganization"),
+			conf.GetConfigString("casdoorApplication"),
+		)
+	})
+}
+
+func (c *ApiController) signinLocalUser() {
+	if !object.IsLocalSigninEnabled() {
+		c.ResponseError("local sign-in is unavailable")
+		return
+	}
+	form := localSigninForm{}
+	if len(c.Ctx.Input.RequestBody) > 0 {
+		if err := json.Unmarshal(c.Ctx.Input.RequestBody, &form); err != nil {
+			c.ResponseError("invalid sign-in request")
+			return
+		}
+	}
+	form.Username = strings.TrimSpace(form.Username)
+	if sanitized, err := json.Marshal(localSigninForm{Username: form.Username, Password: "***"}); err == nil {
+		c.Ctx.Input.RequestBody = sanitized
+	}
+	user, ok, err := object.VerifyLocalUser(form.Username, form.Password)
+	if err != nil {
+		beego.Error("local sign-in failed: %v", err)
+		c.ResponseError("invalid username or password")
+		return
+	}
+	if !ok {
+		beego.Warning("local sign-in failed for user %q", form.Username)
+		c.ResponseError("invalid username or password")
+		return
+	}
+	claims := newLocalSessionClaims(user)
+	c.SetSessionClaims(claims)
+	c.ResponseOk(claims)
+}
+
+func isLocalSetupRequest(request *http.Request) bool {
+	mediaType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	if err != nil || !strings.EqualFold(mediaType, "application/json") {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(request.Header.Get("Sec-Fetch-Site")), "cross-site") {
+		return false
+	}
+	for _, header := range []string{"Forwarded", "X-Forwarded-For", "X-Real-IP"} {
+		if strings.TrimSpace(request.Header.Get(header)) != "" {
+			return false
+		}
+	}
+	if !isLoopbackAddress(request.RemoteAddr) {
+		return false
+	}
+	host := request.Host
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	if !strings.EqualFold(host, "localhost") && !isLoopbackAddress(host) {
+		return false
+	}
+	origin := strings.TrimSpace(request.Header.Get("Origin"))
+	if origin == "" {
+		return true
+	}
+	parsedOrigin, err := url.Parse(origin)
+	expectedScheme := "http"
+	if request.TLS != nil {
+		expectedScheme = "https"
+	}
+	if err != nil || parsedOrigin.Scheme != expectedScheme || parsedOrigin.User != nil || parsedOrigin.Path != "" || parsedOrigin.RawQuery != "" || parsedOrigin.Fragment != "" {
+		return false
+	}
+	return strings.EqualFold(parsedOrigin.Host, request.Host)
+}
+
+func isLoopbackAddress(address string) bool {
+	parsedHost, _, err := net.SplitHostPort(address)
+	if err == nil {
+		address = parsedHost
+	}
+	ip := net.ParseIP(address)
+	return ip != nil && ip.IsLoopback()
 }
 
 func (c *ApiController) Signout() {

--- a/object/local_user.go
+++ b/object/local_user.go
@@ -1,0 +1,170 @@
+package object
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
+	"github.com/casosorg/casos/conf"
+	"golang.org/x/crypto/bcrypt"
+	"xorm.io/xorm"
+)
+
+const (
+	LocalUserOwner         = "local"
+	maxPasswordLengthBytes = 72
+	minPasswordLengthBytes = 12
+	unknownPasswordHash    = "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
+)
+
+var ErrLocalAdminAlreadyInitialized = errors.New("local administrator is already initialized")
+
+type LocalUser struct {
+	Owner        string `xorm:"varchar(100) notnull pk" json:"owner"`
+	Name         string `xorm:"varchar(100) notnull pk" json:"name"`
+	DisplayName  string `xorm:"varchar(100)" json:"displayName"`
+	PasswordHash string `xorm:"varchar(150)" json:"-"`
+	IsAdmin      bool   `xorm:"notnull default false" json:"isAdmin"`
+}
+
+func IsLocalSigninEnabled() bool {
+	for _, key := range []string{"casdoorEndpoint", "clientId", "clientSecret", "casdoorOrganization", "casdoorApplication"} {
+		if strings.TrimSpace(conf.GetConfigString(key)) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func IsCasdoorConfigured() bool {
+	for _, key := range []string{"casdoorEndpoint", "clientId", "clientSecret", "casdoorOrganization", "casdoorApplication"} {
+		if strings.TrimSpace(conf.GetConfigString(key)) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeLocalUsername(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("username cannot be empty")
+	}
+	if strings.Contains(name, "/") {
+		return "", fmt.Errorf("username cannot contain slash")
+	}
+	if len(name) > 100 {
+		return "", fmt.Errorf("username is too long")
+	}
+	return name, nil
+}
+
+func ValidateLocalPassword(password string) error {
+	if len(password) < minPasswordLengthBytes {
+		return fmt.Errorf("password cannot be shorter than %d bytes", minPasswordLengthBytes)
+	}
+	if len(password) > maxPasswordLengthBytes {
+		return fmt.Errorf("password cannot be longer than %d bytes", maxPasswordLengthBytes)
+	}
+	return nil
+}
+
+func getLocalUser(name string) (*LocalUser, error) {
+	return getLocalUserFromEngine(ormer.Engine, name)
+}
+
+func getLocalUserFromEngine(engine *xorm.Engine, name string) (*LocalUser, error) {
+	name, err := normalizeLocalUsername(name)
+	if err != nil {
+		return nil, err
+	}
+	user := &LocalUser{Owner: LocalUserOwner, Name: name}
+	existed, err := engine.Get(user)
+	if err != nil || !existed {
+		return nil, err
+	}
+	return user, nil
+}
+
+func VerifyLocalUser(name, password string) (*LocalUser, bool, error) {
+	user, err := getLocalUser(name)
+	if err != nil {
+		compareUnknownPassword(password)
+		return nil, false, err
+	}
+	if user == nil || len(password) > maxPasswordLengthBytes {
+		compareUnknownPassword(password)
+		return nil, false, nil
+	}
+	if bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)) != nil {
+		return nil, false, nil
+	}
+	return user, true, nil
+}
+
+func compareUnknownPassword(password string) {
+	if len(password) <= maxPasswordLengthBytes {
+		_ = bcrypt.CompareHashAndPassword([]byte(unknownPasswordHash), []byte(password))
+	}
+}
+
+func (user *LocalUser) ToSessionUser() casdoorsdk.User {
+	displayName := user.DisplayName
+	if displayName == "" {
+		displayName = user.Name
+	}
+	return casdoorsdk.User{
+		Owner:       LocalUserOwner,
+		Name:        user.Name,
+		Id:          LocalUserOwner + ":" + user.Name,
+		Type:        "local",
+		DisplayName: displayName,
+		IsAdmin:     user.IsAdmin,
+	}
+}
+
+func IsLocalAdminInitialized() (bool, error) {
+	return isLocalAdminInitialized(ormer.Engine)
+}
+
+func isLocalAdminInitialized(engine *xorm.Engine) (bool, error) {
+	user, err := getLocalUserFromEngine(engine, "admin")
+	return user != nil, err
+}
+
+func InitializeLocalAdmin(password string) (*LocalUser, error) {
+	return initializeLocalAdmin(ormer.Engine, password)
+}
+
+func initializeLocalAdmin(engine *xorm.Engine, password string) (*LocalUser, error) {
+	if err := ValidateLocalPassword(password); err != nil {
+		return nil, err
+	}
+	initialized, err := isLocalAdminInitialized(engine)
+	if err != nil {
+		return nil, err
+	}
+	if initialized {
+		return nil, ErrLocalAdminAlreadyInitialized
+	}
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, err
+	}
+	user := &LocalUser{
+		Owner:        LocalUserOwner,
+		Name:         "admin",
+		DisplayName:  "Admin",
+		PasswordHash: string(passwordHash),
+		IsAdmin:      true,
+	}
+	_, err = engine.Insert(user)
+	if err != nil {
+		if initialized, lookupErr := isLocalAdminInitialized(engine); lookupErr == nil && initialized {
+			return nil, ErrLocalAdminAlreadyInitialized
+		}
+		return nil, err
+	}
+	return user, nil
+}

--- a/object/ormer.go
+++ b/object/ormer.go
@@ -220,6 +220,7 @@ func (a *Ormer) createTable() {
 		new(CasbinRule),
 		new(TrivyScanResult),
 		new(HelmRepo),
+		new(LocalUser),
 	); err != nil {
 		panic(fmt.Errorf("sync database schema: %w", err))
 	}

--- a/routers/router.go
+++ b/routers/router.go
@@ -6,6 +6,8 @@ import (
 )
 
 func InitAPI() {
+	beego.Router("/api/get-signin-options", &controllers.ApiController{}, "GET:GetSigninOptions")
+	beego.Router("/api/initialize-local-admin", &controllers.ApiController{}, "POST:InitializeLocalAdmin")
 	beego.Router("/api/signin", &controllers.ApiController{}, "POST:Signin")
 	beego.Router("/api/signout", &controllers.ApiController{}, "POST:Signout")
 	beego.Router("/api/get-account", &controllers.ApiController{}, "GET:GetAccount")


### PR DESCRIPTION
## Summary

- make local authentication the default when all Casdoor settings are empty, while enabling Casdoor only when all required settings are present
- store local users in the existing SQLite database with bcrypt password hashes and generic credential errors
- replace generated/default credentials with a first-run administrator setup for the fixed `admin` account
- allow administrator initialization exactly once and only from a direct local JSON request; reject forwarded, cross-site, foreign-origin, null-origin, and scheme-mismatched requests
- establish the normal CasOS session immediately after successful initialization and never create a plaintext password file
- bind persisted sessions to the active authentication mode so local, Casdoor, and E2E sessions cannot survive an incompatible mode switch
- initialize the Casdoor SDK from environment-aware configuration and never expose the client secret

## Coordinated release

This backend PR and companion frontend PR #150 are intentionally direct, non-stacked branches from `master`, so either can be reviewed and merged first. They form one authentication delivery unit: merge both into `master` in the same release and do not deploy the intermediate state between the two merges.

## OpenAgent alignment

Adapted OpenAgent local password authentication and server-selected provider behavior to CasOS. OpenAgent preconfigured `admin/123` behavior was deliberately not copied; CasOS requires first-run password creation and stores only its bcrypt hash.

## Validation

- `go test ./...`
- temporary regression tests for legacy local and disabled E2E sessions in Casdoor mode
- exact-file ESLint validation for the companion frontend
- production frontend build
- standalone binary build
- runtime mode-switch check proving an existing local session is rejected after Casdoor is configured
- combined frontend/backend lifecycle covering setup, authenticated session, repeat initialization rejection, sign-out, local password sign-in, and absence of a plaintext password file
- two fresh independent reviews against upstream `master` `85672170`: no Critical or Important findings
- upstream merge tree reviewed: `f80fd8dff1fe8cf38b7c8b4bd3341218dd9e905c`
- combined tree reviewed: `50a09f916a8c0c860835397c81814bb330c02b25`

No corresponding issue exists.