### PR TITLE
fix: report incomplete cluster health

### DIFF
--- a/controllers/dashboard.go
+++ b/controllers/dashboard.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"fmt"
 	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +15,24 @@ type unhealthyPod struct {
 	Phase     string `json:"phase"`
 	Reason    string `json:"reason"`
 }
+
+var dashboardContainerFailureReasons = map[string]struct{}{
+	"CrashLoopBackOff":           {},
+	"OOMKilled":                  {},
+	"ImagePullBackOff":           {},
+	"ErrImagePull":               {},
+	"ErrImageNeverPull":          {},
+	"InvalidImageName":           {},
+	"CreateContainerConfigError": {},
+	"CreateContainerError":       {},
+	"RunContainerError":          {},
+}
+
+const (
+	dashboardHealthHealthy   = "healthy"
+	dashboardHealthUnhealthy = "unhealthy"
+	dashboardHealthUnknown   = "unknown"
+)
 
 type dashboardStats struct {
 	NodesTotal           int            `json:"nodesTotal"`
@@ -32,6 +51,10 @@ type dashboardStats struct {
 	DeploymentsTotal     int            `json:"deploymentsTotal"`
 	DeploymentsAvailable int            `json:"deploymentsAvailable"`
 	UnhealthyPods        []unhealthyPod `json:"unhealthyPods"`
+	// Deprecated compatibility field. False means either unhealthy or unknown;
+	// consumers should use HealthStatus when they need to distinguish the two.
+	Healthy      bool   `json:"healthy"`
+	HealthStatus string `json:"healthStatus"`
 	// Resource usage (from metrics-server; zero when metrics-server is absent)
 	ClusterCPUUsedM   int64 `json:"clusterCPUUsedM"`
 	ClusterCPUTotalM  int64 `json:"clusterCPUTotalM"`
@@ -57,7 +80,9 @@ func (c *ApiController) GetDashboard() {
 		UnhealthyPods:   []unhealthyPod{},
 	}
 
+	nodesLoaded := false
 	if nodes, err := object.GetNodes(cfg); err == nil {
+		nodesLoaded = true
 		stats.NodesTotal = len(nodes)
 		for _, n := range nodes {
 			for _, cond := range n.Status.Conditions {
@@ -78,20 +103,12 @@ func (c *ApiController) GetDashboard() {
 		}
 	}
 
-	unhealthyReasons := map[string]bool{
-		"CrashLoopBackOff":           true,
-		"OOMKilled":                  true,
-		"ImagePullBackOff":           true,
-		"ErrImagePull":               true,
-		"InvalidImageName":           true,
-		"CreateContainerConfigError": true,
-		"CreateContainerError":       true,
-		"Evicted":                    true,
-	}
-
+	podsLoaded := false
 	if pods, err := object.GetPods(cfg, ""); err == nil {
+		podsLoaded = true
 		stats.PodsTotal = len(pods)
-		for _, p := range pods {
+		for i := range pods {
+			p := &pods[i]
 			phase := string(p.Status.Phase)
 			if phase == "" {
 				phase = "Unknown"
@@ -106,37 +123,7 @@ func (c *ApiController) GetDashboard() {
 			}
 			stats.PodsByNamespace[ns]++
 
-			// Detect unhealthy pods
-			reason := ""
-			if phase == "Failed" {
-				reason = p.Status.Reason
-				if reason == "" {
-					reason = "Failed"
-				}
-			} else if phase == "Unknown" {
-				reason = "Unknown"
-			} else {
-				// Check container statuses for known bad waiting/terminated reasons
-			outer:
-				for _, cs := range p.Status.ContainerStatuses {
-					if cs.State.Waiting != nil && unhealthyReasons[cs.State.Waiting.Reason] {
-						reason = cs.State.Waiting.Reason
-						break outer
-					}
-					if cs.State.Terminated != nil && unhealthyReasons[cs.State.Terminated.Reason] {
-						reason = cs.State.Terminated.Reason
-						break outer
-					}
-				}
-				for _, cs := range p.Status.InitContainerStatuses {
-					if reason != "" {
-						break
-					}
-					if cs.State.Waiting != nil && unhealthyReasons[cs.State.Waiting.Reason] {
-						reason = cs.State.Waiting.Reason
-					}
-				}
-			}
+			reason := dashboardPodUnhealthyReason(p)
 			if reason != "" {
 				stats.UnhealthyPods = append(stats.UnhealthyPods, unhealthyPod{
 					Namespace: ns,
@@ -184,6 +171,9 @@ func (c *ApiController) GetDashboard() {
 		stats.ServiceAccounts = len(sas)
 	}
 
+	stats.HealthStatus = dashboardHealthStatus(stats, nodesLoaded, podsLoaded)
+	stats.Healthy = stats.HealthStatus == dashboardHealthHealthy
+
 	// Cluster resource usage — best-effort, ignored if kubelet is unreachable
 	certDir := ""
 	if sc := getServerConfig(); sc != nil {
@@ -199,4 +189,67 @@ func (c *ApiController) GetDashboard() {
 	}
 
 	c.ResponseOk(stats)
+}
+
+func dashboardHealthStatus(stats dashboardStats, nodesLoaded, podsLoaded bool) string {
+	if nodesLoaded && stats.NodesTotal > 0 && stats.NodesReady != stats.NodesTotal {
+		return dashboardHealthUnhealthy
+	}
+	if podsLoaded && len(stats.UnhealthyPods) > 0 {
+		return dashboardHealthUnhealthy
+	}
+	if !nodesLoaded || !podsLoaded || stats.NodesTotal == 0 {
+		return dashboardHealthUnknown
+	}
+	return dashboardHealthHealthy
+}
+
+func dashboardPodUnhealthyReason(p *corev1.Pod) string {
+	if p.Status.Phase == corev1.PodFailed {
+		if p.Status.Reason != "" {
+			return p.Status.Reason
+		}
+		return "Failed"
+	}
+	if p.Status.Phase == "" || p.Status.Phase == corev1.PodUnknown {
+		return "Unknown"
+	}
+
+	for _, statuses := range [][]corev1.ContainerStatus{
+		p.Status.InitContainerStatuses,
+		p.Status.ContainerStatuses,
+	} {
+		for _, cs := range statuses {
+			if reason := dashboardContainerUnhealthyReason(cs); reason != "" {
+				return reason
+			}
+		}
+	}
+	if p.Status.Phase == corev1.PodPending {
+		for _, condition := range p.Status.Conditions {
+			if condition.Type != corev1.PodScheduled || condition.Status != corev1.ConditionFalse {
+				continue
+			}
+			switch condition.Reason {
+			case corev1.PodReasonUnschedulable, corev1.PodReasonSchedulerError:
+				return condition.Reason
+			}
+		}
+	}
+	return ""
+}
+
+func dashboardContainerUnhealthyReason(status corev1.ContainerStatus) string {
+	if status.State.Waiting != nil {
+		if _, ok := dashboardContainerFailureReasons[status.State.Waiting.Reason]; ok {
+			return status.State.Waiting.Reason
+		}
+	}
+	if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+		if status.State.Terminated.Reason != "" {
+			return status.State.Terminated.Reason
+		}
+		return fmt.Sprintf("ExitCode %d", status.State.Terminated.ExitCode)
+	}
+	return ""
 }

--- a/web2/src/lib/dashboardHealth.js
+++ b/web2/src/lib/dashboardHealth.js
@@ -1,0 +1,29 @@
+const HEALTH_STATES = new Set(["healthy", "unhealthy", "unknown"]);
+
+export function getDashboardHealthState(stats) {
+  stats ??= {};
+  const unhealthyPods = Array.isArray(stats.unhealthyPods) ? stats.unhealthyPods : [];
+  const nodeCountsAvailable = typeof stats.nodesTotal === "number" &&
+    typeof stats.nodesReady === "number";
+  const knownNodeFailure = nodeCountsAvailable && stats.nodesTotal > 0 &&
+    stats.nodesReady !== stats.nodesTotal;
+  const notReadyNodes = knownNodeFailure
+    ? Math.max(stats.nodesTotal - stats.nodesReady, 0)
+    : 0;
+
+  let healthStatus = "unknown";
+  if (knownNodeFailure || unhealthyPods.length > 0) {
+    healthStatus = "unhealthy";
+  } else if (HEALTH_STATES.has(stats.healthStatus)) {
+    healthStatus = stats.healthStatus;
+  } else if (stats.healthStatus === undefined) {
+    if (typeof stats.healthy === "boolean") {
+      healthStatus = stats.healthy ? "healthy" : "unhealthy";
+    } else if (nodeCountsAvailable && stats.nodesTotal > 0 &&
+      stats.nodesReady === stats.nodesTotal) {
+      healthStatus = "healthy";
+    }
+  }
+
+  return {healthStatus, notReadyNodes};
+}

--- a/web2/src/locales/en/data.json
+++ b/web2/src/locales/en/data.json
@@ -1,4 +1,23 @@
 {
+  "dashboard": {
+    "health data unavailable": "Cluster health data unavailable",
+    "alert healthy": "Cluster healthy",
+    "alert unhealthy": "{{count}} unhealthy pod(s)",
+    "alert nodes not ready": "{{count}} node(s) not ready",
+    "alert unhealthy cluster": "Cluster unhealthy",
+    "reason CrashLoopBackOff": "Container repeatedly restarting",
+    "reason OOMKilled": "Out of memory",
+    "reason ImagePullBackOff": "Image pull failed",
+    "reason ConfigError": "Container configuration error",
+    "reason ContainerError": "Container creation error",
+    "reason Evicted": "Evicted",
+    "reason Failed": "Failed",
+    "reason Unknown": "Unknown",
+    "reason Unschedulable": "Unschedulable",
+    "reason SchedulerError": "Scheduler error",
+    "reason RunContainerError": "Container run error",
+    "reason ErrImageNeverPull": "Image is not available locally"
+  },
   "account": {
     "Back to sign in": "Back to sign in",
     "Confirm password": "Confirm password",

--- a/web2/src/locales/zh/data.json
+++ b/web2/src/locales/zh/data.json
@@ -1,4 +1,23 @@
 {
+  "dashboard": {
+    "health data unavailable": "集群健康数据不可用",
+    "alert healthy": "集群健康",
+    "alert unhealthy": "{{count}} 个异常 Pod",
+    "alert nodes not ready": "{{count}} 个节点未就绪",
+    "alert unhealthy cluster": "集群不健康",
+    "reason CrashLoopBackOff": "容器反复重启",
+    "reason OOMKilled": "内存不足被终止",
+    "reason ImagePullBackOff": "镜像拉取失败",
+    "reason ConfigError": "容器配置错误",
+    "reason ContainerError": "容器创建错误",
+    "reason Evicted": "已驱逐",
+    "reason Failed": "失败",
+    "reason Unknown": "未知",
+    "reason Unschedulable": "无法调度",
+    "reason SchedulerError": "调度器错误",
+    "reason RunContainerError": "容器运行错误",
+    "reason ErrImageNeverPull": "本地不存在镜像"
+  },
   "account": {
     "Back to sign in": "返回登录",
     "Confirm password": "确认密码",

--- a/web2/src/pages/DashboardPage.jsx
+++ b/web2/src/pages/DashboardPage.jsx
@@ -14,6 +14,7 @@ import {StatCard} from "@/components/shared/stat-card";
 import {Loading} from "@/components/shared/loading";
 import {RadialProgress} from "@/components/shared/radial-progress";
 import {CHART_COLORS, EchartsWidget} from "@/components/shared/echarts-widget";
+import {getDashboardHealthState} from "@/lib/dashboardHealth";
 
 const POD_PHASE_COLORS = {
   Running: "#3b82f6",
@@ -174,10 +175,14 @@ function DashboardPage() {
     OOMKilled: "danger",
     ImagePullBackOff: "warning",
     ErrImagePull: "warning",
+    ErrImageNeverPull: "warning",
     InvalidImageName: "warning",
     CreateContainerConfigError: "warning",
     CreateContainerError: "warning",
+    RunContainerError: "danger",
     Evicted: "secondary",
+    Unschedulable: "warning",
+    SchedulerError: "danger",
     Failed: "danger",
     Unknown: "muted",
   };
@@ -187,10 +192,14 @@ function DashboardPage() {
     OOMKilled: t("dashboard:reason OOMKilled"),
     ImagePullBackOff: t("dashboard:reason ImagePullBackOff"),
     ErrImagePull: t("dashboard:reason ImagePullBackOff"),
+    ErrImageNeverPull: t("dashboard:reason ErrImageNeverPull"),
     InvalidImageName: t("dashboard:reason InvalidImageName"),
     CreateContainerConfigError: t("dashboard:reason ConfigError"),
     CreateContainerError: t("dashboard:reason ContainerError"),
+    RunContainerError: t("dashboard:reason RunContainerError"),
     Evicted: t("dashboard:reason Evicted"),
+    Unschedulable: t("dashboard:reason Unschedulable"),
+    SchedulerError: t("dashboard:reason SchedulerError"),
     Failed: t("dashboard:reason Failed"),
     Unknown: t("dashboard:reason Unknown"),
   };
@@ -205,7 +214,22 @@ function DashboardPage() {
 
   const nodeReadyRate = stats.nodesTotal > 0 ? Number(((stats.nodesReady / stats.nodesTotal) * 100).toFixed(1)) : 0;
   const podRunningRate = stats.podsTotal > 0 ? Number(((stats.podsRunning / stats.podsTotal) * 100).toFixed(1)) : 0;
-  const unhealthyPods = stats.unhealthyPods || [];
+  const unhealthyPods = Array.isArray(stats.unhealthyPods) ? stats.unhealthyPods : [];
+  const {healthStatus, notReadyNodes} = getDashboardHealthState(stats);
+  const clusterHealthy = healthStatus === "healthy";
+  let healthMessage = "";
+  if (healthStatus === "unknown") {
+    healthMessage = t("dashboard:health data unavailable");
+  } else if (healthStatus === "unhealthy") {
+    const unhealthyDetails = [];
+    if (notReadyNodes > 0) {
+      unhealthyDetails.push(t("dashboard:alert nodes not ready", {count: notReadyNodes}));
+    }
+    if (unhealthyPods.length > 0) {
+      unhealthyDetails.push(t("dashboard:alert unhealthy", {count: unhealthyPods.length}));
+    }
+    healthMessage = unhealthyDetails.join(", ") || t("dashboard:alert unhealthy cluster");
+  }
   const deploymentsDegraded = stats.deploymentsAvailable < stats.deploymentsTotal;
   const hasClusterMetrics = stats.clusterCPUTotalM > 0 || stats.clusterMemTotalMi > 0;
 
@@ -223,20 +247,22 @@ function DashboardPage() {
 
   return (
     <PageContainer>
-      {unhealthyPods.length > 0 ? (
+      {!clusterHealthy ? (
         <div className="grid gap-2">
-          <Alert variant="destructive">
+          <Alert variant={healthStatus === "unknown" ? "warning" : "destructive"}>
             <TriangleAlert />
-            <AlertTitle>{t("dashboard:alert unhealthy", {count: unhealthyPods.length})}</AlertTitle>
+            <AlertTitle className="line-clamp-none break-words">{healthMessage}</AlertTitle>
           </Alert>
-          <DataTable
-            columns={unhealthyColumns}
-            dataSource={unhealthyPods}
-            rowKey={(record, index) => `${record.namespace}/${record.name}/${index}`}
-            pageSize={5}
-            dense
-            onRowClick={(record) => history.push(`/pods?namespace=${record.namespace}`)}
-          />
+          {healthStatus === "unhealthy" && unhealthyPods.length > 0 ? (
+            <DataTable
+              columns={unhealthyColumns}
+              dataSource={unhealthyPods}
+              rowKey={(record, index) => `${record.namespace}/${record.name}/${index}`}
+              pageSize={5}
+              dense
+              onRowClick={(record) => history.push(`/pods?namespace=${record.namespace}`)}
+            />
+          ) : null}
         </div>
       ) : (
         <Alert variant="success">


### PR DESCRIPTION
## Summary

- expose healthy, unhealthy, and unknown dashboard health states while preserving the legacy healthy field
- report confirmed node and Pod failures even when other cluster data is unavailable
- migrate the health UI to the shadcn-based web2 Dashboard
- distinguish ordinary Pending Pods from explicit scheduling and container failures
- show separate unavailable-data and confirmed-failure messages with localized reason labels

## Health semantics

| Confirmed failure | Data complete | Result |
| --- | --- | --- |
| yes | either | unhealthy |
| no | no | unknown |
| no | yes | healthy |

Confirmed NotReady nodes or entries in unhealthyPods take precedence over incomplete data and conflicting status fields. unknown means the health check is incomplete and no failure has been confirmed.

Pod phase Unknown remains unhealthy. Ordinary Pending and SchedulingGated Pods are not treated as failures, while Unschedulable, SchedulerError, image failures, container creation/run failures, and non-zero container exits are reported.

## Compatibility

The existing healthy boolean remains in the API response. New clients can use healthStatus to distinguish unhealthy from unknown; old clients continue to receive healthy: false for both states.

## Testing

- go test ./... -tags skipCi -count=1
- node --test web2/src/lib/dashboardHealth.test.mjs (8/8)
- focused JSX/ESLint syntax and unused-variable check
- cd web2 && yarn build
- git diff --check
- parsed both modified locale JSON files
- Playwright smoke checks for healthy, unknown, and unhealthy states on desktop/mobile viewports

Focused test files were used locally for red/green verification. Per repository contribution policy, test files are not included in this PR.
