### PR TITLE
fix: fail Helm installs early without schedulable nodes

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -37,7 +37,7 @@ imageRegistryMirror = auto
 ; Set true only when implicit/latest chart images must use IfNotPresent.
 helmImplicitLatestPullPolicy = false
 ; Maximum time Helm waits for an application and its jobs to become ready.
-helmInstallTimeout = 20m
+helmInstallTimeout = 5m
 
 ; -- Control plane ----------------------------------------------------------
 apiserverPort = 6443

--- a/store/helm.go
+++ b/store/helm.go
@@ -1382,6 +1382,9 @@ func installHelmChart(cfg *rest.Config, releaseName, namespace, chartName, repoU
 	if err != nil {
 		return err
 	}
+	if err := validateHelmInstallPreflight(context.Background(), cfg); err != nil {
+		return err
+	}
 	ch, err := loadChart(chartName, repoURL, version)
 	if err != nil {
 		return err
@@ -1539,6 +1542,10 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 		actionConfig, err := newHelmConfigWithLog(cfg, namespace, logFn)
 		if err != nil {
 			finishWithError(err, "configuration error")
+			return
+		}
+		if err := validateHelmInstallPreflight(installCtx, cfg); err != nil {
+			finishWithError(err, "preflight validation error")
 			return
 		}
 		helmChart, err := loadChartWithContext(installCtx, chartName, repoURL, version)

--- a/store/helm_install.go
+++ b/store/helm_install.go
@@ -13,7 +13,7 @@ import (
 	"github.com/casosorg/casos/conf"
 )
 
-const defaultHelmInstallTimeout = 20 * time.Minute
+const defaultHelmInstallTimeout = 5 * time.Minute
 
 func helmInstallOperationDeadline(installTimeout time.Duration) time.Duration {
 	return helmChartLoadTimeout + helmCompatibilityTimeout + installTimeout + helmDiagnosticsTimeout

--- a/store/helm_preflight.go
+++ b/store/helm_preflight.go
@@ -1,0 +1,55 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const helmInstallPreflightTimeout = 5 * time.Second
+
+// validateHelmInstallNodes checks the scheduler has at least one node on which
+// a newly installed workload can be placed. Taints are intentionally left to
+// the rendered Pod tolerations; this check only rejects an empty or fully
+// cordoned cluster.
+func validateHelmInstallNodes(ctx context.Context, client kubernetes.Interface) error {
+	if client == nil {
+		return fmt.Errorf("Helm install preflight Kubernetes client is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list Kubernetes nodes for Helm install preflight: %w", err)
+	}
+	if len(nodes.Items) == 0 {
+		return fmt.Errorf("Helm install preflight failed: no Kubernetes nodes are registered; add at least one worker node before installing")
+	}
+	for _, node := range nodes.Items {
+		if !node.Spec.Unschedulable {
+			return nil
+		}
+	}
+	return fmt.Errorf("Helm install preflight failed: all Kubernetes nodes are cordoned (unschedulable); uncordon at least one worker node before installing")
+}
+
+func validateHelmInstallPreflight(parent context.Context, cfg *rest.Config) error {
+	if cfg == nil {
+		return fmt.Errorf("Helm install preflight REST config is nil")
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, helmInstallPreflightTimeout)
+	defer cancel()
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("create Kubernetes client for Helm install preflight: %w", err)
+	}
+	return validateHelmInstallNodes(ctx, client)
+}


### PR DESCRIPTION
## Summary
- Add a 5-second Helm install preflight that rejects clusters with no registered or schedulable (uncordoned) nodes before chart loading.
- Reduce the default Helm install wait timeout from 20 minutes to 5 minutes.
- Preserve Helm compatibility dry-run, Wait/WaitForJobs behavior, SSE progress, and lifecycle error reporting.

## Verification
- `gofmt` and `git diff --check` pass.
- `go test ./store -count=1` passes.
- `go test ./...` is blocked by unrelated dirty-tree `controllers/dashboard_test.go` references to missing dashboard helpers.
- No `web/`, `web2/`, or Go test files are included in this PR per repository rules.

No corresponding issue was provided.