### PR TITLE
fix: repair deploy worker node locale key

### DIFF
--- a/web2/src/locales/en/data.json
+++ b/web2/src/locales/en/data.json
@@ -213,7 +213,7 @@
     "Auth type": "Auth type",
     "Auth type - Tooltip": "Choose password authentication or an SSH private key.",
     "Deploy Node": "Deploy Node",
-    "Deploy worker node\", \"Deploy worker node": "Deploy worker node\", \"Deploy worker node",
+    "Deploy worker node": "Deploy worker node",
     "Deployment failed": "Deployment failed",
     "Edit Machine": "Edit Machine",
     "Failed to add local WSL machine": "Failed to add local WSL machine",

--- a/web2/src/locales/zh/data.json
+++ b/web2/src/locales/zh/data.json
@@ -213,7 +213,7 @@
     "Auth type": "Auth type",
     "Auth type - Tooltip": "选择密码认证或 SSH 私钥认证。",
     "Deploy Node": "部署节点",
-    "Deploy worker node\", \"Deploy worker node": "Deploy worker node\", \"Deploy worker node",
+    "Deploy worker node": "部署工作节点",
     "Deployment failed": "部署失败",
     "Edit Machine": "Edit Machine",
     "Failed to add local WSL machine": "添加本机 WSL 失败",


### PR DESCRIPTION
## Summary

- repair the malformed `Deploy worker node` locale key in web2
- provide the correct English and Chinese values

## Tests

- parsed both web2 locale JSON files and asserted `machine["Deploy worker node"]`
- confirmed the malformed key is absent from web2
- ran `git diff --check`