### PR TITLE
fix: correct machine settings description

### DIFF
--- a/web2/src/locales/en/data.json
+++ b/web2/src/locales/en/data.json
@@ -219,6 +219,7 @@
     "Failed to add local WSL machine": "Failed to add local WSL machine",
     "Failed to load node logs": "Failed to load node logs",
     "Failed to load node tasks": "Failed to load node tasks",
+    "General Settings desc": "Basic machine information",
     "IP address": "IP address",
     "IP address - Tooltip": "The node's reachable IP address.",
     "Local WSL machine added": "Local WSL machine added",

--- a/web2/src/locales/zh/data.json
+++ b/web2/src/locales/zh/data.json
@@ -219,6 +219,7 @@
     "Failed to add local WSL machine": "添加本机 WSL 失败",
     "Failed to load node logs": "加载节点日志失败",
     "Failed to load node tasks": "加载节点任务失败",
+    "General Settings desc": "机器基本信息",
     "IP address": "IP address",
     "IP address - Tooltip": "节点可访问的 IP 地址。",
     "Local WSL machine added": "已添加本机 WSL",

--- a/web2/src/pages/MachineEditPage.jsx
+++ b/web2/src/pages/MachineEditPage.jsx
@@ -86,7 +86,7 @@ function MachineEditPage() {
         }
       />
 
-      <Section title={i18next.t("general:General Settings")} description={i18next.t("general:General Settings desc")}>
+      <Section title={i18next.t("general:General Settings")} description={i18next.t("machine:General Settings desc")}>
         <Field label={<LabelWithTip text={i18next.t("general:Name")} tooltip={i18next.t("general:Name - Tooltip")} />} htmlFor="machine-name">
           {/* The name is the record's key on the server, so it is shown but not editable. */}
           <Input id="machine-name" value={machine.name ?? ""} disabled />


### PR DESCRIPTION
## Summary
- use a machine-specific translation key for the machine form's General Settings description
- add matching English and Chinese machine descriptions

## Testing
- `npm run build` (web2)
- machine description regression assertion