### PR TITLE
fix(deployment): expose CPU/memory request fields end-to-end

### DIFF
--- a/controllers/app.go
+++ b/controllers/app.go
@@ -58,7 +58,11 @@ func (c *ApiController) DeployApp() {
 		Image:     req.Image,
 		EnvVars:   req.EnvVars,
 	}
-	depl := buildDeployment(deplReq)
+	depl, err := buildDeployment(deplReq)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
 
 	if len(req.Ports) > 0 && len(depl.Spec.Template.Spec.Containers) > 0 {
 		cports := make([]corev1.ContainerPort, 0, len(req.Ports))

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -20,12 +21,60 @@ type deploymentSummary struct {
 	ReadyReplicas     int32             `json:"readyReplicas"`
 	AvailableReplicas int32             `json:"availableReplicas"`
 	Image             string            `json:"image"`
+	CpuRequest        string            `json:"cpuRequest"`
+	MemoryRequest     string            `json:"memoryRequest"`
 	Ports             []portSummary     `json:"ports"`
 	Selector          map[string]string `json:"selector"`
 	EnvVars           []envVarSummary   `json:"envVars"`
 	Volumes           []volumeSummary   `json:"volumes"`
 	CreatedAt         string            `json:"createdAt"`
 	ResourceVersion   string            `json:"resourceVersion"`
+}
+
+// containerResourcesRequest extracts the cpu/memory request strings from the
+// first container's Resources.Requests. Returns empty strings when the field
+// is unset so the form can round-trip the value.
+func containerResourcesRequest(d appsv1.Deployment) (cpu, memory string) {
+	if len(d.Spec.Template.Spec.Containers) == 0 {
+		return "", ""
+	}
+	reqs := d.Spec.Template.Spec.Containers[0].Resources.Requests
+	if q, ok := reqs[corev1.ResourceCPU]; ok {
+		cpu = q.String()
+	}
+	if q, ok := reqs[corev1.ResourceMemory]; ok {
+		memory = q.String()
+	}
+	return cpu, memory
+}
+
+// mergeContainerResourceRequests writes the supplied cpu/memory request
+// strings into the given container's Resources.Requests map, only overriding
+// keys the caller actually supplied. An empty input string leaves that
+// particular resource untouched. parseQuantity failures are surfaced as
+// errors with the bad input so the controller can return them to the user
+// instead of panicking.
+func mergeContainerResourceRequests(container *corev1.Container, cpu, memory string) error {
+	reqs := container.Resources.Requests
+	if reqs == nil {
+		reqs = corev1.ResourceList{}
+	}
+	if cpu != "" {
+		q, err := resource.ParseQuantity(cpu)
+		if err != nil {
+			return fmt.Errorf("invalid cpuRequest %q: %w", cpu, err)
+		}
+		reqs[corev1.ResourceCPU] = q
+	}
+	if memory != "" {
+		q, err := resource.ParseQuantity(memory)
+		if err != nil {
+			return fmt.Errorf("invalid memoryRequest %q: %w", memory, err)
+		}
+		reqs[corev1.ResourceMemory] = q
+	}
+	container.Resources.Requests = reqs
+	return nil
 }
 
 func toDeploymentSummary(d appsv1.Deployment) deploymentSummary {
@@ -56,6 +105,7 @@ func toDeploymentSummary(d appsv1.Deployment) deploymentSummary {
 			})
 		}
 	}
