### PR TITLE
fix(dashboard): show 'add a worker node' banner on empty clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ tmp/
 # Editor/IDE
 .idea/
 .vscode/
+
+# Local playwright-mcp browsing artifacts (console logs + page snapshots)
+/.playwright-mcp/
+
+# Empty-cluster dashboard screenshots captured during local testing
+/dashboard-empty-cluster*.png

--- a/controllers/dashboard.go
+++ b/controllers/dashboard.go
@@ -37,6 +37,10 @@ const (
 type dashboardStats struct {
 	NodesTotal           int            `json:"nodesTotal"`
 	NodesReady           int            `json:"nodesReady"`
+	// NodesLoaded tells the UI whether the node list above is real data or a
+	// zero default from a failed apiserver query, so the "no worker nodes"
+	// banner can avoid firing on a transient apiserver outage.
+	NodesLoaded          bool           `json:"nodesLoaded"`
 	NodesByOS            map[string]int `json:"nodesByOS"`
 	NodesByArch          map[string]int `json:"nodesByArch"`
 	PodsTotal            int            `json:"podsTotal"`
@@ -82,6 +86,7 @@ func (c *ApiController) GetDashboard() {
 	nodesLoaded := false
 	if nodes, err := object.GetNodes(cfg); err == nil {
 		nodesLoaded = true
+		stats.NodesLoaded = true
 		stats.NodesTotal = len(nodes)
 		for _, n := range nodes {
 			for _, cond := range n.Status.Conditions {

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -32,6 +32,8 @@
     "col Namespace": "Namespace",
     "col Status": "Status",
     "health data unavailable": "Cluster health data unavailable",
+    "no usable nodes title": "No worker nodes are available",
+    "no usable nodes description": "Workloads can't run until at least one node is ready. Add a machine and deploy it as a node to get started.",
     "label Offline": "Offline",
     "label Online": "Online",
     "label Other": "Other",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -32,6 +32,8 @@
     "col Namespace": "命名空间",
     "col Status": "状态",
     "health data unavailable": "集群健康数据不可用",
+    "no usable nodes title": "当前没有可用的工作节点",
+    "no usable nodes description": "集群中至少需要一个就绪节点才能调度工作负载。请先添加一台机器并将其部署为节点。",
     "label Offline": "离线",
     "label Online": "在线",
     "label Other": "其他",

--- a/web/src/pages/DashboardPage.jsx
+++ b/web/src/pages/DashboardPage.jsx
@@ -1,15 +1,16 @@
 import React, {useEffect, useMemo, useState} from "react";
 import {useHistory} from "react-router-dom";
 import {useTranslation} from "react-i18next";
-import {Boxes, CheckCircle2, Layers, Network, Server, Settings, TriangleAlert} from "lucide-react";
+import {ArrowRight, Boxes, CheckCircle2, Layers, Network, Server, Settings, TriangleAlert} from "lucide-react";
 import * as AccountBackend from "@/backend/AccountBackend";
 import * as DashboardBackend from "@/backend/DashboardBackend";
 import * as HelmBackend from "@/backend/HelmBackend";
 import * as MachineBackend from "@/backend/MachineBackend";
 import {useResource} from "@/hooks/use-resource";
 import {Badge} from "@/components/ui/badge";
+import {Button} from "@/components/ui/button";
 import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
-import {Alert, AlertTitle} from "@/components/ui/alert";
+import {Alert, AlertTitle, MessageAlert} from "@/components/ui/alert";
 import {Progress} from "@/components/ui/progress";
 import {DataTable} from "@/components/shared/data-table";
 import {PageContainer} from "@/components/shared/page-header";
@@ -159,6 +160,12 @@ function DashboardPage({account, accountUpdatedAt, onOpenAccount}) {
   const unhealthyPods = Array.isArray(stats.unhealthyPods) ? stats.unhealthyPods : [];
   const {healthStatus, notReadyNodes} = getDashboardHealthState(stats);
   const clusterHealthy = healthStatus === "healthy";
+  // nodesLoaded guards against a transient apiserver outage being read as
+  // "fresh install, no nodes" — the banner is wrong on a brief blip but right
+  // on the common case where the cluster genuinely has zero nodes. We narrow
+  // to nodesTotal === 0 (not nodesReady === 0) so the "Add a machine" CTA
+  // doesn't fire on a cluster whose nodes exist but are all NotReady.
+  const needsNodes = stats.nodesLoaded && stats.nodesTotal === 0;
   let healthMessage = "";
   if (healthStatus === "unknown") {
     healthMessage = t("dashboard:health data unavailable");
@@ -190,7 +197,19 @@ function DashboardPage({account, accountUpdatedAt, onOpenAccount}) {
   return (
     <PageContainer>
       {firstRunChecklist}
-      {!clusterHealthy ? (
+      {needsNodes ? (
+        <MessageAlert
+          variant="destructive"
+          title={t("dashboard:no usable nodes title")}
+          description={t("dashboard:no usable nodes description")}
+          action={
+            <Button size="sm" onClick={() => history.push("/machines")}>
+              {t("general:Add Machine")}
+              <ArrowRight />
+            </Button>
+          }
+        />
+      ) : !clusterHealthy ? (
         <div className="grid gap-2">
           <Alert variant={healthStatus === "unknown" ? "warning" : "destructive"}>
             <TriangleAlert />


### PR DESCRIPTION
## WhatFresh installs of CasOS start with zero worker nodes, but the dashboard
fell back to a generic **"Cluster health data unavailable"** warning in
that state. That copy reads like the apiserver is broken, when the more
common cause is the cluster simply waiting on its first node. New users
had no obvious next step.

This PR replaces that warning with a dedicated banner that says what's
actually wrong ("no worker nodes are available") and ships a direct
**Add Machine** CTA that jumps to `/machines`.

## Why nowP0-1 of the empty-cluster UX gap — the banner has been the most
frequent "this looks broken" complaint against the dashboard.

## How

- **Backend** ([controllers/dashboard.go](controllers/dashboard.go)):
  add a `NodesLoaded bool` flag on the dashboard stats payload. It only  flips to `true` inside the successful `object.GetNodes(cfg)` branch,
  so the UI can tell a genuine zero-node cluster apart from a transient
  apiserver failure.
- **Frontend** ([web/src/pages/DashboardPage.jsx](web/src/pages/DashboardPage.jsx)):
  - New `MessageAlert` banner with the existing `general:Add Machine`
 key, linking to `/machines`. The same `action={Button}` pattern is
    already in use in `helm-install-dialog.jsx`, so the calling    convention is established.
  - Alert rendering is now a three-way nested ternary
    (`needsNodes ? banner : !clusterHealthy ? warning : success`), so
    the three states cannot stack — the previous bug where the banner
    and the green "healthy" alert both showed is structurally    impossible.
  - `needsNodes` is pinned to `stats.nodesLoaded && stats.nodesTotal === 0`.
    Deliberately narrower than `nodesReady === 0` so the "Add a
    machine" CTA doesn't mislead on a cluster whose nodes exist but
    are all NotReady — that case still falls through to the existing
    **"X node(s) not ready"** warning, where the copy is accurate.
- **i18n** ([en](web/src/locales/en/data.json) /
 [zh](web/src/locales/zh/data.json)): two new keys (`no usable nodes
  title`, `no usable nodes description`) under the `dashboard:`
  namespace. CTA reuses the existing `general:Add Machine` instead of
  adding a duplicate.
- **.gitignore**: drops `.playwright-mcp/` browsing artifacts and the
  `dashboard-empty-cluster*.png` screenshots captured during local UI
  verification, anchored to the repo root like the other `/` entries.

## Edge cases handled

| Cluster state                 | Old UI | New UI |
| ----------------------------- | ------------------------------- | ---------------------------- |
| 0 nodes, apiserver healthy | "Cluster health data unavailable" | **No-worker-nodes banner + Add Machine CTA** |
| 0 nodes, apiserver down | "Cluster health data unavailable" | "Cluster health data unavailable" (unchanged — apiserver outage, not empty cluster) |
| 3 nodes, all NotReady         | "3 node(s) not ready"           | "3 node(s) not ready" (unchanged — copy is accurate, no misleading CTA) |
| 3 nodes, all healthy | Green "Cluster healthy"         | Green "Cluster healthy" (unchanged) |
| 1 node down, 2 healthy | "1 node(s) not ready" + pod table | Same (unchanged) |


## Out of scope

- i18n completeness audit (per user: low priority, not blocking)
- Authz / access-control implications (per user: skipped)
- Whether stat cards and chart math are still right — no inputs
  touched, no regressions observed