### PR TITLE
fix: isolate UI tests from local node enrollment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
       driverName: mysql
       dataSourceName: root:casos-${{ github.run_id }}-${{ github.run_attempt }}@tcp(127.0.0.1:3306)/
       dbName: casos
+      autoEnrollLocalNode: "false"
       socks5Proxy: ""
       coreDNSImage: registry.k8s.io/coredns/coredns:v1.12.4
       flannelImage: ghcr.io/flannel-io/flannel:v0.27.4


### PR DESCRIPTION
## Summary

- disable automatic local node enrollment only in the UI test job
- keep the Docker-backed MySQL service available while Playwright runs
- preserve the production default and worker VM test path

## Root cause

The UI job starts CasOS on the GitHub runner while MySQL runs as a Docker service. Automatic local node enrollment reaches the node installer, which reconfigures and restarts containerd on that runner. Docker and the MySQL service then become unavailable.

## Testing

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -ignore 'runner of "actions/.*" action is too old' .github/workflows/build.yml`\n- `go test -vet=asmdecl,assign,atomic,bools,buildtag,cgocall,composites,copylocks,defers,directive,errorsas,framepointer,httpresponse,ifaceassert,loopclosure,lostcancel,nilfunc,shift,sigchanyzer,slog,stdmethods,stringintconv,structtag,testinggoroutine,tests,timeformat,unmarshal,unreachable,unsafeptr,unusedresult ./... -tags skipCi`\n- Fork CI, including UI smoke, App Store UI, worker VM validation, and UI regression tests: https://github.com/bugkeep/casos/actions/runs/32029513343\n\nNo corresponding issue.