### PR TITLE
fix: repair app store button composition

### DIFF
--- a/web2/src/components/ui/button.jsx
+++ b/web2/src/components/ui/button.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {Slot} from "@radix-ui/react-slot";
+import {Slot, Slottable} from "@radix-ui/react-slot";
 import {cva} from "class-variance-authority";
 import {cn} from "@/lib/utils";
 
@@ -32,19 +32,23 @@ const buttonVariants = cva(
 // `loading` mirrors the prop every antd button in the old UI relied on: it both
 // shows a spinner and blocks the click, so callers never have to disable the
 // button separately while a request is in flight.
-function Button({className, variant, size, asChild = false, loading = false, disabled, children, ...props}) {
+const Button = React.forwardRef(function Button(
+  {className, variant, size, asChild = false, loading = false, disabled, children, ...props},
+  ref
+) {
   const Comp = asChild ? Slot : "button";
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       className={cn(buttonVariants({variant, size, className}))}
       disabled={asChild ? undefined : disabled || loading}
       {...props}
     >
       {loading ? <span className="size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" /> : null}
-      {children}
+      <Slottable>{children}</Slottable>
     </Comp>
   );
-}
+});
 
 export {Button, buttonVariants};


### PR DESCRIPTION
## Summary

- fix the shared `Button` component crashing Radix `Slot` when `asChild` is used
- mark the actual link child with `Slottable` so the loading spinner can coexist with it
- forward refs through `Button` to remove the React ref warning

## Root cause

`Button` rendered both the optional loading spinner and `children` directly inside `Slot`. Radix requires a single slot target, so `/app-store` crashed when its `Button asChild` rendered a React Router `Link`.

## Testing

- `cd web2 && yarn build`
- `git diff --check f76dd263153ec1034e47798aca13b8f158580995...e73cb7afe7225d554c4719af40ff3d57eb8e6095`
- browser regression: base `/app-store` reproduces the Slot/ref errors; candidate renders `/app-store` and the 404 `Button asChild` path without either error
- fork CI: Go tests, Front-end, UI tests, Back-end, Go-Linter, and Standalone build all passed
- `ocr review`: 0 findings
- Claude CLI final read-only review: `可以 merge`; no blocking or important findings

No linked issue was found.
