### PR TITLE
fix: paginate configmap list responses

### DIFF
--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,9 +15,32 @@ type configMapSummary struct {
 	Namespace       string            `json:"namespace"`
 	Name            string            `json:"name"`
 	DataKeys        int               `json:"dataKeys"`
-	Data            map[string]string `json:"data"`
+	Data            map[string]string `json:"data,omitempty"`
 	CreatedAt       string            `json:"createdAt"`
 	ResourceVersion string            `json:"resourceVersion"`
+}
+
+func toListSummary(cm corev1.ConfigMap) configMapSummary {
+	summary := toSummary(cm)
+	summary.Data = nil
+	return summary
+}
+
+type configMapPage struct {
+	Items              []configMapSummary `json:"items"`
+	ContinueToken      string             `json:"continueToken"`
+	RemainingItemCount *int64             `json:"remainingItemCount,omitempty"`
+}
+
+func parseConfigMapLimit(value string) (int64, bool, error) {
+	if value == "" {
+		return 0, false, nil
+	}
+	limit, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || limit < 1 || limit > 100 {
+		return 0, false, fmt.Errorf("limit must be an integer between 1 and 100")
+	}
+	return limit, true, nil
 }
 
 func toSummary(cm corev1.ConfigMap) configMapSummary {
@@ -38,6 +63,28 @@ func (c *ApiController) GetConfigMaps() {
 		return
 	}
 	namespace := c.GetString("namespace")
+	limit, paginated, err := parseConfigMapLimit(c.GetString("limit"))
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	if paginated {
+		page, err := object.GetConfigMapPage(cfg, namespace, limit, c.GetString("continue"))
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+		items := make([]configMapSummary, 0, len(page.Items))
+		for _, cm := range page.Items {
+			items = append(items, toListSummary(cm))
+		}
+		c.ResponseOk(configMapPage{
+			Items:              items,
+			ContinueToken:      page.Continue,
+			RemainingItemCount: page.RemainingItemCount,
+		})
+		return
+	}
 	cms, err := object.GetConfigMaps(cfg, namespace)
 	if err != nil {
 		c.ResponseError(err.Error())

--- a/object/configmap.go
+++ b/object/configmap.go
@@ -14,6 +14,18 @@ func newClient(cfg *rest.Config) (*kubernetes.Clientset, error) {
 }
 
 func GetConfigMaps(cfg *rest.Config, namespace string) ([]corev1.ConfigMap, error) {
+	list, err := getConfigMaps(cfg, namespace, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func GetConfigMapPage(cfg *rest.Config, namespace string, limit int64, continueToken string) (*corev1.ConfigMapList, error) {
+	return getConfigMaps(cfg, namespace, metav1.ListOptions{Limit: limit, Continue: continueToken})
+}
+
+func getConfigMaps(cfg *rest.Config, namespace string, options metav1.ListOptions) (*corev1.ConfigMapList, error) {
 	client, err := newClient(cfg)
 	if err != nil {
 		return nil, err
@@ -22,11 +34,11 @@ func GetConfigMaps(cfg *rest.Config, namespace string) ([]corev1.ConfigMap, erro
 	if ns == "" {
 		ns = metav1.NamespaceAll
 	}
-	list, err := client.CoreV1().ConfigMaps(ns).List(context.Background(), metav1.ListOptions{})
+	list, err := client.CoreV1().ConfigMaps(ns).List(context.Background(), options)
 	if err != nil {
 		return nil, err
 	}
-	return list.Items, nil
+	return list, nil
 }
 
 func GetConfigMap(cfg *rest.Config, namespace, name string) (*corev1.ConfigMap, error) {

--- a/web2/src/backend/ConfigMapBackend.js
+++ b/web2/src/backend/ConfigMapBackend.js
@@ -8,6 +8,27 @@ export function getConfigMaps(namespace = "") {
   }).then(res => res.json());
 }
 
+export function getConfigMapPage(namespace = "", limit = 20, continueToken = "") {
+  const params = new URLSearchParams({namespace, limit: String(limit)});
+  if (continueToken) {
+    params.set("continue", continueToken);
+  }
+  return fetch(`${Setting.ServerUrl}/api/get-configmaps?${params}`, {
+    method: "GET",
+    credentials: "include",
+    headers: {"Accept-Language": Setting.getAcceptLanguage()},
+  }).then(res => res.json());
+}
+
+export function getConfigMap(namespace, name) {
+  const params = new URLSearchParams({namespace, name});
+  return fetch(`${Setting.ServerUrl}/api/get-configmap?${params}`, {
+    method: "GET",
+    credentials: "include",
+    headers: {"Accept-Language": Setting.getAcceptLanguage()},
+  }).then(res => res.json());
+}
+
 export function addConfigMap(configmap) {
   return fetch(`${Setting.ServerUrl}/api/add-configmap`, {
     method: "POST",

--- a/web2/src/components/shared/data-table.jsx
+++ b/web2/src/components/shared/data-table.jsx
@@ -88,6 +88,7 @@ function SortIcon({state}) {
  *   description     small text under the title
  *   searchable      renders a filter box that matches across all cells
  *   pageSize        rows per page; pass 0 to disable pagination
+ *   manualPagination controlled server-side pagination state and callbacks
  *   emptyText       shown when there is no data and nothing is loading
  *   onRowClick      makes rows interactive
  *   expandable      {rowExpandable(record), expandedRowRender(record)}
@@ -110,6 +111,7 @@ export function DataTable({
   searchable = false,
   searchPlaceholder = "Search...",
   pageSize = 20,
+  manualPagination = null,
   emptyText = "No data",
   emptyIcon,
   onRowClick,
@@ -135,7 +137,7 @@ export function DataTable({
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: pageSize > 0 ? getPaginationRowModel() : undefined,
+    getPaginationRowModel: pageSize > 0 && !manualPagination ? getPaginationRowModel() : undefined,
     getRowId: (record, index) => resolveRowKey(rowKey, record, index),
     // The default filter only sees accessor values, which would silently skip
     // display columns. Matching the whole record keeps a search for an action
@@ -144,13 +146,15 @@ export function DataTable({
       JSON.stringify(row.original ?? {})
         .toLowerCase()
         .includes(String(value).toLowerCase()),
-    initialState: pageSize > 0 ? {pagination: {pageSize}} : undefined,
+    initialState: pageSize > 0 && !manualPagination ? {pagination: {pageSize}} : undefined,
   });
 
   const rows = table.getRowModel().rows;
   const showHeader = Boolean(title || description || toolbar || searchable);
-  const totalRows = table.getFilteredRowModel().rows.length;
-  const showPagination = pageSize > 0 && totalRows > pageSize;
+  const totalRows = manualPagination?.totalRows ?? table.getFilteredRowModel().rows.length;
+  const showPagination = manualPagination
+    ? manualPagination.hasPreviousPage || manualPagination.hasNextPage
+    : pageSize > 0 && totalRows > pageSize;
 
   return (
     <div
@@ -305,28 +309,32 @@ export function DataTable({
       {showPagination && (
         <div className="flex items-center justify-between border-t px-4 py-2.5">
           <span className="text-muted-foreground text-xs">
-            {table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1}
-            {"–"}
-            {Math.min((table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize, totalRows)} of {totalRows}
+            {manualPagination
+              ? manualPagination.label
+              : <>
+                {table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1}
+                {"–"}
+                {Math.min((table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize, totalRows)} of {totalRows}
+              </>}
           </span>
           <div className="flex items-center gap-1">
             <Button
               variant="outline"
               size="icon-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
+              onClick={manualPagination?.onPreviousPage ?? (() => table.previousPage())}
+              disabled={manualPagination ? !manualPagination.hasPreviousPage : !table.getCanPreviousPage()}
               aria-label="Previous page"
             >
               <ChevronLeft className="size-4" />
             </Button>
             <span className="text-muted-foreground px-2 text-xs tabular-nums">
-              {table.getState().pagination.pageIndex + 1} / {table.getPageCount()}
+              {manualPagination ? `Page ${manualPagination.pageIndex + 1}` : `${table.getState().pagination.pageIndex + 1} / ${table.getPageCount()}`}
             </span>
             <Button
               variant="outline"
               size="icon-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
+              onClick={manualPagination?.onNextPage ?? (() => table.nextPage())}
+              disabled={manualPagination ? !manualPagination.hasNextPage : !table.getCanNextPage()}
               aria-label="Next page"
             >
               <ChevronRight className="size-4" />

--- a/web2/src/pages/ConfigMapListPage.jsx
+++ b/web2/src/pages/ConfigMapListPage.jsx
@@ -1,10 +1,10 @@
-import React, {useState} from "react";
+import React, {useEffect, useRef, useState} from "react";
 import i18next from "i18next";
 import {Pencil, Plus, RefreshCw, Trash2} from "lucide-react";
 import * as ConfigMapBackend from "@/backend/ConfigMapBackend";
 import * as NamespaceBackend from "@/backend/NamespaceBackend";
+import * as Setting from "@/Setting";
 import {runAction, useResource} from "@/hooks/use-resource";
-import {Badge} from "@/components/ui/badge";
 import {Button} from "@/components/ui/button";
 import {Input} from "@/components/ui/input";
 import {MessageAlert} from "@/components/ui/alert";
@@ -17,10 +17,30 @@ import {KeyValueEditor, fromEntries, toEntries} from "@/components/shared/key-va
 import {RestartDeploymentsDialog} from "@/components/shared/restart-deployments-dialog";
 
 const emptyForm = {namespace: "", name: "", entries: []};
+const CONFIG_MAP_PAGE_SIZE = 20;
 
 function ConfigMapListPage() {
-  const {data: configMaps, loading, error, refresh} = useResource(() => ConfigMapBackend.getConfigMaps(), [], {initialData: []});
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageTokens, setPageTokens] = useState([""]);
+  const pageToken = pageTokens[pageIndex] ?? "";
+  const {
+    data: configMapPage,
+    loading,
+    error,
+    refresh: refreshPage,
+  } = useResource(
+    () => ConfigMapBackend.getConfigMapPage("", CONFIG_MAP_PAGE_SIZE, pageToken),
+    [pageIndex, pageToken],
+    {initialData: {items: [], continueToken: "", remainingItemCount: null}}
+  );
   const {data: namespaces} = useResource(() => NamespaceBackend.getNamespaces(), [], {initialData: [], toastOnError: false});
+
+  const configMaps = configMapPage?.items ?? [];
+  const hasNextPage = Boolean(configMapPage?.continueToken);
+  const remainingItemCount = configMapPage?.remainingItemCount;
+  const totalRows = Number.isFinite(remainingItemCount)
+    ? pageIndex * CONFIG_MAP_PAGE_SIZE + configMaps.length + remainingItemCount
+    : null;
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [mode, setMode] = useState("add");
@@ -28,11 +48,23 @@ function ConfigMapListPage() {
   const [form, setForm] = useState(emptyForm);
   const [errors, setErrors] = useState({});
   const [submitting, setSubmitting] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
   const [restartTarget, setRestartTarget] = useState(null);
+  const editRequestRef = useRef(0);
+
+  useEffect(() => () => {
+    editRequestRef.current += 1;
+  }, []);
 
   const namespaceOptions = (namespaces ?? []).map((item) => ({label: item.name, value: item.name}));
 
+  function invalidateEditRequest() {
+    editRequestRef.current += 1;
+    setDetailLoading(false);
+  }
+
   function openAdd() {
+    invalidateEditRequest();
     setMode("add");
     setEditing(null);
     setForm({...emptyForm, namespace: namespaces?.[0]?.name ?? "default"});
@@ -40,12 +72,61 @@ function ConfigMapListPage() {
     setDialogOpen(true);
   }
 
-  function openEdit(record) {
+  function openPreviousPage() {
+    setPageIndex((current) => Math.max(0, current - 1));
+  }
+
+  function openNextPage() {
+    if (!hasNextPage) {
+      return;
+    }
+    setPageTokens((current) => {
+      const next = current.slice(0, pageIndex + 1);
+      next.push(configMapPage.continueToken);
+      return next;
+    });
+    setPageIndex((current) => current + 1);
+  }
+
+  function refreshFromFirstPage() {
+    if (pageIndex === 0) {
+      refreshPage();
+      return;
+    }
+    setPageTokens([""]);
+    setPageIndex(0);
+  }
+
+  async function openEdit(record) {
+    const requestId = ++editRequestRef.current;
     setMode("edit");
     setEditing(record);
-    setForm({namespace: record.namespace, name: record.name, entries: toEntries(record.data)});
+    setForm({namespace: record.namespace, name: record.name, entries: []});
     setErrors({});
     setDialogOpen(true);
+
+    setDetailLoading(true);
+    try {
+      const response = await ConfigMapBackend.getConfigMap(record.namespace, record.name);
+      if (requestId !== editRequestRef.current) {
+        return;
+      }
+      if (response?.status !== "ok") {
+        Setting.showMessage("error", response?.msg ?? "Request failed");
+        return;
+      }
+      const configMap = response.data ?? {};
+      setEditing(configMap);
+      setForm({namespace: configMap.namespace, name: configMap.name, entries: toEntries(configMap.data)});
+    } catch (error) {
+      if (requestId === editRequestRef.current) {
+        Setting.showMessage("error", error.message);
+      }
+    } finally {
+      if (requestId === editRequestRef.current) {
+        setDetailLoading(false);
+      }
+    }
   }
 
   async function handleSubmit() {
@@ -73,7 +154,7 @@ function ConfigMapListPage() {
 
     if (ok) {
       setDialogOpen(false);
-      refresh();
+      refreshFromFirstPage();
       if (mode === "edit") {
         // Pods hold the values they started with, so an edit is only live once
         // the deployments referencing it roll.
@@ -87,7 +168,7 @@ function ConfigMapListPage() {
       successMessage: "ConfigMap deleted",
     });
     if (ok) {
-      refresh();
+      refreshFromFirstPage();
     }
   }
 
@@ -97,16 +178,8 @@ function ConfigMapListPage() {
     {
       key: "data",
       title: "Keys",
-      dataIndex: "data",
-      render: (data) => (
-        <div className="flex flex-wrap gap-1">
-          {Object.keys(data ?? {}).map((key) => (
-            <Badge key={key} variant="muted" className="font-mono">
-              {key}
-            </Badge>
-          ))}
-        </div>
-      ),
+      dataIndex: "dataKeys",
+      render: (count) => `${count ?? 0}`,
     },
     {key: "createdAt", title: i18next.t("general:Created"), dataIndex: "createdAt", width: 190, sortable: true},
     {
@@ -141,16 +214,26 @@ function ConfigMapListPage() {
 
       <DataTable
         title={i18next.t("general:ConfigMaps")}
-        description={`${configMaps?.length ?? 0} config maps`}
+        description={`${totalRows ?? pageIndex * CONFIG_MAP_PAGE_SIZE + configMaps.length} config maps`}
         columns={columns}
         dataSource={configMaps}
         rowKey={(record) => `${record.namespace}/${record.name}`}
         loading={loading}
         searchable
+        pageSize={0}
+        manualPagination={{
+          pageIndex,
+          hasPreviousPage: pageIndex > 0,
+          hasNextPage,
+          onPreviousPage: openPreviousPage,
+          onNextPage: openNextPage,
+          label: totalRows === null ? `Page ${pageIndex + 1}` : `${pageIndex * CONFIG_MAP_PAGE_SIZE + 1}–${pageIndex * CONFIG_MAP_PAGE_SIZE + configMaps.length} of ${totalRows}`,
+          totalRows,
+        }}
         emptyText="No ConfigMaps found"
         toolbar={
           <>
-            <Button variant="outline" size="sm" onClick={() => refresh()} loading={loading}>
+            <Button variant="outline" size="sm" onClick={refreshFromFirstPage} loading={loading}>
               <RefreshCw />
               {i18next.t("general:Refresh")}
             </Button>
@@ -164,10 +247,16 @@ function ConfigMapListPage() {
 
       <FormDialog
         open={dialogOpen}
-        onOpenChange={setDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            invalidateEditRequest();
+          }
+          setDialogOpen(open);
+        }}
         title={mode === "add" ? "Add ConfigMap" : "Edit ConfigMap"}
         submitText={mode === "add" ? "Create" : "Update"}
-        submitting={submitting}
+        submitting={submitting || detailLoading}
+        submitDisabled={detailLoading}
         onSubmit={handleSubmit}
         size="lg"
       >


### PR DESCRIPTION
## Summary

- add server-side pagination to `/api/get-configmaps` using Kubernetes `limit` and `continue`
- omit ConfigMap `data` values from paginated list responses
- fetch the complete ConfigMap only when opening the edit dialog
- add manual server-side pagination support to the web2 data table
- prevent stale detail requests from overwriting a newly opened form

## Why

The ConfigMap list previously returned every object's complete `data` map, including large values such as CA certificate PEM content.

On production clusters, this caused the browser to download and parse the full ConfigMap payload for the entire cluster at once. Client-side pagination did not reduce the API response size.

## Compatibility

Legacy clients that omit the `limit` parameter continue to receive the existing full response from `/api/get-configmaps`.

The web2 ConfigMap list now uses the paginated metadata-only response.

## Verification

- `go test ./controllers -count=1`
- `go test ./object -count=1`
- `cd web2 && yarn build`
- `node --check web2/src/backend/ConfigMapBackend.js`
- Claude CLI final review: `可以 merge`