### PR TITLE
feat: add first-run setup checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ casos --version
 A released binary prints its tag, commit and build date; a binary you built
 yourself reports `dev`.
 
+## First run
+
+CasOS needs at least one Kubernetes worker node before it can schedule
+workloads. After signing in, use the dashboard's first-run checklist to finish
+these steps:
+
+1. Change the default `admin` password (`123`) from the account menu.
+2. Add a machine with SSH credentials on the **Machines** page.
+3. Deploy that machine as a worker node. The node must join the cluster and be
+   ready before workloads can run.
+4. Install the first application from the **App Store**.
+
+The checklist derives its state from the cluster, so it remains accurate after
+refreshing the browser or signing in from another session.
+
 ### Uninstall
 
 The uninstaller removes the binary and the `PATH` entry the installer added.

--- a/web2/src/FirstRunChecklistState.js
+++ b/web2/src/FirstRunChecklistState.js
@@ -1,0 +1,15 @@
+export function getFirstRunChecklist({account, signinOptions, machines, stats}) {
+  const passwordDone = Boolean(
+    account &&
+      (account.owner !== "basic" ||
+        signinOptions?.signinAvailable === false ||
+        signinOptions?.autoSignin === false)
+  );
+
+  return [
+    {key: "password", done: passwordDone},
+    {key: "machine", done: Array.isArray(machines) && machines.length > 0},
+    {key: "node", done: Number(stats?.nodesReady) > 0},
+    {key: "app", done: Number(stats?.deploymentsTotal) > 0},
+  ];
+}

--- a/web2/src/FirstRunChecklistState.test.js
+++ b/web2/src/FirstRunChecklistState.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {getFirstRunChecklist} from "./FirstRunChecklistState.js";
+
+test("marks all setup steps from the account and cluster state", () => {
+  assert.deepEqual(
+    getFirstRunChecklist({
+      account: {owner: "basic"},
+      signinOptions: {signinAvailable: true, autoSignin: false},
+      machines: [{name: "worker-1"}],
+      stats: {nodesTotal: 1, nodesReady: 1, deploymentsTotal: 2},
+    }).map((item) => item.done),
+    [true, true, true, true]
+  );
+});
+
+test("leaves incomplete steps unchecked and skips password changes for Casdoor", () => {
+  assert.deepEqual(
+    getFirstRunChecklist({
+      account: {owner: "basic"},
+      signinOptions: {signinAvailable: true, autoSignin: true},
+      machines: [],
+      stats: {nodesTotal: 1, nodesReady: 0, deploymentsTotal: 0},
+    }).map((item) => item.done),
+    [false, false, false, false]
+  );
+  assert.equal(
+    getFirstRunChecklist({
+      account: {owner: "casdoor"},
+      signinOptions: {signinAvailable: false, autoSignin: false},
+      machines: [],
+      stats: {nodesTotal: 0, nodesReady: 0, deploymentsTotal: 0},
+    })[0].done,
+    true
+  );
+});