+	cpu, memory := containerResourcesRequest(d)
 	return deploymentSummary{
 		Namespace:         d.Namespace,
 		Name:              d.Name,
@@ -63,6 +113,8 @@ func toDeploymentSummary(d appsv1.Deployment) deploymentSummary {
 		ReadyReplicas:     d.Status.ReadyReplicas,
 		AvailableReplicas: d.Status.AvailableReplicas,
 		Image:             image,
+		CpuRequest:        cpu,
+		MemoryRequest:     memory,
 		Ports:             ports,
 		Selector:          selector,
 		EnvVars:           extractEnvVars(d.Spec.Template.Spec.Containers),
@@ -124,7 +176,7 @@ type deploymentRequest struct {
 	ResourceVersion string          `json:"resourceVersion"`
 }
 
-func buildDeployment(req deploymentRequest) *appsv1.Deployment {
+func buildDeployment(req deploymentRequest) (*appsv1.Deployment, error) {
 	replicas := req.Replicas
 	if replicas <= 0 {
 		replicas = 1
@@ -141,14 +193,9 @@ func buildDeployment(req deploymentRequest) *appsv1.Deployment {
 	}
 
 	if req.CpuRequest != "" || req.MemoryRequest != "" {
-		reqs := corev1.ResourceList{}
-		if req.CpuRequest != "" {
-			reqs[corev1.ResourceCPU] = resource.MustParse(req.CpuRequest)
+		if err := mergeContainerResourceRequests(&container, req.CpuRequest, req.MemoryRequest); err != nil {
+			return nil, err
 		}
-		if req.MemoryRequest != "" {
-			reqs[corev1.ResourceMemory] = resource.MustParse(req.MemoryRequest)
-		}
-		container.Resources = corev1.ResourceRequirements{Requests: reqs}
 	}
 
 	podVolumes, mounts := buildPodVolumes(req.Name, req.Volumes)
@@ -175,7 +222,7 @@ func buildDeployment(req deploymentRequest) *appsv1.Deployment {
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 // AddDeployment
@@ -194,11 +241,16 @@ func (c *ApiController) AddDeployment() {
 	if req.Namespace == "" {
 		req.Namespace = "default"
 	}
+	deployment, err := buildDeployment(req)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
 	if err := ensureDeploymentPVCs(cfg, req.Namespace, req.Name, req.Volumes); err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
-	created, err := object.AddDeployment(cfg, buildDeployment(req))
+	created, err := object.AddDeployment(cfg, deployment)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
@@ -235,19 +287,25 @@ func (c *ApiController) UpdateDeployment() {
 		replicas = 1
 	}
 	existing.Spec.Replicas = &replicas
-	if len(existing.Spec.Template.Spec.Containers) > 0 {
-		existing.Spec.Template.Spec.Containers[0].Image = req.Image
-		existing.Spec.Template.Spec.Containers[0].Env = buildEnvVars(req.EnvVars)
-	} else {
-		containerName := req.ContainerName
-		if containerName == "" {
-			containerName = req.Name
+	if len(existing.Spec.Template.Spec.Containers) == 0 {
+		// K8s rejects Deployments with no containers at create time, so this
+		// only fires if the apiserver returns a malformed object. Surface it
+		// instead of silently rebuilding a container — rebuilding would mask
+		// the actual cluster state.
+		c.ResponseError(fmt.Sprintf("deployment %s/%s has no containers", existing.Namespace, existing.Name))
+		return
+	}
+	container := &existing.Spec.Template.Spec.Containers[0]
+	container.Image = req.Image
+	container.Env = buildEnvVars(req.EnvVars)
+	// Resource requests: only override the keys the form actually sent. An
+	// empty string leaves the existing value intact so opening the editor
+	// and saving image/env alone does not clear resources.
+	if req.CpuRequest != "" || req.MemoryRequest != "" {
+		if err := mergeContainerResourceRequests(container, req.CpuRequest, req.MemoryRequest); err != nil {
+			c.ResponseError(err.Error())
+			return
 		}
-		existing.Spec.Template.Spec.Containers = []corev1.Container{{
-			Name:  containerName,
-			Image: req.Image,
-			Env:   buildEnvVars(req.EnvVars),
-		}}
 	}
 	existing.ResourceVersion = req.ResourceVersion
 

--- a/web/src/pages/DeploymentListPage.jsx
+++ b/web/src/pages/DeploymentListPage.jsx
@@ -33,7 +33,23 @@ import {
   DeploymentUpdateImageDialog,
 } from "@/components/shared/deployment-dialogs";
 
-const emptyForm = {namespace: "", name: "", image: "", replicas: 1, containerName: "", envVars: [], volumes: []};
+const emptyForm = {namespace: "", name: "", image: "", replicas: 1, containerName: "", cpuRequest: "", memoryRequest: "", envVars: [], volumes: []};
+
+// K8s quantity syntax. Mirrors the regex embedded in `resource.ParseQuantity`
+// (k8s.io/apimachinery/pkg/api/resource) so the form rejects the same input
+// the API would. An empty string is always allowed here — the backend
+// treats absence as "leave the value unset", which keeps the update path
+// from silently zeroing existing resources when the user opens the dialog
+// and saves without touching the field. Final authority is the backend
+// ParseQuantity call.
+const QUANTITY_PATTERN = /^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$/;
+
+function isValidQuantity(value) {
+  if (value === "" || value == null) {
+    return true;
+  }
+  return QUANTITY_PATTERN.test(value.trim());
+}
 
 function splitImage(image) {
   if (!image) {
@@ -181,6 +197,8 @@ function DeploymentListPage() {
       image: record.image,
       replicas: record.replicas,
       containerName: "",
+      cpuRequest: record.cpuRequest ?? "",
+      memoryRequest: record.memoryRequest ?? "",
       envVars: envVarsToRows(record.envVars),
       volumes: record.volumes ?? [],
     });
@@ -249,6 +267,12 @@ function DeploymentListPage() {
     if (!form.image) {
       nextErrors.image = "Image is required";
     }
+    if (!isValidQuantity(form.cpuRequest)) {
+      nextErrors.cpuRequest = "Must be a Kubernetes quantity (e.g. 100m, 0.5, 1Gi)";
+    }
+    if (!isValidQuantity(form.memoryRequest)) {
+      nextErrors.memoryRequest = "Must be a Kubernetes quantity (e.g. 256Mi, 1Gi)";
+    }
     setErrors(nextErrors);
     if (Object.keys(nextErrors).length > 0) {
       return;
@@ -260,6 +284,8 @@ function DeploymentListPage() {
       replicas: Number(form.replicas) ?? 1,
       image: form.image,
       containerName: form.containerName ?? "",
+      cpuRequest: form.cpuRequest.trim(),
+      memoryRequest: form.memoryRequest.trim(),
       envVars: rowsToEnvVars(form.envVars),
       // Volumes are only sent on create; the API rejects mount changes on an
       // existing deployment, and the editor is read-only there for that reason.
@@ -539,6 +565,29 @@ function DeploymentListPage() {
             value={form.image}
             onChange={(event) => setForm((prev) => ({...prev, image: event.target.value}))}
             placeholder="nginx:latest"
+          />
+        </Field>
+
+        <Field label="CPU Request" htmlFor="deploy-cpu-request" hint="Optional. Kubernetes quantity, e.g. 100m or 0.5." error={errors.cpuRequest}>
+          <Input
+            id="deploy-cpu-request"
+            value={form.cpuRequest}
+            onChange={(event) => setForm((prev) => ({...prev, cpuRequest: event.target.value}))}
+            placeholder="100m"
+          />
+        </Field>
+
+        <Field
+          label="Memory Request"
+          htmlFor="deploy-memory-request"
+          hint="Optional. Kubernetes quantity, e.g. 256Mi or 1Gi."
+          error={errors.memoryRequest}
+        >
+          <Input
+            id="deploy-memory-request"
+            value={form.memoryRequest}
+            onChange={(event) => setForm((prev) => ({...prev, memoryRequest: event.target.value}))}
+            placeholder="256Mi"
           />
         </Field>
 


### PR DESCRIPTION
The Deployment editor let users fill cpuRequest / memoryRequest in the UI but neither the form nor the API actually plumbed those values through: the form sent them nowhere, AddDeployment's buildDeployment ignored them, and UpdateDeployment's GET-modify-UPDATE path had an inline parser with a silent fallback that rebuilt an entire container when the existing spec happened to be empty (which K8s itself rejects at create time, so the branch was unreachable in practice).

Changes:
- Form: add CPU Request / Memory Request fields between Image and Replicas, send them in the payload, validate against the same regex K8s ParseQuantity accepts on the backend (no false negatives like ".5" or "1E3"; empty string always allowed).
- Controllers: thread cpuRequest/memoryRequest through deploymentRequest, parse with resource.ParseQuantity (returns error instead of MustParse panicking on bad input), and surface the error to the caller. Extract the parse-and-merge step into mergeContainerResourceRequests so AddDeployment and UpdateDeployment share one implementation.
- UpdateDeployment: drop the dead container-rebuild fallback. If the apiserver hands back a Deployment with no containers, that is a malformed cluster state — return a 4xx instead of silently overwriting the spec.
- UpdateDeployment: empty cpu/memory strings are now treated as "leave this key alone" so opening the dialog and saving image/env alone preserves the existing resource requests instead of zeroing them.