--- a/web2/src/components/shared/first-run-checklist.jsx
+++ b/web2/src/components/shared/first-run-checklist.jsx
@@ -1,0 +1,72 @@
+import {ArrowRight, KeyRound, Laptop, Network, Rocket} from "lucide-react";
+import {useTranslation} from "react-i18next";
+import {Button} from "@/components/ui/button";
+import {Card, CardContent, CardDescription, CardHeader, CardTitle} from "@/components/ui/card";
+import {Checkbox} from "@/components/ui/checkbox";
+import {getFirstRunChecklist} from "@/FirstRunChecklistState";
+
+const STEP_ICONS = {password: KeyRound, machine: Laptop, node: Network, app: Rocket};
+
+export function FirstRunChecklist({account, signinOptions, machines, stats, onAction}) {
+  const {t} = useTranslation();
+  const steps = getFirstRunChecklist({account, signinOptions, machines, stats});
+  const labels = {
+    password: {
+      title: t("onboarding:Change the default password"),
+      description: t("onboarding:Use a unique password for the built-in admin account."),
+      action: t("onboarding:Open account settings"),
+    },
+    machine: {
+      title: t("onboarding:Add a machine"),
+      description: t("onboarding:Add an SSH-accessible machine before deploying it as a node."),
+      action: t("onboarding:Open Machines"),
+    },
+    node: {
+      title: t("onboarding:Deploy a machine as a node"),
+      description: t("onboarding:A node is required before CasOS can schedule workloads."),
+      action: t("onboarding:Open Machines"),
+    },
+    app: {
+      title: t("onboarding:Install your first app"),
+      description: t("onboarding:Install an app from the App Store after a node is ready."),
+      action: t("onboarding:Open App Store"),
+    },
+  };
+  const completed = steps.filter((step) => step.done).length;
+
+  return (
+    <Card>
+      <CardHeader className="gap-1">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-base">{t("onboarding:First-run checklist")}</CardTitle>
+          <span className="text-muted-foreground text-xs tabular-nums">
+            {t("onboarding:{{completed}} of 4 complete", {completed})}
+          </span>
+        </div>
+        <CardDescription>{t("onboarding:Complete these steps to get a working CasOS cluster.")}</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-0">
+        {steps.map((step) => {
+          const Icon = STEP_ICONS[step.key];
+          const label = labels[step.key];
+          return (
+            <div key={step.key} className="flex items-start gap-3 border-b py-3 last:border-b-0">
+              <Checkbox checked={step.done} disabled aria-label={label.title} className="mt-0.5" />
+              <Icon className={step.done ? "text-success mt-0.5 size-4 shrink-0" : "text-info mt-0.5 size-4 shrink-0"} />
+              <div className="min-w-0 flex-1">
+                <p className={step.done ? "text-muted-foreground text-sm line-through" : "text-sm font-medium"}>{label.title}</p>
+                <p className="text-muted-foreground mt-1 text-xs">{label.description}</p>
+              </div>
+              {!step.done && onAction ? (
+                <Button variant="link" size="sm" className="h-auto min-w-0 shrink-0 whitespace-normal px-1 text-right" onClick={() => onAction(step.key)}>
+                  {label.action}
+                  <ArrowRight />
+                </Button>
+              ) : null}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web2/src/locales/en/data.json
+++ b/web2/src/locales/en/data.json
@@ -224,6 +224,7 @@
     "Local WSL machine added": "Local WSL machine added",
     "Local WSL machine refreshed": "Local WSL machine refreshed",
     "Machine owner is required": "Machine owner is required",
+    "No machines yet": "No machines yet. Add a machine to get started.",
     "No node deployment logs": "No node deployment logs.",
     "Node deployment failed": "Node deployment failed",
     "Node deployment logs": "Node deployment logs",
@@ -249,6 +250,25 @@
     "SSH port - Tooltip": "The SSH port used to connect to the node, usually 22.",
     "Username - Tooltip": "The SSH user CasOS uses to connect to the node.",
     "Worker Node": "Worker Node"
+  },
+  "node": {
+    "No nodes registered. Add a machine and deploy it as a node from Machines.": "No nodes registered. Add a machine, then deploy it as a node from Machines."
+  },
+  "onboarding": {
+    "First-run checklist": "First-run checklist",
+    "{{completed}} of 4 complete": "{{completed}} of 4 complete",
+    "Complete these steps to get a working CasOS cluster.": "Complete these steps to get a working CasOS cluster.",
+    "Change the default password": "Change the default password",
+    "Use a unique password for the built-in admin account.": "Use a unique password for the built-in admin account.",
+    "Open account settings": "Open account settings",
+    "Add a machine": "Add a machine",
+    "Add an SSH-accessible machine before deploying it as a node.": "Add an SSH-accessible machine before deploying it as a node.",
+    "Open Machines": "Open Machines",
+    "Deploy a machine as a node": "Deploy a machine as a node",
+    "A node is required before CasOS can schedule workloads.": "A node is required before CasOS can schedule workloads.",
+    "Install your first app": "Install your first app",
+    "Install an app from the App Store after a node is ready.": "Install an app from the App Store after a node is ready.",
+    "Open App Store": "Open App Store"
   },
   "policy": {
     "Add Rule": "Add Rule",

--- a/web2/src/locales/zh/data.json
+++ b/web2/src/locales/zh/data.json
@@ -224,6 +224,7 @@
     "Local WSL machine added": "已添加本机 WSL",
     "Local WSL machine refreshed": "已刷新本机 WSL",
     "Machine owner is required": "机器所有者不能为空",
+    "No machines yet": "还没有机器，请先添加一台机器。",
     "No node deployment logs": "暂无部署日志。",
     "Node deployment failed": "节点部署失败",
     "Node deployment logs": "节点部署日志",
@@ -249,6 +250,25 @@
     "SSH port - Tooltip": "连接节点使用的 SSH 端口，通常为 22。",
     "Username - Tooltip": "CasOS 用于连接节点的 SSH 用户名。",
     "Worker Node": "工作节点"
+  },
+  "node": {
+    "No nodes registered. Add a machine and deploy it as a node from Machines.": "还没有注册节点，请先在机器页添加机器并部署为节点。"
+  },
+  "onboarding": {
+    "First-run checklist": "首次运行清单",
+    "{{completed}} of 4 complete": "已完成 {{completed}} / 4 项",
+    "Complete these steps to get a working CasOS cluster.": "完成以下步骤即可开始使用 CasOS 集群。",
+    "Change the default password": "修改默认密码",
+    "Use a unique password for the built-in admin account.": "为内置管理员账户设置一个唯一密码。",
+    "Open account settings": "打开账户设置",
+    "Add a machine": "添加机器",
+    "Add an SSH-accessible machine before deploying it as a node.": "先添加一台可通过 SSH 访问的机器，再将它部署为节点。",
+    "Open Machines": "打开机器页",
+    "Deploy a machine as a node": "将机器部署为节点",
+    "A node is required before CasOS can schedule workloads.": "必须先有节点，CasOS 才能调度工作负载。",
+    "Install your first app": "安装第一个应用",
+    "Install an app from the App Store after a node is ready.": "节点就绪后，从应用市场安装一个应用。",
+    "Open App Store": "打开应用市场"
   },
   "policy": {
     "Add Rule": "添加规则",

--- a/web2/src/pages/DashboardPage.jsx
+++ b/web2/src/pages/DashboardPage.jsx
@@ -2,7 +2,9 @@ import React, {useMemo} from "react";
 import {useHistory} from "react-router-dom";
 import {useTranslation} from "react-i18next";
 import {Boxes, CheckCircle2, Layers, Network, Server, Settings, TriangleAlert} from "lucide-react";
+import * as AccountBackend from "@/backend/AccountBackend";
 import * as DashboardBackend from "@/backend/DashboardBackend";
+import * as MachineBackend from "@/backend/MachineBackend";
 import {useResource} from "@/hooks/use-resource";
 import {Badge} from "@/components/ui/badge";
 import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
@@ -13,6 +15,7 @@ import {PageContainer} from "@/components/shared/page-header";
 import {StatCard} from "@/components/shared/stat-card";
 import {Loading} from "@/components/shared/loading";
 import {RadialProgress} from "@/components/shared/radial-progress";
+import {FirstRunChecklist} from "@/components/shared/first-run-checklist";
 import {CHART_COLORS, EchartsWidget} from "@/components/shared/echarts-widget";
 import {getDashboardHealthState} from "@/lib/dashboardHealth";
 
@@ -160,10 +163,18 @@ function GaugeCard({title, percent, tone, primaryValue, primaryLabel, secondaryV
   );
 }
 
-function DashboardPage() {
+function DashboardPage({account, accountUpdatedAt, onOpenAccount}) {
   const history = useHistory();
   const {t} = useTranslation();
   const {data: stats, loading} = useResource(() => DashboardBackend.getDashboard(), [], {initialData: null});
+  const {data: machines} = useResource(() => MachineBackend.getGlobalMachines(), [accountUpdatedAt], {
+    initialData: null,
+    toastOnError: false,
+  });
+  const {data: signinOptions} = useResource(() => AccountBackend.getSigninOptions(), [accountUpdatedAt], {
+    initialData: null,
+    toastOnError: false,
+  });
 
   const podPhase = useMemo(() => donutOption(stats?.podsByPhase, POD_PHASE_COLORS), [stats]);
   const serviceTypes = useMemo(() => donutOption(stats?.servicesByType, SVC_TYPE_COLORS), [stats]);
@@ -247,6 +258,21 @@ function DashboardPage() {
 
   return (
     <PageContainer>
+      <FirstRunChecklist
+        account={account}
+        signinOptions={signinOptions}
+        machines={machines}
+        stats={stats}
+        onAction={(step) => {
+          if (step === "password") {
+            onOpenAccount?.();
+          } else if (step === "machine" || step === "node") {
+            history.push("/machines");
+          } else if (step === "app") {
+            history.push("/app-store");
+          }
+        }}
+      />
       {!clusterHealthy ? (
         <div className="grid gap-2">
           <Alert variant={healthStatus === "unknown" ? "warning" : "destructive"}>

--- a/web2/src/pages/MachineListPage.jsx
+++ b/web2/src/pages/MachineListPage.jsx
@@ -212,7 +212,7 @@ function MachineListPage({account}) {
         rowKey="name"
         loading={loading}
         searchable
-        emptyText="No machines"
+        emptyText={i18next.t("machine:No machines yet")}
         toolbar={
           <>
             <SimpleTooltip title={i18next.t("machine:Add Local WSL - Tooltip")}>

--- a/web2/src/pages/ManagementPage.jsx
+++ b/web2/src/pages/ManagementPage.jsx
@@ -15,6 +15,7 @@ function ManagementPage(props) {
   useTranslation();
 
   const {account, site, themeAlgorithm, logo, uri, onSignout, onUpdateSite, onUpdateAccount, setLogoAndThemeAlgorithm} = props;
+  const [accountUpdatedAt, setAccountUpdatedAt] = useState(0);
 
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem("siderCollapsed") === "true");
   const [accountDialogOpen, setAccountDialogOpen] = useState(false);
@@ -88,6 +89,11 @@ function ManagementPage(props) {
     }
   }
 
+  function handleAccountUpdated() {
+    onUpdateAccount?.();
+    setAccountUpdatedAt(Date.now());
+  }
+
   const sidebarLogo = logo || Setting.getLogo(themeAlgorithm || [], site?.logoUrl);
   const navbarHtml = Setting.getNavbarHtml(themeAlgorithm || [], site?.navbarHtml);
   const footerHtml = Setting.getFooterHtml(themeAlgorithm || [], site?.footerHtml, site);
@@ -116,7 +122,7 @@ function ManagementPage(props) {
         />
 
         <main className="flex min-w-0 flex-1 flex-col">
-          <AppRoutes account={account} onUpdateSite={onUpdateSite} />
+          <AppRoutes account={account} accountUpdatedAt={accountUpdatedAt} onOpenAccount={handleOpenAccount} onUpdateSite={onUpdateSite} />
         </main>
 
         <footer className="text-muted-foreground flex items-center justify-center border-t py-5 text-sm">
@@ -128,7 +134,7 @@ function ManagementPage(props) {
         account={account}
         open={accountDialogOpen}
         onOpenChange={setAccountDialogOpen}
-        onUpdateAccount={onUpdateAccount}
+        onUpdateAccount={handleAccountUpdated}
       />
     </div>
   );

--- a/web2/src/pages/NodeListPage.jsx
+++ b/web2/src/pages/NodeListPage.jsx
@@ -189,7 +189,7 @@ function NodeListPage() {
         rowKey="name"
         loading={loading}
         searchable
-        emptyText="No nodes registered. Start kubelet on a worker to join the cluster."
+        emptyText={i18next.t("node:No nodes registered. Add a machine and deploy it as a node from Machines.")}
         toolbar={
           <Button variant="outline" size="sm" onClick={() => refresh()} loading={loading}>
             <RefreshCw />

--- a/web2/src/routes.jsx
+++ b/web2/src/routes.jsx
@@ -55,11 +55,15 @@ function NotFound() {
   );
 }
 
-export function AppRoutes({account, onUpdateSite}) {
+export function AppRoutes({account, accountUpdatedAt, onOpenAccount, onUpdateSite}) {
   return (
     <Suspense fallback={<Loading type="page" />}>
       <Switch>
-        <Route exact path={["/", "/dashboard"]} component={DashboardPage} />
+        <Route
+          exact
+          path={["/", "/dashboard"]}
+          render={(props) => <DashboardPage account={account} accountUpdatedAt={accountUpdatedAt} onOpenAccount={onOpenAccount} {...props} />}
+        />
         <Route exact path="/namespaces" component={NamespaceListPage} />
         <Route exact path="/configmaps" component={ConfigMapListPage} />
         <Route exact path="/secrets" component={SecretListPage} />


### PR DESCRIPTION
Summary: add a first-run checklist to the web2 dashboard for password, machine, ready node, and first app setup; make Machines and Nodes empty states actionable and localized; document that a machine must be deployed as a ready node before installing apps. Tests: node --test web2/src/FirstRunChecklistState.test.js; en/zh locale JSON parse; yarn build (Vite, 2494 modules). Notes: yarn lint could not start because eslint is missing; changes are limited to web2 and README.md; this PR contains one commit. Claude read-only review: can merge; no blocking findings.